### PR TITLE
Fix broken links

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -171,7 +171,7 @@
               {
                 "group": "BloodHound API",
                 "pages": [
-                  "integrations/bloodhound-api/working-with-api",
+                  "reference/overview",
                   "integrations/bloodhound-api/json-formats"
                 ]
               },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -171,7 +171,7 @@
               {
                 "group": "BloodHound API",
                 "pages": [
-                  "reference/overview",
+                  "integrations/bloodhound-api/working-with-api",
                   "integrations/bloodhound-api/json-formats"
                 ]
               },

--- a/docs/manage-bloodhound/auth/saml.mdx
+++ b/docs/manage-bloodhound/auth/saml.mdx
@@ -37,10 +37,10 @@ Currently, BloodHound requires the configuration of SAML system in the following
 
 If your IDP supports custom icons for configured applications, please feel free to utilize either of the two logos below:
 <Frame>
-<img height="50" noZoom src="/assets/19622280069019.png"/> 
+<img height="50" noZoom src="/assets/19622280069019.png" alt="BloodHound Icon – Dark theme"/> 
 </Frame>
 <Frame>
-<img height="50" noZoom src="/assets/19622280078363.png"/>
+<img height="50" noZoom src="/assets/19622280078363.png" alt="BloodHound Icon – Light theme"/>
 </Frame>
 
 ## Create the SAML Configuration

--- a/docs/manage-bloodhound/auth/saml.mdx
+++ b/docs/manage-bloodhound/auth/saml.mdx
@@ -36,9 +36,12 @@ Currently, BloodHound requires the configuration of SAML system in the following
 ## BloodHound Icons
 
 If your IDP supports custom icons for configured applications, please feel free to utilize either of the two logos below:
-
-* [Dark-colored icon](/assets/19622280069019.png)
-* [Light-colored icon](/assets/19622280078363.png)
+<Frame>
+<img height="50" noZoom src="/assets/19622280069019.png"/> 
+</Frame>
+<Frame>
+<img height="50" noZoom src="/assets/19622280078363.png"/>
+</Frame>
 
 ## Create the SAML Configuration
 


### PR DESCRIPTION
Update links in SAML to load logo images to allow download for entra apps - broken

Resolves https://specterops.atlassian.net/browse/BHCS-481

Tested and viewed in Mintlify Dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved the visual presentation of BloodHound icon images by embedding them directly in the documentation with frames, making it easier to view both dark and light themed icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->