### PR TITLE
BloodHound Query Library references

### DIFF
--- a/docs/analyze-data/bloodhound-gui/cypher-search.mdx
+++ b/docs/analyze-data/bloodhound-gui/cypher-search.mdx
@@ -13,10 +13,9 @@ This article describes how to use Cypher Search within BloodHound. Users of Bloo
 Quickstart
 ==========
 
-A great way to start exploring Cypher queries is through the community-driven BloodHound Query Library at https://queries.specterops.io/. This comprehensive collection includes both community-contributed queries and BloodHound's built-in "Pre-built Searches.
+A great way to start exploring Cypher queries is through the community-driven [BloodHound Query Library](https://queries.specterops.io/). This comprehensive collection includes both community-contributed queries and BloodHound's built-in "Pre-built Searches".
 
 Inside BloodHound, you can explore the "Pre-built Searches" section, which is expanded after clicking the folder icon within the application interface.
-
 <Frame>
   <img src="/assets/image1-26.png"/>
 </Frame>

--- a/docs/analyze-data/bloodhound-gui/cypher-search.mdx
+++ b/docs/analyze-data/bloodhound-gui/cypher-search.mdx
@@ -13,7 +13,9 @@ This article describes how to use Cypher Search within BloodHound. Users of Bloo
 Quickstart
 ==========
 
-A quick way to start looking at Cypher queries is through the many examples included in the "Pre-built Searches" section, which is expanded after clicking the folder icon.
+A great way to start exploring Cypher queries is through the community-driven BloodHound Query Library at https://queries.specterops.io/. This comprehensive collection includes both community-contributed queries and BloodHound's built-in "Pre-built Searches.
+
+Inside BloodHound, you can explore the "Pre-built Searches" section, which is expanded after clicking the folder icon within the application interface.
 
 <Frame>
   <img src="/assets/image1-26.png"/>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -858,6 +858,11 @@
           "icon": "slack"
         },
         {
+          "anchor": "Query Library",
+          "href": "https://queries.specterops.io/",
+          "icon": "code"
+        },
+        {
           "anchor": "Blog",
           "href": "https://specterops.io/blog/?_gl=1*1qw21rw*_up*MQ..*_ga*NTYxMzY4OTkxLjE3MzMzMDkyNTk.*_ga_53SGLN9EBJ*MTczMzMwOTI1Ny4xLjAuMTczMzMwOTI1Ny4wLjAuMA..",
           "icon": "newspaper"


### PR DESCRIPTION
Added references to the BloodHound Query Library
- Mention in the **Quick Start** section of https://bloodhound.specterops.io/analyze-data/bloodhound-gui/cypher-search
- Added BloodHound navigation anchor link

Anchor links are these:

![image](https://github.com/user-attachments/assets/3fd1ef8e-7bac-4be1-81ce-28e88a129f27)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the quickstart guide to highlight the BloodHound Query Library website as a key resource for Cypher queries.
  - Clarified the distinction between community-driven queries and built-in searches within the application.
  - Added a "Query Library" link to the global documentation navigation for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->