### PR TITLE
Standardize version images and descriptions

### DIFF
--- a/docs/collect-data/ce-collection/azurehound-flags.mdx
+++ b/docs/collect-data/ce-collection/azurehound-flags.mdx
@@ -2,7 +2,7 @@
 title: AzureHound Community Edition Flags
 ---
 
-<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 AzureHound Community Edition has several optional flags that let you control scan scope, performance, output, and other behaviors.
 

--- a/docs/collect-data/ce-collection/azurehound-flags.mdx
+++ b/docs/collect-data/ce-collection/azurehound-flags.mdx
@@ -2,7 +2,7 @@
 title: AzureHound Community Edition Flags
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
 AzureHound Community Edition has several optional flags that let you control scan scope, performance, output, and other behaviors.
 

--- a/docs/collect-data/ce-collection/azurehound.mdx
+++ b/docs/collect-data/ce-collection/azurehound.mdx
@@ -2,7 +2,7 @@
 title: AzureHound Community Edition
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
 AzureHound Community Edition is a Go binary that collects data from Entra ID (formerly known as AzureAD) and AzureRM via the Microsoft Graph and Azure REST APIs. It does not use any external dependencies and will run on any operating system.
 

--- a/docs/collect-data/ce-collection/azurehound.mdx
+++ b/docs/collect-data/ce-collection/azurehound.mdx
@@ -2,7 +2,7 @@
 title: AzureHound Community Edition
 ---
 
-<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 AzureHound Community Edition is a Go binary that collects data from Entra ID (formerly known as AzureAD) and AzureRM via the Microsoft Graph and Azure REST APIs. It does not use any external dependencies and will run on any operating system.
 

--- a/docs/collect-data/ce-collection/create-gmsa-community-edition.mdx
+++ b/docs/collect-data/ce-collection/create-gmsa-community-edition.mdx
@@ -4,7 +4,7 @@ title: Create a gMSA for Use With SharpHound Community Edition
 
 import MySnippet from '/snippets/gmsa-intro-snippet.mdx';
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
 This page describes how to configure and run the SharpHound Community Edition collection tool using an Active Directory gMSA.
 

--- a/docs/collect-data/ce-collection/create-gmsa-community-edition.mdx
+++ b/docs/collect-data/ce-collection/create-gmsa-community-edition.mdx
@@ -4,7 +4,7 @@ title: Create a gMSA for Use With SharpHound Community Edition
 
 import MySnippet from '/snippets/gmsa-intro-snippet.mdx';
 
-<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 This page describes how to configure and run the SharpHound Community Edition collection tool using an Active Directory gMSA.
 

--- a/docs/collect-data/ce-collection/sharphound-flags.mdx
+++ b/docs/collect-data/ce-collection/sharphound-flags.mdx
@@ -2,7 +2,7 @@
 title: SharpHound Community Edition Flags
 ---
 
-<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 SharpHound Community Edition has several optional flags that let you control scan scope, performance, output, and other behaviors.
 

--- a/docs/collect-data/ce-collection/sharphound-flags.mdx
+++ b/docs/collect-data/ce-collection/sharphound-flags.mdx
@@ -2,7 +2,7 @@
 title: SharpHound Community Edition Flags
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
 SharpHound Community Edition has several optional flags that let you control scan scope, performance, output, and other behaviors.
 

--- a/docs/collect-data/ce-collection/sharphound.mdx
+++ b/docs/collect-data/ce-collection/sharphound.mdx
@@ -3,7 +3,7 @@ title: SharpHound Community Edition
 description: "SharpHound Community Edition (CE) is the official data collector for BloodHound CE. It is written in C# and uses native Windows API functions and LDAP namespace functions to collect data from domain controllers and domain-joined Windows systems."
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
 SharpHound CE can be obtained in a few ways:
 

--- a/docs/collect-data/ce-collection/sharphound.mdx
+++ b/docs/collect-data/ce-collection/sharphound.mdx
@@ -3,7 +3,7 @@ title: SharpHound Community Edition
 description: "SharpHound Community Edition (CE) is the official data collector for BloodHound CE. It is written in C# and uses native Windows API functions and LDAP namespace functions to collect data from domain controllers and domain-joined Windows systems."
 ---
 
-<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 SharpHound CE can be obtained in a few ways:
 

--- a/docs/collect-data/enterprise-collection/faq.mdx
+++ b/docs/collect-data/enterprise-collection/faq.mdx
@@ -3,7 +3,7 @@ title: SharpHound Collection FAQ
 description: "The following are common questions about the data collection capabilities provided by the SharpHound Enterprise service."
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 <AccordionGroup>
 <Accordion title="How long does collection take?">

--- a/docs/collect-data/enterprise-collection/permissions.mdx
+++ b/docs/collect-data/enterprise-collection/permissions.mdx
@@ -2,7 +2,7 @@
 title: SharpHound Enterprise Data Collection and Permissions
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 SharpHound Enterprise data collection utilizes the open-source [SharpHound Common](https://github.com/BloodHoundAD/SharpHoundCommon) library, maintained by the BloodHound Enterprise Engineering team.
 

--- a/docs/get-started/security-boundaries/tier-zero-members.mdx
+++ b/docs/get-started/security-boundaries/tier-zero-members.mdx
@@ -17,7 +17,7 @@ The following sections will cover the default objects in Tier Zero in BloodHound
 1.  Identify all starting members of Tier Zero (default objects and any objects tagged manually within the environment).
 2.  Unroll group memberships and role assignments:
     1.  For Active Directory, all group objects will be unrolled to identify any nested objects and tag them as members of Tier Zero. This process is recursive, so any nested memberships will also be identified and tagged.
-    2.  In Azure, the same process occurs with Roles and Groups, identifying objects with those roles assigned to them. This process only identifies direct group members as Azure does not grant nested group members permissions of the parent group.
+    2.  In Azure, the same process occurs with Roles and Groups, identifying objects with those roles assigned to them. This process only identifies direct group members, as Azure does not grant nested group members permissions of the parent group.
 3.  After identifying these objects, BloodHound will identify objects which maintain structural control over those things already tagged. This includes things like OUs, Containers, and GPOs in Active Directory and Subscriptions and Management Groups in Azure.
 
 At this point, the "Tier Zero Boundary" is drawn, and any remaining control over those objects would be identified as a Tier Zero path within BloodHound.

--- a/docs/get-started/security-boundaries/tier-zero-members.mdx
+++ b/docs/get-started/security-boundaries/tier-zero-members.mdx
@@ -4,31 +4,31 @@ title: "Tier Zero: Members and Modification"
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-BloodHound Enterprise borrows from [Microsoft's Enhanced Security Administration Environment (ESAE - Retired)](https://learn.microsoft.com/en-us/security/compass/esae-retirement) model in using the term "Tier Zero." In this model, Tier Zero is the set of objects with full control over the environment AND _any objects with control over those objects_. You may also be familiar with [Microsoft's Enterprise Access Model (EAM)](https://learn.microsoft.com/en-us/security/compass/privileged-access-access-model), which later replaced ESAE; however, they recommend effectively the same advice.
+BloodHound borrows from [Microsoft's Enhanced Security Administration Environment (ESAE - Retired)](https://learn.microsoft.com/en-us/security/compass/esae-retirement) model in using the term "Tier Zero." In this model, Tier Zero is the set of objects with full control over the environment AND _any objects with control over those objects_. You may also be familiar with [Microsoft's Enterprise Access Model (EAM)](https://learn.microsoft.com/en-us/security/compass/privileged-access-access-model), which later replaced ESAE; however, they recommend effectively the same advice.
 
-Although implementing a tiered model remains the best path toward securing your overall environment, BloodHound Enterprise enables your teams to identify and remediate the paths towards control of Tier Zero assets without necessarily implementing a strict tiering model.
+Although implementing a tiered model remains the best path toward securing your overall environment, BloodHound enables your teams to identify and remediate the paths towards control of Tier Zero assets without necessarily implementing a strict tiering model.
 
 Jonas Bülow Knudsen, one of our BloodHound Enterprise team members, has written this fantastic blog on implementing a tiering model in your environment: [Establish security boundaries in your on-prem AD and Azure environment](https://posts.specterops.io/establish-security-boundaries-in-your-on-prem-ad-and-azure-environment-dcb44498cfc2).
 
-## How BloodHound Enterprise Identifies Tier Zero Objects
+## How BloodHound Identifies Tier Zero Objects
 
-The following sections will cover the default objects in Tier Zero in BloodHound Enterprise and what to include in the group manually. Still, it's important to understand how the identification process works. Loosely, the steps look like this in BloodHound Enterprise
+The following sections will cover the default objects in Tier Zero in BloodHound and what to include in the group manually. Still, it's important to understand how the identification process works. Loosely, the steps look like this in BloodHound:
 
 1.  Identify all starting members of Tier Zero (default objects and any objects tagged manually within the environment).
 2.  Unroll group memberships and role assignments:
     1.  For Active Directory, all group objects will be unrolled to identify any nested objects and tag them as members of Tier Zero. This process is recursive, so any nested memberships will also be identified and tagged.
     2.  In Azure, the same process occurs with Roles and Groups, identifying objects with those roles assigned to them. This process only identifies direct group members as Azure does not grant nested group members permissions of the parent group.
-3.  After identifying these objects, BloodHound Enterprise will identify objects which maintain structural control over those things already tagged. This includes things like OUs, Containers, and GPOs in Active Directory and Subscriptions and Management Groups in Azure.
+3.  After identifying these objects, BloodHound will identify objects which maintain structural control over those things already tagged. This includes things like OUs, Containers, and GPOs in Active Directory and Subscriptions and Management Groups in Azure.
 
-At this point, the "Tier Zero Boundary" is drawn, and any remaining control over those objects would be identified as a Tier Zero path within BloodHound Enterprise.
+At this point, the "Tier Zero Boundary" is drawn, and any remaining control over those objects would be identified as a Tier Zero path within BloodHound.
 
-## Default Members of Tier Zero in BloodHound Enterprise
+## Default Members of Tier Zero
 
-BloodHound Enterprise will automatically identify many Tier Zero objects within your environment to get you started on protecting the most critical assets within your environment.
+BloodHound will automatically identify many Tier Zero objects within your environment to get you started on protecting the most critical assets within your environment.
 
 ### Active Directory
 
-In Active Directory, BloodHound Enterprise starts primarily with the default groups that maintain full control of a domain or have the (effectively) irrevocable ability to gain access to those groups. These include (default RIDs are provided for reference):
+In Active Directory, BloodHound starts primarily with the default groups that maintain full control of a domain or have the (effectively) irrevocable ability to gain access to those groups. These include (default RIDs are provided for reference):
 
 * Domain head object
 * AdminSDHolder object
@@ -46,7 +46,7 @@ _Please see the following sections about modifying Tier Zero in an Active Direct
 
 ### Azure
 
-In Azure, BloodHound Enterprise starts primarily with the default roles that maintain full control of an Azure tenant or have the (effectively) irrevocable ability to gain access to those roles. These include:
+In Azure, BloodHound starts primarily with the default roles that maintain full control of an Azure tenant or have the (effectively) irrevocable ability to gain access to those roles. These include:
 
 * Tenant object
 * Global Administrator
@@ -56,7 +56,7 @@ In Azure, BloodHound Enterprise starts primarily with the default roles that mai
 
 ## Modifying Tier Zero
 
-Although BloodHound Enterprise can identify much of Tier Zero by default, many things included in Tier Zero do not have a consistent means to identify them across multiple environments. We recommend splitting this effort into two phases for organizations just starting on developing the internal concept of Tier Zero. If your organization has already begun the process you may decided to go through both phases more rapidly.
+Although BloodHound can identify much of Tier Zero by default, many things included in Tier Zero do not have a consistent means to identify them across multiple environments. We recommend splitting this effort into two phases for organizations just starting to develop the internal concept of Tier Zero. If your organization has already begun the process you may decide to go through both phases more rapidly.
 
 ### Phase One
 
@@ -90,4 +90,4 @@ In Phase 2, you will include systems in Tier Zero that have code execution abili
 
 There are often many systems in this category, and it will usually require some effort to execute this part of the Tier Zero classifications.
 
-We recommend examining the [TierZeroTable](https://github.com/SpecterOps/TierZeroTable) and adding assets classified as Tier Zero in this table to Tier Zero in BloodHound Enterprise as part of this phase as well.
+We recommend examining the [TierZeroTable](https://github.com/SpecterOps/TierZeroTable) and adding assets classified as Tier Zero in this table to Tier Zero in BloodHound as part of this phase as well.

--- a/docs/get-started/security-boundaries/tier-zero-members.mdx
+++ b/docs/get-started/security-boundaries/tier-zero-members.mdx
@@ -2,7 +2,7 @@
 title: "Tier Zero: Members and Modification"
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 BloodHound Enterprise borrows from [Microsoft's Enhanced Security Administration Environment (ESAE - Retired)](https://learn.microsoft.com/en-us/security/compass/esae-retirement) model in using the term "Tier Zero." In this model, Tier Zero is the set of objects with full control over the environment AND _any objects with control over those objects_. You may also be familiar with [Microsoft's Enterprise Access Model (EAM)](https://learn.microsoft.com/en-us/security/compass/privileged-access-access-model), which later replaced ESAE; however, they recommend effectively the same advice.
 

--- a/docs/get-started/security-boundaries/tier-zero-members.mdx
+++ b/docs/get-started/security-boundaries/tier-zero-members.mdx
@@ -2,7 +2,7 @@
 title: "Tier Zero: Members and Modification"
 ---
 
-<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 BloodHound Enterprise borrows from [Microsoft's Enhanced Security Administration Environment (ESAE - Retired)](https://learn.microsoft.com/en-us/security/compass/esae-retirement) model in using the term "Tier Zero." In this model, Tier Zero is the set of objects with full control over the environment AND _any objects with control over those objects_. You may also be familiar with [Microsoft's Enterprise Access Model (EAM)](https://learn.microsoft.com/en-us/security/compass/privileged-access-access-model), which later replaced ESAE; however, they recommend effectively the same advice.
 

--- a/docs/get-started/security-boundaries/tier-zero-members.mdx
+++ b/docs/get-started/security-boundaries/tier-zero-members.mdx
@@ -56,7 +56,7 @@ In Azure, BloodHound starts primarily with the default roles that maintain full 
 
 ## Modifying Tier Zero
 
-Although BloodHound can identify much of Tier Zero by default, many things included in Tier Zero do not have a consistent means to identify them across multiple environments. We recommend splitting this effort into two phases for organizations just starting to develop the internal concept of Tier Zero. If your organization has already begun the process you may decide to go through both phases more rapidly.
+Although BloodHound can identify much of Tier Zero by default, many things included in Tier Zero do not have a consistent means to identify them across multiple environments. We recommend splitting this effort into two phases for organizations just starting to develop the internal concept of Tier Zero. If your organization has already begun the process, you may decide to go through both phases more rapidly.
 
 ### Phase One
 

--- a/docs/install-data-collector/install-sharphound/installation-upgrade.mdx
+++ b/docs/install-data-collector/install-sharphound/installation-upgrade.mdx
@@ -2,7 +2,7 @@
 title: Install and Upgrade SharpHound Enterprise
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 ## Purpose
 

--- a/docs/install-data-collector/install-sharphound/local-configuration.mdx
+++ b/docs/install-data-collector/install-sharphound/local-configuration.mdx
@@ -2,7 +2,7 @@
 title: SharpHound Enterprise Local Configuration
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 The local configuration of SharpHound Enterprise occurs within two files: [settings.json](#settings-json) and [auth.json](#auth-json), their file paths can be found in the table below. Note that %AppData% is the directory of the service account: "C:\\Users\\SERVICE_ACCOUNT$\\AppData\\Roaming".
 

--- a/docs/install-data-collector/install-sharphound/system-requirements.mdx
+++ b/docs/install-data-collector/install-sharphound/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: SharpHound Enterprise System Requirements and Deployment Process
 ---
 
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 The SharpHound Enterprise service is a critical element in your deployment that collects and uploads data about your environment to your BloodHound Enterprise instance for processing and analysis.
 
@@ -60,7 +60,7 @@ The SharpHound Enterprise service will run as a domain-joined account and will u
 * \[Optional\] If performing DC Registry and DC Registry collection (see [DC Registry and CA Registry details](/collect-data/enterprise-collection/permissions))
     * Member of the local Administrators group on all domain controllers and domain-joined certificate authorities
 * \[Optional\]: If Active Directory tombstoning is enabled
-    * * Read privileges to the Deleted Objects container (see [How to let non-administrators view the Active Directory deleted objects container](https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/non-administrators-view-deleted-object-container))
+    * Read privileges to the Deleted Objects container (see [How to let non-administrators view the Active Directory deleted objects container](https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/non-administrators-view-deleted-object-container))
 
 See [SharpHound Data Collection and Permissions](/collect-data/enterprise-collection/permissions) for comprehensive requirement information.
 

--- a/docs/resources/community-support/getting-help.mdx
+++ b/docs/resources/community-support/getting-help.mdx
@@ -2,7 +2,7 @@
 title: Get Help and Use the BloodHound Community
 ---
 
-<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 
 ## SpecterOps ❤️ Community

--- a/docs/resources/community-support/training-resources.mdx
+++ b/docs/resources/community-support/training-resources.mdx
@@ -2,6 +2,8 @@
 title: Additional Training and Resources
 ---
 
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+
 ## BloodHound and attack paths
 
 * [BloodHound Docs](/), searchable for various topics and documentation on edges/attack paths

--- a/docs/resources/edges/abuse-tgt-delegation.mdx
+++ b/docs/resources/edges/abuse-tgt-delegation.mdx
@@ -1,12 +1,10 @@
 ---
 title: AbuseTGTDelegation
+description: The trust from the target node domain to the source node domain has TGT delegation enabled. When a resource in the source node domain is configured with unconstrained delegation, principals from the target node domain will automatically forward their Ticket Granting Ticket (TGT) to that resource upon access.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-The trust from the target node domain to the source node domain has TGT delegation enabled.
-
-When a resource in the source node domain is configured with unconstrained delegation, principals from the target node domain will automatically forward their Ticket Granting Ticket (TGT) to that resource upon access.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/allowed-to-act.mdx
+++ b/docs/resources/edges/allowed-to-act.mdx
@@ -1,10 +1,8 @@
 ---
 title: AllowedToAct
+description: This edge allows an attacker to abuse resource-based constrained delegation to compromise the target. This property is a binary DACL that controls what security principals can pretend to be any domain user to the particular computer object.
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-This edge allows an attacker to abuse resource-based constrained delegation to compromise the target. This property is a binary DACL that controls what security principals can pretend to be any domain user to the particular computer object.
 
 An attacker can execute a modified S4U2self/S4U2proxy abuse chain to impersonate any domain user to the target computer system and receive a valid service ticket “as” this user.
 

--- a/docs/resources/edges/az-add-owner.mdx
+++ b/docs/resources/edges/az-add-owner.mdx
@@ -2,10 +2,7 @@
 title: AZAddOwner
 description: "This edge is created during post-processing."
 ---
-
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 It is created against all App Registrations and Service Principals within the same tenant when an Azure principal has one of the following Entra ID roles:
 

--- a/docs/resources/edges/az-add-secret.mdx
+++ b/docs/resources/edges/az-add-secret.mdx
@@ -2,10 +2,7 @@
 title: AZAddSecret
 description: Azure provides several systems and mechanisms for granting control of securable objects within Entra ID, including tenant-scoped admin roles, object-scoped admin roles, explicit object ownership, and API permissions.
 ---
-
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 When a principal has been granted “Cloud App Admin” or “App Admin” against the tenant, that principal gains the ability to add new secrets to all Service Principals and App Registrations. Additionally, a principal that has been granted “Cloud App Admin” or “App Admin” against, or explicit ownership of a Service Principal or App Registration gains the ability to add secrets to that particular object.
 

--- a/docs/resources/edges/az-automation-contributor.mdx
+++ b/docs/resources/edges/az-automation-contributor.mdx
@@ -1,11 +1,9 @@
 ---
 title: AZAutomationContributor
+description: The Azure Automation Contributor role grants full control of the target Azure Automation Account. This includes the ability to execute arbitrary commands on the Automation Account.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The Azure Automation Contributor role grants full control of the target Azure Automation Account. This includes the ability to execute arbitrary commands on the Automation Account.
 
 ## Abuse Info
 

--- a/docs/resources/edges/az-avere-contributor.mdx
+++ b/docs/resources/edges/az-avere-contributor.mdx
@@ -1,11 +1,10 @@
 ---
 title: AZAvereContributor
+description: Any principal granted the Avere Contributor role, scoped to the affected VM, can reset the built-in administrator password on the VM.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-Any principal granted the Avere Contributor role, scoped to the affected VM, can reset the built-in administrator password on the VM.
 
 ## Abuse Info
 

--- a/docs/resources/edges/az-contains.mdx
+++ b/docs/resources/edges/az-contains.mdx
@@ -2,9 +2,7 @@
 title: AZContains
 description: "This indicates that the parent object contains the child object, such as a resource group containing a virtual machine, or a tenant “containing” a subscription."
 ---
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 ## Abuse Info
 

--- a/docs/resources/edges/az-has-role.mdx
+++ b/docs/resources/edges/az-has-role.mdx
@@ -1,11 +1,9 @@
 ---
 title: AZHasRole
+description: This edge indicates that a principal has been granted a particular AzureAD admin role.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-This edge indicates that a principal has been granted a particular AzureAD admin role.
 
 ## Abuse Info
 

--- a/docs/resources/edges/az-member-of.mdx
+++ b/docs/resources/edges/az-member-of.mdx
@@ -2,10 +2,7 @@
 title: AZMemberOf
 description: "The given asset is a member of the group."
 ---
-
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 Groups in Entra ID grant their direct members any privileges the group itself has. If a group has an Entra admin role, its direct members inherit those permissions.
 

--- a/docs/resources/edges/az-mg-add-member.mdx
+++ b/docs/resources/edges/az-mg-add-member.mdx
@@ -2,10 +2,7 @@
 title: AZMGAddMember
 description: "This edge is created during post-processing."
 ---
-
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 It is created against non-role assignable Entra ID security groups when a Service Principal has one of the following MS Graph app role assignments:
 

--- a/docs/resources/edges/az-owns.mdx
+++ b/docs/resources/edges/az-owns.mdx
@@ -2,10 +2,7 @@
 title: AZOwns
 description: "The principal is granted owner rights on the principal."
 ---
-
-<Frame>
-  <img noZoom src="/assets/image-2-1.png"/>
-</Frame>
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 AZOwns targets resources in Entra ID (for example [AZGroup](/resources/nodes/az-group), [AZServicePrincipal](/resources/nodes/az-service-principal), and [AZDevice](/resources/nodes/az-device)) from various object-specific ownership.
 

--- a/docs/resources/edges/cross-forest-trust.mdx
+++ b/docs/resources/edges/cross-forest-trust.mdx
@@ -1,10 +1,11 @@
 ---
 title: CrossForestTrust
+description: The CrossForestTrust edge represents a trust relationship between two domains/forests. In this relationship, the source node domain has a cross-forest (interforest) trust to the destination node domain, allowing principals (users and computers) from the destination domain to access resources in the source domain.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-The CrossForestTrust edge represents a trust relationship between two domains/forests. In this relationship, the source node domain has a cross-forest (interforest) trust to the destination node domain, allowing principals (users and computers) from the destination domain to access resources in the source domain.
+
 
 Abuse Info
 ----------

--- a/docs/resources/edges/generic-all.mdx
+++ b/docs/resources/edges/generic-all.mdx
@@ -1,11 +1,9 @@
 ---
 title: GenericAll
+description: This is also known as full control. This privilege allows the trustee to manipulate the target object however they wish.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-This is also known as full control. This privilege allows the trustee to manipulate the target object however they wish.
 
 ## Abuse Info
 

--- a/docs/resources/edges/generic-write.mdx
+++ b/docs/resources/edges/generic-write.mdx
@@ -1,11 +1,9 @@
 ---
 title: GenericWrite
+description: Generic Write access grants you the ability to write to any non-protected attribute on the target object, including "members" for a group, and "servicePrincipalNames" for a user.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-Generic Write access grants you the ability to write to any non-protected attribute on the target object, including "members" for a group, and "servicePrincipalNames" for a user.
 
 ## Abuse Info
 

--- a/docs/resources/edges/get-changes-all.mdx
+++ b/docs/resources/edges/get-changes-all.mdx
@@ -1,10 +1,9 @@
 ---
 title: GetChangesAll
+description: The principal is granted the GetChangesAll right on the domain.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-The principal is granted the GetChangesAll right on the domain.
 
 ## Abuse Info
 

--- a/docs/resources/edges/get-changes-in-filtered-set.mdx
+++ b/docs/resources/edges/get-changes-in-filtered-set.mdx
@@ -1,11 +1,9 @@
 ---
 title: GetChangesInFilteredSet
+description: The principal is allowed to synchronize (DCSync) the Filtered Attribute Set (FAS), which are the attributes not replicated to RODCs.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The principal is allowed to synchronize (DCSync) the Filtered Attribute Set (FAS), which are the attributes not replicated to RODCs.
 
 ## Abuse Info
 

--- a/docs/resources/edges/golden-cert.mdx
+++ b/docs/resources/edges/golden-cert.mdx
@@ -1,12 +1,9 @@
 ---
 title: GoldenCert
+description: The victim principal has a certificate private key that can be abused to sign "golden" certificates for authentication of any enabled principal in the AD forest of the domain.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The victim principal has a certificate private key that can be abused to sign "golden" certificates for authentication of any enabled principal in the AD forest of the domain.
-
 
 The victim principal hosts the enrollment service of an enterprise CA, which implies it has the private key of the enterprise CA's certificate. This private key allows an attacker to sign certificates for authentication as any enabled principal in the AD forest of the domain, as the enterprise CA is trusted for NT authentication and chain up to a root CA.
 

--- a/docs/resources/edges/gp-link.mdx
+++ b/docs/resources/edges/gp-link.mdx
@@ -1,11 +1,9 @@
 ---
 title: GPLink
+description: A linked GPO applies its settings to objects in the linked container.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-A linked GPO applies its settings to objects in the linked container.
 
 ## Abuse Info
 

--- a/docs/resources/edges/has-session.mdx
+++ b/docs/resources/edges/has-session.mdx
@@ -1,11 +1,9 @@
 ---
 title: HasSession
+description: When a user authenticates to a computer, they often leave credentials exposed on the system, which can be retrieved through LSASS injection, token manipulation or theft, or injecting into a user’s process.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-When a user authenticates to a computer, they often leave credentials exposed on the system, which can be retrieved through LSASS injection, token manipulation or theft, or injecting into a user’s process.
 
 Any user that is an administrator to the system has the capability to retrieve the credential material from memory if it still exists.
 

--- a/docs/resources/edges/has-sid-history.mdx
+++ b/docs/resources/edges/has-sid-history.mdx
@@ -1,11 +1,9 @@
 ---
 title: HasSIDHistory
+description: The given source principal has, in its SIDHistory attribute, the SID for the target principal.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The given source principal has, in its SIDHistory attribute, the SID for the target principal.
 
 When a Kerberos ticket is created for source principal, it will include the SID for the target principal, and therefore grant the source principal the same privileges and permissions as the target principal.
 

--- a/docs/resources/edges/has-trust-keys.mdx
+++ b/docs/resources/edges/has-trust-keys.mdx
@@ -1,10 +1,11 @@
 ---
 title: HasTrustKeys
+description: The relationship's source node is a domain which has the trust keys for the end node trust account. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-The relationship's source node is a domain which has the trust keys for the end node trust account. The trust account exists because the source domain has an outbound trust to the domain of the trust account.
+The trust account exists because the source domain has an outbound trust to the domain of the trust account.
 
 The trust keys can be leveraged to authenticate as the trust account and gain access to the trust account's domain.
 

--- a/docs/resources/edges/hosts-ca-service.mdx
+++ b/docs/resources/edges/hosts-ca-service.mdx
@@ -1,24 +1,22 @@
 ---
 title: HostsCAService
+description: The Enterprise Certification Authority node is the enrollment service LDAP object for CA hosted on the computer node.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The Enterprise Certification Authority node is the enrollment service LDAP object for CA hosted on the computer node.
-
-Abuse Info[](#h_01HPHZJSTFS46D4BFVYAB25KTE)
--------------------------------------------
+Abuse Info
+-----------
 
 An attacker may perform several attacks that rely on this relationship. This relationship alone is not enough to escalate rights or impersonate other principals. The enterprise CA must chain up to a root CA of the AD forest and it must be trusted for NT authentication in the AD forest for an escalation to be possible. If both conditions are met, BloodHound will generate a GoldenCert edge from the computer node to the domain node. Check if there is an outbound GoldenCert edge from the computer node.
 
-Opsec Considerations[](#heading-2)
-----------------------------------
+Opsec Considerations
+--------------------
 
 When an attacker abuses a privilege escalation or impersonation primitive that relies on this relationship, it will necessarily result in the issuance of a certificate. A copy of the issued certificate will be saved on the host that issued the certificate.
 
-References[](#heading-3)
-------------------------
+References
+----------
 
 This edge is related to the following MITRE ATT&CK tactic and techniques:
 

--- a/docs/resources/edges/issued-signed-by.mdx
+++ b/docs/resources/edges/issued-signed-by.mdx
@@ -1,11 +1,9 @@
 ---
 title: IssuedSignedBy
+description: When Windows assesses the validity and trustworthiness of a certificate it verifies the certificate chain up to a trusted root certificate. The IssuedSignedBy edge represents a link within the certificate chain.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-When Windows assesses the validity and trustworthiness of a certificate it verifies the certificate chain up to a trusted root certificate. The IssuedSignedBy edge represent a link within the certificate chain.
 
 Abuse Info
 -----------

--- a/docs/resources/edges/local-to-computer.mdx
+++ b/docs/resources/edges/local-to-computer.mdx
@@ -1,24 +1,22 @@
 ---
 title: LocalToComputer
+description: The LocalGroup is a local group on the Computer.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-From LocalGroup to Computer: The LocalGroup is a local group on the Computer.
-
-Abuse Info[](#heading-1)
-------------------------
+Abuse Info
+----------
 
 This edge simply indicates that a local group belongs to a computer.
 
-Opsec Considerations[](#heading-2)
-----------------------------------
+Opsec Considerations
+--------------------
 
 No opsec considerations apply to this edge.
 
-References[](#heading-3)
-------------------------
+References
+----------
 
 * [https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc725622(v=ws.11)](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc725622(v=ws.11))
 

--- a/docs/resources/edges/manage-ca.mdx
+++ b/docs/resources/edges/manage-ca.mdx
@@ -1,12 +1,11 @@
 ---
 title: ManageCA
+description: The principal has the "Manage CA", also known as "CA Administrator", permission on the EnterpriseCA. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-
-The principal has the "Manage CA", also known as "CA Administrator", permission on the EnterpriseCA. This permission allows the principal to configure the CA to allow subject alternate names, publish certificate templates, grant "Manage Certificates" and more.
+This permission allows the principal to configure the CA to allow subject alternate names, publish certificate templates, grant "Manage Certificates" and more.
 
 Abuse Info
 -----------

--- a/docs/resources/edges/manage-ca.mdx
+++ b/docs/resources/edges/manage-ca.mdx
@@ -1,6 +1,6 @@
 ---
 title: ManageCA
-description: The principal has the "Manage CA", also known as "CA Administrator", permission on the EnterpriseCA. 
+description: The principal has the "Manage CA", also known as "CA Administrator", permission on the Enterprise CA.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/edges/manage-certificates.mdx
+++ b/docs/resources/edges/manage-certificates.mdx
@@ -1,11 +1,11 @@
 ---
 title: ManageCertificates
+description: The principal has the "Manage Certificates", also known as "CA Officer", permission on the Enterprise CA. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The principal has the "Manage Certificates", also known as "CA Officer", permission on the Enterprise CA. This permission allows the principal to force the CA to issue certificates that the CA had previously denied issuance of.
+This permission allows the principal to force the CA to issue certificates that the CA had previously denied issuance of.
 
 Abuse Info[](#h_01HPHZJSTFS46D4BFVYAB25KTE)
 -------------------------------------------

--- a/docs/resources/edges/member-of-local-group.mdx
+++ b/docs/resources/edges/member-of-local-group.mdx
@@ -1,11 +1,9 @@
 ---
 title: MemberOfLocalGroup
+description: From a Principal to LocalGroup. Principal is a member of the LocalGroup.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-From a Principal to LocalGroup: Principal is a member of the LocalGroup.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/member-of.mdx
+++ b/docs/resources/edges/member-of.mdx
@@ -1,10 +1,11 @@
 ---
 title: MemberOf
+description: Groups in active directory grant their members any privileges the group itself has. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-Groups in active directory grant their members any privileges the group itself has. If a group has rights to another principal, users/computers in the group, as well as other groups inside the group inherit those permissions.
+If a group has rights to another principal, users/computers in the group, as well as other groups inside the group inherit those permissions.
 
 Abuse Info[](#heading-1)
 ------------------------

--- a/docs/resources/edges/nt-auth-store-for.mdx
+++ b/docs/resources/edges/nt-auth-store-for.mdx
@@ -1,6 +1,6 @@
 ---
 title: NTAuthStoreFor
-description: The NTAuthStore is the Enterprise NTAuth store (NTAuthCertificates object) for the the AD forest of the domain node. 
+description: The NTAuthStore is the Enterprise NTAuth store (NTAuthCertificates object) for the AD forest of the domain node. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/edges/nt-auth-store-for.mdx
+++ b/docs/resources/edges/nt-auth-store-for.mdx
@@ -1,11 +1,12 @@
 ---
 title: NTAuthStoreFor
+description: The NTAuthStore is the Enterprise NTAuth store (NTAuthCertificates object) for the the AD forest of the domain node. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 
-The NTAuthStore is the Enterprise NTAuth store (NTAuthCertificates object) for the the AD forest of the domain node. The NTAuthStore holds the list of certificates trusted for authentication in the AD forest of the domain. When a user attempts to authenticate against a domain with a certificate, a domain controller will verify that the certificate is signed by a certificate in the NTAuthStore.
+The NTAuthStore holds the list of certificates trusted for authentication in the AD forest of the domain. When a user attempts to authenticate against a domain with a certificate, a domain controller will verify that the certificate is signed by a certificate in the NTAuthStore.
 
 Abuse Info[](#h_01HPHZJSTFS46D4BFVYAB25KTE)
 -------------------------------------------

--- a/docs/resources/edges/oid-group-link.mdx
+++ b/docs/resources/edges/oid-group-link.mdx
@@ -1,10 +1,8 @@
 ---
 title: OIDGroupLink
+description: The edge indicates that an IssuancePolicy has an OID group link to a group.
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The edge indicates that an IssuancePolicy has an OID group link to a group.
 
 Certificate templates may include the IssuancePolicy as an issuance policy extension. Users authenticating using a certificate of such a certificate template will be granted access as a member of the group.
 

--- a/docs/resources/edges/owns.mdx
+++ b/docs/resources/edges/owns.mdx
@@ -1,10 +1,9 @@
 ---
 title: Owns
+description: Object owners retain the ability to modify object security descriptors, regardless of permissions on the object’s DACL
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-Object owners retain the ability to modify object security descriptors, regardless of permissions on the object’s DACL
 
 This clip shows an example of abusing object ownership:
 

--- a/docs/resources/edges/published-to.mdx
+++ b/docs/resources/edges/published-to.mdx
@@ -1,12 +1,11 @@
 ---
 title: PublishedTo
+description: The certificate template is published to an enterprise certification authority. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The certificate template is published to an enterprise certification authority. This relationship means
-the certificate template can be used when submitting an enrollment request to the specified
+This relationship means the certificate template can be used when submitting an enrollment request to the specified
 certification authority.
 
 Abuse Info

--- a/docs/resources/edges/read-gmsa-password.mdx
+++ b/docs/resources/edges/read-gmsa-password.mdx
@@ -1,12 +1,13 @@
 ---
 title: ReadGMSAPassword
+description: This privilege allows you to read the password for a Group Managed Service Account (GMSA). 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 
 
-This privilege allows you to read the password for a Group Managed Service Account (GMSA). Group Managed Service Accounts are a special type of Active Directory object, where the password for that object is managed by and automatically changed by Domain Controllers on a set interval (check the MSDS-ManagedPasswordInterval attribute).
+Group Managed Service Accounts are a special type of Active Directory object, where the password for that object is managed by and automatically changed by Domain Controllers on a set interval (check the MSDS-ManagedPasswordInterval attribute).
 
 The intended use of a GMSA is to allow certain computer accounts to retrieve the password for the GMSA, then run local services as the GMSA. An attacker with control of an authorized principal may abuse that privilege to impersonate the GMSA.`;
 

--- a/docs/resources/edges/read-laps-password.mdx
+++ b/docs/resources/edges/read-laps-password.mdx
@@ -1,12 +1,9 @@
 ---
 title: ReadLAPSPassword
+description: This privilege allows a principal to read the LAPS password from a computer.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-
-This privilege allows a principal to read the LAPS password from a computer.
 
 For systems using legacy LAPS, the following AD computer object properties are relevant:
 

--- a/docs/resources/edges/remote-interactive-logon-right.mdx
+++ b/docs/resources/edges/remote-interactive-logon-right.mdx
@@ -1,11 +1,9 @@
 ---
 title: RemoveInteractiveLogonRight
+description: From Principal to Computer. Principal has the SeRemoteInteractiveLogonRight on the Computer.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-From Principal to Computer: Principal has the SeRemoteInteractiveLogonRight on the Computer.
 
 For RDP access the principal also needs membership in the computer's local Remote Desktop Users group, which related to the edge [MemberOfLocalGroup](/resources/edges/member-of-local-group). When RDP access is possible, the principal will have the edge [CanRDP](/resources/edges/can-rdp).
 

--- a/docs/resources/edges/root-ca-for.mdx
+++ b/docs/resources/edges/root-ca-for.mdx
@@ -1,13 +1,11 @@
 ---
 title: RootCAFor
+description: The CA is trusted as a root certification authority by the domain. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-
-The CA is trusted as a root certification authority by the domain. Any certificates signed by this CA
-will be trusted by the domain and all hosts in the domain.
+Any certificates signed by this CA will be trusted by the domain and all hosts in the domain.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/same-forest-trust.mdx
+++ b/docs/resources/edges/same-forest-trust.mdx
@@ -1,10 +1,11 @@
 ---
 title: SameForestTrust
+description: The SameForestTrust edge represents a trust relationship between two domains within the same AD forest. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-The SameForestTrust edge represents a trust relationship between two domains within the same AD forest. In this relationship, the source node domain has a same-forest (intraforest) trust to the destination node domain, allowing principals (users and computers) from the destination domain to access resources in the source domain.
+In this relationship, the source node domain has a same-forest (intraforest) trust to the destination node domain, allowing principals (users and computers) from the destination domain to access resources in the source domain.
 
 Because the domains are part of the same forest, they inherently trust each other, granting implicit control over resources across domains.
 

--- a/docs/resources/edges/spoof-sid-history.mdx
+++ b/docs/resources/edges/spoof-sid-history.mdx
@@ -1,10 +1,9 @@
 ---
 title: SpoofSIDHistory
+description: The cross-forest trust from the target domain to the source domain has a weak SID filtering configuration (SpoofSIDHistoryBlocked = False).
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-The cross-forest trust from the target domain to the source domain has a weak SID filtering configuration (SpoofSIDHistoryBlocked = False).
 
 The target domain allows principals of the source domain access by SIDs of the target domain in their SID history. An attacker with control over the source domain can craft access requests with manipulated SID history containing SIDs of privileged principals of the target domain to gain control over the target domain.
 

--- a/docs/resources/edges/sql-admin.mdx
+++ b/docs/resources/edges/sql-admin.mdx
@@ -1,11 +1,9 @@
 ---
 title: SQLAdmin
+description: The user is a SQL admin on the target computer
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The user is a SQL admin on the target computer
 
 There is at least one MSSQL instance running on the computer where the user with the inbound SQLAdmin edge is the account configured to run the SQL Server instance. The typical configuration for MSSQL is to have the local Windows account or Active Directory domain account that is configured to run the SQL Server service (the primary database engine for SQL Server) have sysadmin privileges in the SQL Server application. As a result, the SQL Server service account can be used to log into the SQL Server instance remotely, read all of the databases (including those protected with transparent encryption), and run operating systems command through SQL Server (as the service account) using a variety of techniques.
 

--- a/docs/resources/edges/sync-laps-password.mdx
+++ b/docs/resources/edges/sync-laps-password.mdx
@@ -1,11 +1,10 @@
 ---
 title: SyncLAPSPassword
+description: A principal with this signifies the capability of retrieving, through a directory synchronization, the value of confidential and RODC filtered attributes, such as LAPS’ _ms-Mcs-AdmPwd_.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-A principal with this signifies the capability of retrieving, through a directory synchronization, the value of confidential and RODC filtered attributes, such as LAPS’ _ms-Mcs-AdmPwd_.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/sync-laps-password.mdx
+++ b/docs/resources/edges/sync-laps-password.mdx
@@ -1,6 +1,6 @@
 ---
 title: SyncLAPSPassword
-description: A principal with this signifies the capability of retrieving, through a directory synchronization, the value of confidential and RODC filtered attributes, such as LAPS’ _ms-Mcs-AdmPwd_.
+description: "A principal with this signifies the capability of retrieving, through a directory synchronization, the value of confidential and RODC filtered attributes, such as LAPS’ _ms-Mcs-AdmPwd_."
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/edges/synced-to-ad-user.mdx
+++ b/docs/resources/edges/synced-to-ad-user.mdx
@@ -1,11 +1,10 @@
 ---
 title: SyncedToADUser
+description: The Entra user is synchronized to the on-prem AD user.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The Entra user is synchronized to the on-prem AD user.
 
 The Entra user may be able to authenticate as the on-prem AD user with its own password if password write-back is enabled. The Entra user may already have the same password as the on-prem user if password hash synchronization is enabled.
 

--- a/docs/resources/edges/synced-to-entra-user.mdx
+++ b/docs/resources/edges/synced-to-entra-user.mdx
@@ -1,11 +1,9 @@
 ---
 title: SyncedToEntraUser
+description: The on-prem AD user is synchronized to the Entra ID user.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The on-prem AD user is synchronized to the Entra ID user.
 
 The on-prem user may be able to authenticate as the Entra user with its own password if password hash synchronization, pass-through authentication, or seamless single sign-on is enabled.
 

--- a/docs/resources/edges/traversable-edges.mdx
+++ b/docs/resources/edges/traversable-edges.mdx
@@ -1,5 +1,6 @@
 ---
 title: Traversable and Non-Traversable Edge Types
+description: 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/edges/traversable-edges.mdx
+++ b/docs/resources/edges/traversable-edges.mdx
@@ -1,6 +1,6 @@
 ---
 title: Traversable and Non-Traversable Edge Types
-description: 
+description: Details on traversable and non-traversable edge types in BloodHound
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/edges/trusted-for-nt-auth.mdx
+++ b/docs/resources/edges/trusted-for-nt-auth.mdx
@@ -1,11 +1,11 @@
 ---
 title: TrustedForNTAuth
+description: The NTAuthStore contains the certificate of the Enterprise CA. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The NTAuthStore contains the certificate of the Enterprise CA. The consequence of the relationship is that certificate issued by the Enterprise CA are trusted for authentication in the AD forest of the NTAuthStore.
+The consequence of the relationship is that certificate issued by the Enterprise CA are trusted for authentication in the AD forest of the NTAuthStore.
 
 Abuse Info[](#h_01HPHZJSTFS46D4BFVYAB25KTE)
 -------------------------------------------

--- a/docs/resources/edges/write-account-restrictions.mdx
+++ b/docs/resources/edges/write-account-restrictions.mdx
@@ -1,11 +1,12 @@
 ---
 title: WriteAccountRestrictions
+description: This edge indicates the principal has the ability to modify several properties on the target principal, most notably the msDS-AllowedToActOnBehalfOfOtherIdentity attribute. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 
-This edge indicates the principal has the ability to modify several properties on the target principal, most notably the msDS-AllowedToActOnBehalfOfOtherIdentity attribute. The ability to modify the msDS-AllowedToActOnBehalfOfOtherIdentity property allows an attacker to abuse resource-based constrained delegation to compromise the remote computer system. This property is a binary DACL that controls what security principals can pretend to be any domain user to the particular computer object.
+The ability to modify the msDS-AllowedToActOnBehalfOfOtherIdentity property allows an attacker to abuse resource-based constrained delegation to compromise the remote computer system. This property is a binary DACL that controls what security principals can pretend to be any domain user to the particular computer object.
 
 This clip demonstrates how to abuse this edge:
 

--- a/docs/resources/edges/write-dacl.mdx
+++ b/docs/resources/edges/write-dacl.mdx
@@ -1,11 +1,10 @@
 ---
 title: WriteDacl
+description: With write access to the target object’s DACL, you can grant yourself any privilege you want on the object.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-With write access to the target object’s DACL, you can grant yourself any privilege you want on the object.
 
 Abuse Info
 -----------

--- a/docs/resources/edges/write-gp-link.mdx
+++ b/docs/resources/edges/write-gp-link.mdx
@@ -1,11 +1,9 @@
 ---
 title: WriteGPLink
+description: The WriteGPLink edge indicates that the principal has the permissions to modify the gPLink attribute of the targeted OU/domain node.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-The WriteGPLink edge indicates that the principal has the permissions to modify the gPLink attribute of the targeted OU/domain node.
 
 The ability to alter the gPLink attribute may allow an attacker to apply a malicious Group Policy Object (GPO) to all child user and computer objects (including the ones located in nested OUs). This can be exploited to make said child objects execute arbitrary commands through an immediate scheduled task, thus compromising them.
 

--- a/docs/resources/edges/write-owner.mdx
+++ b/docs/resources/edges/write-owner.mdx
@@ -1,12 +1,9 @@
 ---
 title: WriteOwner
+description: Object owners retain the ability to modify object security descriptors, regardless of permissions on the object’s DACL.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-
-
-Object owners retain the ability to modify object security descriptors, regardless of permissions on the object’s DACL.
 
 This clip shows an example of abusing this edge:
 

--- a/docs/resources/edges/write-pki-enrollment-flag.mdx
+++ b/docs/resources/edges/write-pki-enrollment-flag.mdx
@@ -1,11 +1,10 @@
 ---
 title: WritePKIEnrollmentFlag
+description: The attacker principal has the ability to write to the msPKI-Enrollment-Flag attribute on the victim principal, which allows the attacker principal to configure "manager approval" for the certificate template and other settings.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The attacker principal has the ability to write to the msPKI-Enrollment-Flag attribute on the victim principal, which allows the attacker principal to configure "manager approval" for the certificate template and other settings.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/write-pki-name-flag.mdx
+++ b/docs/resources/edges/write-pki-name-flag.mdx
@@ -1,11 +1,10 @@
 ---
 title: WritePKINameFlag
+description: The attacker principal has the ability to write to the msPKI-Certificate-Name-Flag attribute on the victim principal, which allows the attacker principal to configure "enrollee supplies subject" for the certificate template and other settings.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-
-The attacker principal has the ability to write to the msPKI-Certificate-Name-Flag attribute on the victim principal, which allows the attacker principal to configure "enrollee supplies subject" for the certificate template and other settings.
 
 Abuse Info
 ----------

--- a/docs/resources/edges/write-spn.mdx
+++ b/docs/resources/edges/write-spn.mdx
@@ -1,14 +1,15 @@
 ---
 title: WriteSPN
+description: The ability to write directly to the servicePrincipalNames attribute on a user object. 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 
-The ability to write directly to the servicePrincipalNames attribute on a user object. Writing to this property gives you the opportunity to perform a targeted kerberoasting attack against that user.
+Writing to this property gives you the opportunity to perform a targeted kerberoasting attack against that user.
 
-Abuse Info[](#heading-1)
-------------------------
+Abuse Info
+----------
 
 A targeted kerberoast attack can be performed using PowerView’s Set-DomainObject along with Get-DomainSPNTicket.
 
@@ -31,13 +32,13 @@ The recovered hash can be cracked offline using the tool of your choice. Cleanup
 ```
 Set-DomainObject -Credential $Cred -Identity harmj0y -Clear serviceprincipalname
 ```
-Opsec Considerations[](#heading-2)
-----------------------------------
+Opsec Considerations
+--------------------
 
 Modifying the servicePrincipalName attribute will not, by default, generate an event on the Domain Controller. Your target may have configured logging on users to generate 5136 events whenever a directory service is modified, but this configuration is very rare.
 
-References[](#heading-3)
-------------------------
+References
+----------
 
 * [https://blog.harmj0y.net/redteaming/kerberoasting-revisited/](https://blog.harmj0y.net/redteaming/kerberoasting-revisited/)
 

--- a/docs/resources/nodes/ad-local-group.mdx
+++ b/docs/resources/nodes/ad-local-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: ADLocalGroup
-description: 
+description: A local group on a domain computer.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/ad-local-group.mdx
+++ b/docs/resources/nodes/ad-local-group.mdx
@@ -1,10 +1,9 @@
 ---
 title: ADLocalGroup
+description: 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-This article outlines the ADLocalGroup node in BloodHound, it describes the node's properties and possible incoming/outgoing edges.
 
 ## Representation
 

--- a/docs/resources/nodes/ad-local-group.mdx
+++ b/docs/resources/nodes/ad-local-group.mdx
@@ -1,6 +1,5 @@
 ---
 title: ADLocalGroup
-description: A local group on a domain computer.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/ad-local-user.mdx
+++ b/docs/resources/nodes/ad-local-user.mdx
@@ -1,6 +1,5 @@
 ---
 title: ADLocalUser
-description:
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/ad-local-user.mdx
+++ b/docs/resources/nodes/ad-local-user.mdx
@@ -1,6 +1,6 @@
 ---
 title: ADLocalUser
-description: "This article outlines the ADLocalUser node in BloodHound, it describes the node's properties and possible incoming/outgoing edges"
+description:
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/aiaca.mdx
+++ b/docs/resources/nodes/aiaca.mdx
@@ -2,6 +2,7 @@
 title: AIACA
 description: "This article outlines the AIACA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
 ---
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 ## Representation
 

--- a/docs/resources/nodes/aiaca.mdx
+++ b/docs/resources/nodes/aiaca.mdx
@@ -1,6 +1,6 @@
 ---
 title: AIACA
-description: "This article outlines the AIACA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
+description:
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 

--- a/docs/resources/nodes/az-base.mdx
+++ b/docs/resources/nodes/az-base.mdx
@@ -1,6 +1,6 @@
 ---
 title: AZBase
-description:
+description: AZBase node used when an Entra ID/Azure node type is unknown.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/az-base.mdx
+++ b/docs/resources/nodes/az-base.mdx
@@ -1,6 +1,5 @@
 ---
 title: AZBase
-description: AZBase node used when an Entra ID/Azure node type is unknown.
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/az-base.mdx
+++ b/docs/resources/nodes/az-base.mdx
@@ -1,10 +1,9 @@
 ---
 title: AZBase
+description:
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-This article outlines the AZBase node in BloodHound, it describes the node's properties and possible incoming/outgoing edges.
 
 ## Representation
 

--- a/docs/resources/nodes/az-web-app.mdx
+++ b/docs/resources/nodes/az-web-app.mdx
@@ -4,7 +4,7 @@ title: AZWebApp
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-## Node Properties
+## Node properties
 
 The node supports the properties of the table below.
 

--- a/docs/resources/nodes/base.mdx
+++ b/docs/resources/nodes/base.mdx
@@ -1,6 +1,6 @@
 ---
 title: Base
-description: "This article outlines the Base node in BloodHound, it describes the node's properties and possible incoming/outgoing edges."
+description:
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/cert-template.mdx
+++ b/docs/resources/nodes/cert-template.mdx
@@ -1,6 +1,7 @@
 ---
 title: CertTemplate
 ---
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 This article outlines the CertTemplate node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges.
 

--- a/docs/resources/nodes/cert-template.mdx
+++ b/docs/resources/nodes/cert-template.mdx
@@ -1,9 +1,8 @@
 ---
 title: CertTemplate
+description: This article outlines the CertTemplate node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges.
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
-
-This article outlines the CertTemplate node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges.
 
 ## Representation
 

--- a/docs/resources/nodes/cert-template.mdx
+++ b/docs/resources/nodes/cert-template.mdx
@@ -1,6 +1,6 @@
 ---
 title: CertTemplate
-description: This article outlines the CertTemplate node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges.
+description:
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 

--- a/docs/resources/nodes/domain.mdx
+++ b/docs/resources/nodes/domain.mdx
@@ -4,7 +4,7 @@ title: Domain
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
-## Node Properties
+## Node properties
 
 The node supports the properties of the table below.
 

--- a/docs/resources/nodes/enterprise-ca.mdx
+++ b/docs/resources/nodes/enterprise-ca.mdx
@@ -1,6 +1,6 @@
 ---
 title: EnterpriseCA
-description: "This article outlines the EnterpriseCA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
+description: 
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 

--- a/docs/resources/nodes/enterprise-ca.mdx
+++ b/docs/resources/nodes/enterprise-ca.mdx
@@ -2,6 +2,7 @@
 title: EnterpriseCA
 description: "This article outlines the EnterpriseCA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
 ---
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 ## Representation
 

--- a/docs/resources/nodes/issuance-policy.mdx
+++ b/docs/resources/nodes/issuance-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: IssuancePolicy
-description: "This article outlines the IssuancePolicy node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
+description: 
 ---
 
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/resources/nodes/nt-auth-store.mdx
+++ b/docs/resources/nodes/nt-auth-store.mdx
@@ -2,6 +2,7 @@
 title: NTAuthStore
 description: "This article outlines the NTAuthStore node in BloodHound, it describes the node's properties and possible incoming/outgoing edges."
 ---
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 ## Representation
 

--- a/docs/resources/nodes/nt-auth-store.mdx
+++ b/docs/resources/nodes/nt-auth-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: NTAuthStore
-description: "This article outlines the NTAuthStore node in BloodHound, it describes the node's properties and possible incoming/outgoing edges."
+description: 
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 

--- a/docs/resources/nodes/root-ca.mdx
+++ b/docs/resources/nodes/root-ca.mdx
@@ -1,6 +1,6 @@
 ---
 title: RootCA
-description: "This article outlines the RootCA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
+description: 
 ---
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 

--- a/docs/resources/nodes/root-ca.mdx
+++ b/docs/resources/nodes/root-ca.mdx
@@ -2,6 +2,8 @@
 title: RootCA
 description: "This article outlines the RootCA node in BloodHound, it describes what the node represents, the node's properties, and possible incoming/outgoing edges."
 ---
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+
 ## Representation
 
 The RootCA node represents the Active Directory LDAP objects of the _certificationAuthority_ class located in the _Certification Authorities_ container in the Configuration Naming Context. 


### PR DESCRIPTION
Resolves BHCS-485
https://specterops.atlassian.net/issues/BHCS-485

Updated relative pill images for all pages.
Removed outdated version images.
Reviewed page description locations and standardized positions.
Small content and code edits as required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated edition applicability badges and images across multiple documentation pages to clarify whether content applies to BloodHound Enterprise, Community Edition, or both.
  - Standardized and moved descriptive metadata for many resource edge documentation pages into frontmatter fields, improving clarity and consistency.
  - Adjusted product naming in select documents for accuracy and consistency.
  - Minor formatting and capitalization improvements in section headers for enhanced readability.
  - Removed redundant or outdated introductory and descriptive sentences for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->