### PR TITLE
ci: Add CLA support for users outside of SpecterOps org

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,62 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Organization Members"
+        id: org-members
+        run: |
+          ALL_MEMBERS=""
+          URL="${{ github.api_url }}/orgs/${{ github.repository_owner }}/members?per_page=100"
+
+          while [ -n "$URL" ]; do
+            MEMBERS=$(curl -s -D headers.txt -H "Authorization: Bearer ${{ secrets.READ_MEMBERS_SCOPE }}" "$URL" | jq -r '[.[] | .login] | join(",")')
+            URL=$(grep -i '^Link:' headers.txt | sed -n 's/.*<\(.*\)>; rel="next".*/\1/p' || true)
+            rm -f headers.txt
+
+            if [ -n "$MEMBERS" ]; then
+              if [ -z "$ALL_MEMBERS" ]; then
+                ALL_MEMBERS="$MEMBERS"
+              else
+                ALL_MEMBERS="$ALL_MEMBERS,$MEMBERS"
+              fi
+            fi
+          done
+
+          echo "::add-mask::$ALL_MEMBERS"
+          echo "org_members=$ALL_MEMBERS" >> $GITHUB_OUTPUT
+        
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.REPO_SCOPE }}
+        with:
+          path-to-signatures: "signatures.json"
+          path-to-document: "https://github.com/SpecterOps/CLA/blob/main/ICLA.md"
+          branch: "main"
+          remote-organization-name: SpecterOps
+          remote-repository-name: CLA
+          allowlist: ${{ steps.org-members.outputs.org_members }}


### PR DESCRIPTION
Adding CLA support to the documentation repo. Signing the CLA will be a mandatory step for any contributors outside of the SpecterOps organization. This addition will validate that all contributors are either:

1. Members of SpecterOps
2. Have signed the CLA

If they have not yet signed it, a prompt will be provided to do so and the PR merge will be blocked until resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced automated Contributor License Agreement (CLA) checks for pull requests and relevant issue comments. Contributors will now be prompted to sign the CLA before their contributions can be merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->