### PR TITLE
fix: BED-5766 Fix Accept-Eula endpoint verb

### DIFF
--- a/docs/reference/eula/accept-eula.mdx
+++ b/docs/reference/eula/accept-eula.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: get /api/v2/accept-eula
+openapi: put /api/v2/accept-eula
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>


### PR DESCRIPTION
Fixes the HTTP verb for the Accept-Eula endpoint

Resolves: BED-5766

![image](https://github.com/user-attachments/assets/ca9d0fc4-491c-4441-89de-573dca3e9a00)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API documentation to reflect that the `/api/v2/accept-eula` endpoint now uses the `PUT` HTTP method instead of `GET`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->