### PR TITLE
BHCS476-Update user roles for API

### DIFF
--- a/docs/manage-bloodhound/auth/users-and-roles.mdx
+++ b/docs/manage-bloodhound/auth/users-and-roles.mdx
@@ -20,7 +20,7 @@ The following properties must be set on each user:
 | Principal Name | Text field for the username used for logging into BloodHound. Can be the same as email address. |
 | First Name | Text field for the user's first name. |
 | Last Name | Text field for the user's first name. |
-| Authentication Method | Drop-down selection for one of the available authentication methods to be used for the user.<br/><br/>* Username / Password - Built-in authentication via username and password, supports TOTP-based multi-factor authentication.<br/>* SAML - SAML 2.0-based Single-Sign-On as described in [SAML in BloodHound Enterprise](/manage-bloodhound/auth/saml).<br/>|
+| Authentication Method | Drop-down selection for one of the available authentication methods to be used for the user.<br/><br/>* Username / Password - Built-in authentication via username and password, supports TOTP-based multifactor authentication.<br/>* SAML - SAML 2.0-based Single-Sign-On as described in [SAML in BloodHound Enterprise](/manage-bloodhound/auth/saml).<br/>|
 | Initial Password | Text field for the user's initial password. |
 | Force Password Reset? | Selecting this check box forces the user to reset their password on the next logon. Must comply with password requirements:<br/><br/>* At least 12 characters long<br/>* Contain at least 1 lowercase character, 1 uppercase character, 1 number and 1 special character (!@#$%^&*) |
 | Role | Drop-down selection for one the available roles.|
@@ -33,10 +33,10 @@ BloodHound offers multiple roles for access control. Each user must be assigned 
 |     | **Administrator** | **Power User** | **User** | **Read-only** | **Upload-only** |
 | --- | --- | --- | --- | --- | --- |
 | **Tenant Administration** |     |     |     |     |     |
-| View, Add, Remove, and Modify users | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
-| View, Add, Remove, all API keys | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
-| View, Add, Remove, owned API keys | <Icon icon="xmark"iconType="solid"/> |<Icon icon="xmark"iconType="solid"/>| <Icon icon="xmark"iconType="solid"/> | -   | -   |
-| View, Add, or Remove SAML provider configurations |<Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View, Add, Remove, Modify users | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View, Add, Remove all API keys | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View, Add, Remove owned API keys | <Icon icon="xmark"iconType="solid"/> |<Icon icon="xmark"iconType="solid"/>| <Icon icon="xmark"iconType="solid"/> | -   | -   |
+| View, Add, Remove SAML provider configurations |<Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
 | Clear the BloodHound database | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
 | View audit log | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
 | **Attack Path Analysis** |     |     |     |     |     |
@@ -44,7 +44,7 @@ BloodHound offers multiple roles for access control. Each user must be assigned 
 | Accept Attack Path Impacted Principals \[BHE\] | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   |
 | Modify Tier Zero / High Value Members | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   |
 | **Collector Clients and File Ingest** |     |     |     |     |     |
-| Download collector installation packages | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | X   |
+| Download collector installation packages | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   |  <Icon icon="xmark"iconType="solid"/>  |
 | View collector client details \[BHE\] | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   |
 | Run collector client on demand scan \[BHE\] | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   |
 | Add collector client \[BHE\] | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   |

--- a/docs/manage-bloodhound/auth/users-and-roles.mdx
+++ b/docs/manage-bloodhound/auth/users-and-roles.mdx
@@ -20,7 +20,7 @@ The following properties must be set on each user:
 | Principal Name | Text field for the username used for logging into BloodHound. Can be the same as email address. |
 | First Name | Text field for the user's first name. |
 | Last Name | Text field for the user's first name. |
-| Authentication Method | Drop-down selection for one of the available authentication methods to be used for the user.<br/><br/>* Username / Password - Built-in authentication via username and password, supports TOTP-based multi-factor authentication.<br/>* SAML - SAML 2.0-based Single-Sign-On as described in SAML in BloodHound Enterprise.<br/><br/>Read more in the article [SAML in BloodHound Enterprise](/manage-bloodhound/auth/saml). |
+| Authentication Method | Drop-down selection for one of the available authentication methods to be used for the user.<br/><br/>* Username / Password - Built-in authentication via username and password, supports TOTP-based multi-factor authentication.<br/>* SAML - SAML 2.0-based Single-Sign-On as described in [SAML in BloodHound Enterprise](/manage-bloodhound/auth/saml).<br/>|
 | Initial Password | Text field for the user's initial password. |
 | Force Password Reset? | Selecting this check box forces the user to reset their password on the next logon. Must comply with password requirements:<br/><br/>* At least 12 characters long<br/>* Contain at least 1 lowercase character, 1 uppercase character, 1 number and 1 special character (!@#$%^&*) |
 | Role | Drop-down selection for one the available roles.|
@@ -33,11 +33,12 @@ BloodHound offers multiple roles for access control. Each user must be assigned 
 |     | **Administrator** | **Power User** | **User** | **Read-only** | **Upload-only** |
 | --- | --- | --- | --- | --- | --- |
 | **Tenant Administration** |     |     |     |     |     |
-| View, Add, Remove, and Modify users | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   | -   |
-| View, Add, Remove, and Modify API keys | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   | -   |
-| View, Add, or Remove SAML provider configurations | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   | -   |
-| Clear the BloodHound database | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   | -   |
-| View audit log | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   | -   |
+| View, Add, Remove, and Modify users | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View, Add, Remove, all API keys | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View, Add, Remove, owned API keys | <Icon icon="xmark"iconType="solid"/> |<Icon icon="xmark"iconType="solid"/>| <Icon icon="xmark"iconType="solid"/> | -   | -   |
+| View, Add, or Remove SAML provider configurations |<Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| Clear the BloodHound database | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
+| View audit log | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
 | **Attack Path Analysis** |     |     |     |     |     |
 | View any available tenant data, including active Attack Paths \[BHE\], and explore the Graph | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   |
 | Accept Attack Path Impacted Principals \[BHE\] | <Icon icon="xmark"iconType="solid"/>   | <Icon icon="xmark"iconType="solid"/>   | -   | -   | -   |

--- a/docs/manage-bloodhound/auth/users-and-roles.mdx
+++ b/docs/manage-bloodhound/auth/users-and-roles.mdx
@@ -31,7 +31,7 @@ BloodHound offers multiple roles for access control. Each user must be assigned 
 
 
 |     | **Administrator** | **Power User** | **User** | **Read-only** | **Upload-only** |
-| --- | --- | --- | --- | --- | --- |
+| --- | :---: | :---: | :---: | :---: | :---: |
 | **Tenant Administration** |     |     |     |     |     |
 | View, Add, Remove, Modify users | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |
 | View, Add, Remove all API keys | <Icon icon="xmark"iconType="solid"/> | -   | -   | -   | -   |


### PR DESCRIPTION
Closes BHCS-476
https://specterops.atlassian.net/issues/BHCS-476

Removed modify from API key role
Updated admin role with "all"
Added line for "owned"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and clarity in the user properties section.
  * Updated the user role permissions table to clarify API key permissions for different roles.
  * Adjusted icons to accurately reflect permission distinctions.
  * Granted "Download collector installation packages" permission to the "Upload-only" role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->