### PR TITLE
fix: Fix links to AzureHound deployment locations v2

### DIFF
--- a/docs/install-data-collector/install-azurehound/installation-options.mdx
+++ b/docs/install-data-collector/install-azurehound/installation-options.mdx
@@ -140,7 +140,7 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 ```
     kubectl create secret generic azurehound-secret --from-literal tokenId=&lt;bloodhound enterprise token id&gt; --from-literal token=&lt;bloodhound enterprise token&gt; --from-literal keypass=&lt;private key passphrase&gt;
 ```
-3.  A sample [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/deployment.yaml) file is attached to this article.
+3.  A sample [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/bloodhound-docs/main/docs/assets/deploy/deployment.yaml) file is attached to this article.
 4.  Edit the provided deployment.yaml file. Read comments and replace instances of \[ INSERT HERE \] with appropriate values
 5.  Deploy AzureHound on k8s:
 ```
@@ -156,6 +156,6 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 
 2.  Review the container logs and BloodHound Enterprise user interface to verify that AzureHound has successfully connected.
 
-* [docker-compose.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/docs/assets/deploy/docker-compose.yaml) (397 Bytes)
-* [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/deploy/deployment.yaml) (2 KB)
+* [docker-compose.yaml](https://raw.githubusercontent.com/SpecterOps/bloodhound-docs/main/docs/assets/deploy/docker-compose.yaml) (397 Bytes)
+* [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/bloodhound-docs/main/docs/assets/deploy/deployment.yaml) (2 KB)
 


### PR DESCRIPTION
Fix some links to AzureHound deployment locations that were missed in the docs repo split off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for Kubernetes and Docker deployment sample files to point to the latest locations in the documentation repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->