### PR TITLE
BHCS-512-Fix-Refistry-Reference

### DIFF
--- a/docs/install-data-collector/install-sharphound/system-requirements.mdx
+++ b/docs/install-data-collector/install-sharphound/system-requirements.mdx
@@ -57,7 +57,7 @@ The SharpHound Enterprise service will run as a domain-joined account and will u
 * Granted "Log on as a service" User Rights Assignment on the SharpHound Enterprise server
 * \[Optional\] If performing privileged collection (see [Why perform privileged collection in SharpHound](/collect-data/enterprise-collection/privileged-collection))
     * Member of the local Administrators group on all in-scope domain-joined Windows systems
-* \[Optional\] If performing DC Registry and DC Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions))
+* \[Optional\] If performing DC Registry and CA Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions))
     * Member of the local Administrators group on all domain controllers and domain-joined certificate authorities
 * \[Optional\]: If Active Directory tombstoning is enabled
     * Read privileges to the Deleted Objects container (see [How to let non-administrators view the Active Directory deleted objects container](https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/non-administrators-view-deleted-object-container))

--- a/docs/install-data-collector/install-sharphound/system-requirements.mdx
+++ b/docs/install-data-collector/install-sharphound/system-requirements.mdx
@@ -46,7 +46,7 @@ To collect Active Directory data with SharpHound and ingest it into BloodHound f
 * \[Optional\] If performing privileged collection (see [Why perform privileged collection in SharpHound](/collect-data/enterprise-collection/privileged-collection))
     * SMB/RPC on 445/TCP to all in-scope domain-joined Windows systems
     * Approximately 60-100kB network bandwidth per collection to each in-scope domain-joined Windows system
-* \[Optional\] If performing DC Registry and DC Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions#01HR6PT0BG44W65EJJ0WE4H63V))
+* \[Optional\] If performing DC Registry and CA Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions))
     * SMB/RPC on 445/TCP to all DCs and domain-joined CAs
 
 ## Service Account Requirements


### PR DESCRIPTION
Closes BHCS-512

Updated registry reference from duplicate DC to CA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated phrase in the system requirements, clarifying the service account requirement for DC Registry and CA Registry collection.
  * Simplified documentation links by removing specific fragment identifiers for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->