### PR TITLE
fix: Fix AzureHound code block

### DIFF
--- a/docs/collect-data/ce-collection/azurehound.mdx
+++ b/docs/collect-data/ce-collection/azurehound.mdx
@@ -48,7 +48,7 @@ $body = @{
 }
 $UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
 $Headers=@{}
-$Headers\["User-Agent"\] = $UserAgent
+$Headers["User-Agent"] = $UserAgent
 $authResponse = Invoke-RestMethod `
     -UseBasicParsing `
     -Method Post `

--- a/docs/collect-data/ce-collection/azurehound.mdx
+++ b/docs/collect-data/ce-collection/azurehound.mdx
@@ -41,7 +41,7 @@ If a user has MFA or CAP restrictions applied to them, you will not be able to a
 The most straight-forward way to accomplish this is to use the device code flow. In this example I will show you how to perform this flow using PowerShell, but this example can be very easily ported to any language, as we are simply making calls to Azure APIs.
 
 Open a PowerShell window on any system and paste the following:
-```json
+```powershell
 $body = @{
     "client_id" =     "1950a258-227b-4e31-a9cf-717495945fc2"
     "resource" =      "https://graph.microsoft.com"


### PR DESCRIPTION
Removed errant escapes remaining from migration to Mintlify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the syntax for setting the "User-Agent" header in a PowerShell script example to improve clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->