### PR TITLE
fix: Slack links

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -880,7 +880,7 @@
         },
         {
           "anchor": "Community",
-          "href": "https://join.slack.com/t/bloodhoundhq/shared_invite/zt-1tgq6ojd2-ixpx5nz9Wjtbhc3i8AVAWw",
+          "href": "http://slack.specterops.io/",
           "icon": "slack"
         },
         {
@@ -931,7 +931,7 @@
       "website": "https://infosec.exchange/@SpecterOps",
       "github": "https://github.com/SpecterOps/BloodHound",
       "linkedin": "https://www.linkedin.com/company/specterops",
-      "slack": "https://ghst.ly/BHSlack",
+      "slack": "http://slack.specterops.io/",
       "instagram": "https://www.instagram.com/specterops.io/",
       "youtube": "https://www.youtube.com/channel/UCWMKKqCCQkUjU8dIyiL1yhQ"
     }


### PR DESCRIPTION
Fixes Slack links to consistently utilize the slack.specterops.io URL.