### PR TITLE
Fix: typo in OCIP description

### DIFF
--- a/docs/opengraph/ocip.mdx
+++ b/docs/opengraph/ocip.mdx
@@ -1,7 +1,7 @@
 ---
 title: BloodHound OpenGraph Community Incentive Program
 sidebarTitle: OpenGraph Community Incentive Program
-description: "Description of the OpenGraph Community Incitive Program (OCIP) and how to "
+description: "Description of the OpenGraph Community Incitive Program (OCIP) and how to participate"
 ---
 
 import { SO_Icon } from '/snippets/logo-icon.mdx';


### PR DESCRIPTION
A word was missing.