### PR TITLE
Feat: Add cards to 2 pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -957,6 +957,28 @@
       "youtube": "https://www.youtube.com/channel/UCWMKKqCCQkUjU8dIyiL1yhQ"
     }
   },
+  "redirects": [
+    {
+        "source": "/analyze-data/bloodhound-gui/cypher-search",
+        "destination": "/analyze-data/cypher-search"
+    },
+    {
+        "source": "/analyze-data/bloodhound-gui/explore-objects",
+        "destination": "/analyze-data/explore-objects"
+    },
+    {
+        "source": "/analyze-data/bloodhound-gui/cypher-supported",
+        "destination": "/analyze-data/cypher-supported"
+    },
+    {
+        "source": "/analyze-data/bloodhound-gui/configuration",
+        "destination": "/analyze-data/configuration"
+    },
+    {
+        "source": "/analyze-data/bloodhound-gui/posture-page",
+        "destination": "/analyze-data/posture-page"
+    }
+  ],
   "integrations": {
     "ga4": {
       "measurementId": "G-V9WNXTYFYH"

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -117,6 +117,14 @@ export function openSearch() {
   >
   Analyzing ingested BloodHound data, and identify and remediate attack paths and risks.
   </Card>
+    <Card
+    title="OpenGraph"
+    icon="diagram-project"
+    href="/opengraph/overview"
+    iconType="solid"
+  >
+    Ingest any data source and map Attack Paths. Learn about the schema, custom icons and more. 
+  </Card>
   <Card
     title="Manage BloodHound"
     icon="user-shield"

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -84,7 +84,7 @@ export function openSearch() {
     >
       Get started
     </div>
-<CardGroup cols={3}>
+<CardGroup cols={4}>
   <Card
     title="Get Started"
     icon="house"

--- a/docs/opengraph/api.mdx
+++ b/docs/opengraph/api.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph API
+title: OpenGraph API
 sidebarTitle: OpenGraph API
 description: "Information on how to use the OpenGraph API"
 ---

--- a/docs/opengraph/best-practices.mdx
+++ b/docs/opengraph/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph Best Practices
+title: OpenGraph Best Practices
 sidebarTitle: Best Practices
 description: "Attack Graph Model Design Requirements and Examples"
 ---

--- a/docs/opengraph/custom-icons.mdx
+++ b/docs/opengraph/custom-icons.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph Custom Icons
+title: OpenGraph Custom Icons
 sidebarTitle: OpenGraph Custom Icons
 description: "How to set Custom Icons for your Custom Nodes"
 ---

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph Library
+title: OpenGraph Library
 sidebarTitle: OpenGraph Library
 description: "List of the OpenGraph models available to the community"
 ---

--- a/docs/opengraph/ocip.mdx
+++ b/docs/opengraph/ocip.mdx
@@ -1,6 +1,6 @@
 ---
-title: BloodHound OpenGraph Community Incentive Program
-sidebarTitle: OpenGraph Community Incentive Program
+title: OpenGraph Community Incentive Program
+sidebarTitle: OpenGraph Incentive Program
 description: "Description of the OpenGraph Community Incentive Program (OCIP) and how to participate"
 ---
 

--- a/docs/opengraph/overview.mdx
+++ b/docs/opengraph/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph Overview
+title: OpenGraph Overview
 sidebarTitle: Overview
 description: "Learn about OpenGraph in BloodHound."
 ---
@@ -11,6 +11,7 @@ description: "Learn about OpenGraph in BloodHound."
 <Card title="Custom Icons" icon="icons" href="/opengraph/custom-icons" horizontal iconType="solid"/>
 <Card title="OpenGraph API" icon="gears" href="/opengraph/api" horizontal iconType="solid"/>
 <Card title="OpenGraph Community Library" icon="book" href="/opengraph/library" horizontal iconType="solid"/>
+<Card title="OpenGraph Community Incentive Program" icon="people-group" href="/opengraph/ocip" horizontal iconType="solid"/>
 <Card title="OpenGraph FAQ" icon="question" href="/opengraph/faq" horizontal iconType="solid"/>
 </CardGroup>
 

--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -1,5 +1,5 @@
 ---
-title: BloodHound OpenGraph Schema
+title: OpenGraph Schema
 sidebarTitle: OpenGraph Schema
 description: "Description of the OpenGraph JSON Schema"
 ---


### PR DESCRIPTION
Add card to Home Page & OCIP Page.
Revmove "Bloodhound" from the title of OG pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "OpenGraph" card to the home page, providing quick access to OpenGraph resources.

* **Documentation**
  * Updated document titles throughout the OpenGraph section to remove references to "BloodHound" for a more streamlined naming.
  * Added a new card entry for the "OpenGraph Community Incentive Program" in the OpenGraph overview.
  * Updated sidebar titles and metadata for consistency.
  * Increased the number of columns in the "Get started" card group on the home page from 3 to 4.

* **Chores**
  * Added URL redirects to improve navigation from legacy BloodHound GUI paths to updated analyze-data paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->