### PR TITLE
Fix: AzureHound - Entra vs. Azure

### DIFF
--- a/docs/install-data-collector/install-azurehound/overview.mdx
+++ b/docs/install-data-collector/install-azurehound/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Overview
 mode: wide
 ---
 
-Deploy and maintain AzureHound Enterprise for continuous automatic collection of Entra ID (formerly Azure AD) attack path data.
+Deploy and maintain AzureHound Enterprise for continuous automatic collection of Entra ID (formerly Azure Active Directory) and Azure attack path data.
 
 <CardGroup cols={2}>
 <Card title="AzureHound Enterprise System Requirements and Deployment Process" icon="server" href="/install-data-collector/install-azurehound/system-requirements"> Promoted article </Card>

--- a/docs/install-data-collector/install-azurehound/overview.mdx
+++ b/docs/install-data-collector/install-azurehound/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Overview
 mode: wide
 ---
 
-Deploy and maintain AzureHound Enterprise for continuous automatic collection of Entra ID (formerly Azure Active Directory) and Azure attack path data.
+Deploy and maintain AzureHound Enterprise for continuous, automated collection of Microsoft Entra ID (formerly Azure Active Directory) and Azure attack path data.
 
 <CardGroup cols={2}>
 <Card title="AzureHound Enterprise System Requirements and Deployment Process" icon="server" href="/install-data-collector/install-azurehound/system-requirements"> Promoted article </Card>

--- a/docs/install-data-collector/install-azurehound/system-requirements.mdx
+++ b/docs/install-data-collector/install-azurehound/system-requirements.mdx
@@ -62,12 +62,12 @@ OR
         * Required for collection of attack path data from Microsoft Azure Resource Manager.
 
 ## Service Principal Requirements
-The AzureHound Enterprise service runs as an Enta ID registered application with a corresponding service principal (Enterprise application) and requires the following permissions:
+The AzureHound Enterprise service runs as an Entra ID registered application with a corresponding service principal (Enterprise application) and requires the following permissions:
 
-* Entra ID [Directory Reader](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) role permanent assignment.
-* Microsoft Graph [Directory.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#directoryreadall) application permission.
-* Microsoft Graph [RoleManagement.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#rolemanagementreadall) application permission.
-* Azure [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role on all Azure Subscriptions, ideally delegated at the [Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) scope.
+* Entra ID [Directory Reader](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) directory role, permanently active (not PIM-eligible only).
+* Microsoft Graph [Directory.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#directoryreadall) application permission (admin consent required).
+* Microsoft Graph [RoleManagement.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#rolemanagementreadall) application permission (admin consent required).
+* Azure [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role on all Azure subscriptions, ideally assigned at the [tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) (root management group) scope.
 
 <Note>
 Both the Directory Reader role **and** the Directory.Read.All permission are required. Although they overlap, they are distinct, and AzureHound relies on both to ensure complete attack path data collection.

--- a/docs/install-data-collector/install-azurehound/system-requirements.mdx
+++ b/docs/install-data-collector/install-azurehound/system-requirements.mdx
@@ -4,10 +4,10 @@ title: AzureHound Enterprise System Requirements and Deployment Process
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
-The AzureHound Enterprise service is a critical element in your deployment that collects and uploads data about your Azure environment to your BloodHound Enterprise tenant for processing and analysis.
+The AzureHound Enterprise service is a critical element in your deployment that collects and uploads data about your Entra ID and Azure environments to your BloodHound Enterprise tenant for processing and analysis.
 
 
-AzureHound Enterprise is generally deployed as a service on a single Windows system per Azure tenant.  You need to create (at least) a single AzureHound server for all the tenants in scope and one Azure Enterprise Application service instance for each tenant.
+AzureHound Enterprise is generally deployed as a service on a single Windows system per Entra ID tenant.  You need to create (at least) a single AzureHound server for all the tenants in scope and one Entra ID Enterprise Application service instance for each tenant.
 
 
 Running multiple AzureHound collector instances on a single server requires the collectors to be installed as Scheduled Tasks instead of Windows Services. Installation instructions for such a configuration can be found at: [Setting up multiple AzureHound collectors on the same server with scheduled tasks](/install-data-collector/install-azurehound/multiple-collectors).
@@ -18,7 +18,7 @@ While it is possible to run both AzureHound and SharpHound on the same machine, 
 
 To deploy a new AzureHound collector service:
 
-1.  Configure Azure: [AzureHound Enterprise Azure Configuration](/install-data-collector/install-azurehound/azure-configuration)
+1.  Configure Entra ID and Azure: [AzureHound Enterprise Azure Configuration](/install-data-collector/install-azurehound/azure-configuration)
 2.  Create your AzureHound configuration: [Create an AzureHound Configuration](/install-data-collector/install-azurehound/create-configuration)
 3.  Deploy and maintain AzureHound: [Run and Upgrade AzureHound (Windows, Docker, or Kubernetes)](/install-data-collector/install-azurehound/installation-options)
 
@@ -33,7 +33,7 @@ To deploy a new AzureHound collector service:
 | **Memory** | 4GB RAM | 16GB RAM | 32GB RAM |
 | **Hard disk space** | 1GB for logging | 5GB for logging | 20GB for logging |
 
-**\*\*These recommendations should be considered a baseline that may need to be increased depending on the size and complexity of your Azure/Entra environment.\*\***
+**These recommendations should be considered a baseline that may need to be increased depending on the size and complexity of your Azure/Entra environment.**
 
 ### Software
 
@@ -53,24 +53,24 @@ OR
 ### Network
 
 * TLS on 443/TCP to your BloodHound Enterprise tenant URL (provided by your account team)
-* TLS on 443/TCP to your Azure tenant. Required domains are:
+* TLS on 443/TCP to your Azure environment. Required domains are:
     * login.microsoftonline.com
-        * Required for authentication to Azure.
+        * Required for authentication to Entra ID and Azure.
     * msidentity.com (CNAME of login.microsoftonline.com)
-        * Required for authentication to Azure.
+        * Required for authentication to Entra ID and Azure.
     * graph.microsoft.com
-        * Required for collection of attack path data from Microsoft Entra ID, etc.
+        * Required for collection of attack path data from Microsoft Entra ID.
     * management.azure.com
-        * Required for collection of attack path data from Microsoft Azure Resource Manager, etc.
+        * Required for collection of attack path data from Microsoft Azure Resource Manager.
 
 ## Service Principal Requirements
 
-The AzureHound Enterprise service will run as an Azure Application backed by a Service Principal with the following permissions:
+The AzureHound Enterprise service will run as an Entra ID Application backed by a Service Principal with the following permissions:
 
-* [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) on all Azure Subscriptions
-* [Directory Reader](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) on Azure Tenant
-* [Directory.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#directoryreadall) on Microsoft Graph
-* [RoleManagement.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#rolemanagementreadall) on Microsoft Graph
+* Entra ID [Directory Reader](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) role permanent assignment.
+* Microsoft Graph [Directory.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#directoryreadall) application permission.
+* Microsoft Graph [RoleManagement.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#rolemanagementreadall) application permission.
+* Azure [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role on all Azure Subscriptions, ideally delegated at the [Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) scope.
 
 <Note>
 Both Directory Reader **and** Directory.Read.All are required; they may read as identical in the Microsoft Documentation above, but they are not. There is some overlap, but each has distinct permissions that AzureHound leverages to ensure attack path data collection coverage.

--- a/docs/install-data-collector/install-azurehound/system-requirements.mdx
+++ b/docs/install-data-collector/install-azurehound/system-requirements.mdx
@@ -4,11 +4,9 @@ title: AzureHound Enterprise System Requirements and Deployment Process
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
-The AzureHound Enterprise service is a critical element in your deployment that collects and uploads data about your Entra ID and Azure environments to your BloodHound Enterprise tenant for processing and analysis.
+The AzureHound Enterprise service is a critical element in your deployment that collects and uploads data about your Microsoft Entra ID and Azure environments to your BloodHound Enterprise tenant for processing and analysis.
 
-
-AzureHound Enterprise is generally deployed as a service on a single Windows system per Entra ID tenant.  You need to create (at least) a single AzureHound server for all the tenants in scope and one Entra ID Enterprise Application service instance for each tenant.
-
+AzureHound Enterprise is generally deployed as a service on a single Windows system per Entra ID tenant. You need to create (at least) a single AzureHound server for all the tenants in scope and one Entra ID Enterprise Application service instance for each tenant.
 
 Running multiple AzureHound collector instances on a single server requires the collectors to be installed as Scheduled Tasks instead of Windows Services. Installation instructions for such a configuration can be found at: [Setting up multiple AzureHound collectors on the same server with scheduled tasks](/install-data-collector/install-azurehound/multiple-collectors).
 
@@ -33,7 +31,7 @@ To deploy a new AzureHound collector service:
 | **Memory** | 4GB RAM | 16GB RAM | 32GB RAM |
 | **Hard disk space** | 1GB for logging | 5GB for logging | 20GB for logging |
 
-**These recommendations should be considered a baseline that may need to be increased depending on the size and complexity of your Azure/Entra environment.**
+**These recommendations should be considered a baseline that may need to be increased depending on the size and complexity of your Microsoft Entra ID and Azure environments.**
 
 ### Software
 
@@ -64,8 +62,7 @@ OR
         * Required for collection of attack path data from Microsoft Azure Resource Manager.
 
 ## Service Principal Requirements
-
-The AzureHound Enterprise service will run as an Entra ID Application backed by a Service Principal with the following permissions:
+The AzureHound Enterprise service runs as an Enta ID registered application with a corresponding service principal (Enterprise application) and requires the following permissions:
 
 * Entra ID [Directory Reader](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) role permanent assignment.
 * Microsoft Graph [Directory.Read.All](https://learn.microsoft.com/en-us/graph/permissions-reference#directoryreadall) application permission.
@@ -73,5 +70,5 @@ The AzureHound Enterprise service will run as an Entra ID Application backed by 
 * Azure [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role on all Azure Subscriptions, ideally delegated at the [Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) scope.
 
 <Note>
-Both Directory Reader **and** Directory.Read.All are required; they may read as identical in the Microsoft Documentation above, but they are not. There is some overlap, but each has distinct permissions that AzureHound leverages to ensure attack path data collection coverage.
+Both the Directory Reader role **and** the Directory.Read.All permission are required. Although they overlap, they are distinct, and AzureHound relies on both to ensure complete attack path data collection.
 </Note>

--- a/docs/install-data-collector/install-azurehound/system-requirements.mdx
+++ b/docs/install-data-collector/install-azurehound/system-requirements.mdx
@@ -16,9 +16,9 @@ While it is possible to run both AzureHound and SharpHound on the same machine, 
 
 To deploy a new AzureHound collector service:
 
-1.  Configure Entra ID and Azure: [AzureHound Enterprise Azure Configuration](/install-data-collector/install-azurehound/azure-configuration)
-2.  Create your AzureHound configuration: [Create an AzureHound Configuration](/install-data-collector/install-azurehound/create-configuration)
-3.  Deploy and maintain AzureHound: [Run and Upgrade AzureHound (Windows, Docker, or Kubernetes)](/install-data-collector/install-azurehound/installation-options)
+1. Configure Entra ID and Azure: [AzureHound Enterprise Azure Configuration](/install-data-collector/install-azurehound/azure-configuration)
+2. Create your AzureHound configuration: [Create an AzureHound Configuration](/install-data-collector/install-azurehound/create-configuration)
+3. Deploy and maintain AzureHound: [Run and Upgrade AzureHound (Windows, Docker, or Kubernetes)](/install-data-collector/install-azurehound/installation-options)
 
 ## Server Requirements
 


### PR DESCRIPTION
I renamed *Azure tenant* to *Entra ID Tenant* and expanded the *Service Principal Requirements* section in AzureHound documentation.
Let's hope Microsoft does not rename the product once again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that AzureHound Enterprise continuously collects attack-path data from both Microsoft Entra ID (formerly Azure AD) and Azure.
  * Updated terminology throughout to explicitly reference Microsoft Entra ID alongside Azure.
  * Enhanced deployment guidance to describe per-Entra ID tenant deployment and Enterprise Application/service principal setup.
  * Expanded hardware, network, and endpoint guidance (Graph vs. Azure Resource Manager).
  * Clarified required permissions, distinguishing Directory Reader and Directory.Read.All.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->