### PR TITLE
chore: BloodHound, not Bloodhound

### DIFF
--- a/docs/get-started/quickstart/community-edition-quickstart.mdx
+++ b/docs/get-started/quickstart/community-edition-quickstart.mdx
@@ -28,7 +28,7 @@ BloodHound CE deploys in a traditional multi-tier container architecture consist
 
 1. Install [Docker Desktop](https://www.docker.com/get-started). This gives you access to Docker Compose.
 
-2.	Download the latest release of **[Bloodhound CLI](https://github.com/SpecterOps/bloodhound-cli/releases)** for your operating system and architecture (AMD or ARM) and unpack the file. BloodHound CLI is a utility that makes it easy to install BloodHound Community Edition in containers on your machine. To avoid the software getting blocked as malware in the browser, we recommend downloading it via command line using the following commands ([substitute your architecture as appropriate](https://github.com/SpecterOps/bloodhound-cli/releases/latest)):
+2.	Download the latest release of **[BloodHound CLI](https://github.com/SpecterOps/bloodhound-cli/releases)** for your operating system and architecture (AMD or ARM) and unpack the file. BloodHound CLI is a utility that makes it easy to install BloodHound Community Edition in containers on your machine. To avoid the software getting blocked as malware in the browser, we recommend downloading it via command line using the following commands ([substitute your architecture as appropriate](https://github.com/SpecterOps/bloodhound-cli/releases/latest)):
 
   <CodeGroup>
     ```bash Linux

--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -24,7 +24,7 @@ You can remove generic data by using one of the following three (3) options:
     - Active Directory Data
     - Azure Data
     - … X Data (there will be 0 or more checkboxes here that allow you to delete any data that had been ingested with a `source_kind` provided)
-    - Sourceless Data (checking this box will delete all entities that do not have a kind that can be found in the `source_kinds` table.  You can observe the `source_kinds` your Bloodhound instance is currently aware of by calling `GET api/v2/graphs/source_kinds`.)
+    - Sourceless Data (checking this box will delete all entities that do not have a kind that can be found in the `source_kinds` table.  You can observe the `source_kinds` your BloodHound instance is currently aware of by calling `GET api/v2/graphs/source_kinds`.)
 
 3. API: `Clear-Database`
     - See the [OpenGraph API Page](/opengraph/API) for more information

--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -24,7 +24,7 @@ Compressed ZIPs containing multiple file types are supported.
 
 ## JSON Format
 
-The standard Bloodhound UI upload screen now accepts files in a generic format. You can continue using it as before. 
+The standard BloodHound UI upload screen now accepts files in a generic format. You can continue using it as before.
 
 At minimum, your JSON file should have these elements:
 
@@ -44,7 +44,7 @@ When ingest completes, the generic data will be available via **Cypher search ON
 **Entity Panels**: clicking on a generic node or edge will only render the entity’s property bag. At this time there is no support for defining entity panels for generic entities.
 
 
-## Nodes 
+## Nodes
 
 ### Property Rules
 
@@ -311,12 +311,12 @@ The following is the most simple JSON file we could come up with. You can use it
 }
 ```
 
-To test the ingestion in your BloodHound instance, navigate to **Explore** → **Cypher**. Enter the following query and hit `Run`: 
+To test the ingestion in your BloodHound instance, navigate to **Explore** → **Cypher**. Enter the following query and hit `Run`:
 
 ``` Cypher
 match p=()-[:Knows]-()
 return p
 ```
 
-You should get something that looks like this: 
+You should get something that looks like this:
 <img noZoom src="/assets/og-sch-1.png" alt="BOB->Knows->Alice"/>


### PR DESCRIPTION
Corrects errant uses of `Bloodhound` with no capital 'H'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized brand capitalization to BloodHound across OpenGraph FAQ and schema documentation.
  - Improved readability with minor spacing/formatting tweaks, including an added blank line before a code block in the Community Edition Quickstart.
  - No changes to guidance, schemas, or examples; content remains functionally the same.
  - These updates polish copy and presentation for a clearer reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->