### PR TITLE
Feat: FAQ & Best Practice - Search & Pathfind warning

### DIFF
--- a/docs/opengraph/best-practices.mdx
+++ b/docs/opengraph/best-practices.mdx
@@ -13,6 +13,10 @@ However, while the process of adding nodes and edges to the product is greatly s
 
 An attack graph is a tool - a powerful force multiplier when wielded correctly, a frustrating and confusing hazard when not. This document aims to equip you with the knowledge and skills necessary to effectively wield this tool.
 
+<Info>
+In the initial BloodHound 8.0 release, OpenGraph nodes and edges are not supported in the Search or Pathfinding tab, so the Cypher tab **must** be used to query the data manually.
+</Info>
+
 # Basic Attack Graph Vocabulary and Design Theory
 Graphs are [well-understood](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29), well-studied mathematical constructs. You can find thousands of guides, tools, and academic papers that make use of graphs. This document will not replace a proper education or time spent working with graphs. But in this section we will touch on the most fundamental aspects of a graph you must understand in order to effectively get BloodHound to work with your nodes and edges.
 

--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -30,6 +30,11 @@ You can remove generic data by using one of the following three (3) options:
     - See the [OpenGraph API Page](/opengraph/API) for more information
 
 </Accordion>
+<Accordion title="Do custom nodes & edges work with Search and Pathfinding?">
+No, not yet.
+
+In the initial BloodHound 8.0 release, OpenGraph nodes and edges are not supported in the Search or Pathfinding tab, so the Cypher tab **must** be used to query the data manually.
+</Accordion>
 <Accordion title="How can I add my project to the OpenGraph library?">
 Have you built a cool project using OpenGraph and want it featured here? Already got your project in the list and need to update something? Open a ["Library Change" issue](https://github.com/SpecterOps/bloodhound-docs/issues) on the BloodHound Docs repo and we'll get it added for you!
 


### PR DESCRIPTION
Added text to warn user that Search & Pathfinding doesn't work with Custom Nodes & Edge (yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added notice to OpenGraph best practices that, in BloodHound 8.0, OpenGraph nodes and edges are not supported in Search or Pathfinding; users should query via the Cypher tab.
  - Updated OpenGraph FAQ with a new item explaining the limitation and directing users to use the Cypher tab.
  - Corrected FAQ accordion structure to ensure proper rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->