### PR TITLE
chore: Add GTM support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -984,6 +984,9 @@
     "ga4": {
       "measurementId": "G-V9WNXTYFYH"
     },
+    "gtm": {
+      "tagId": "GTM-KWNR5WDL"
+    },
    "plausible": {
      "domain": "bloodhound.specterops.io"
     }


### PR DESCRIPTION
Adds Google Tag Manager support for marketing team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Google Tag Manager (GTM) integration to the documentation site configuration to enhance analytics coverage.
  * Existing GA4 and Plausible analytics remain unchanged and continue to operate alongside GTM.
  * This enables more flexible event management and tracking within the docs without affecting current user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->