### PR TITLE
Add SCCM to OG Library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -113,6 +113,20 @@ Collects BloodHound OpenGraph compatible data from one or more [MSSQL](https://w
 - https://github.com/SpecterOps/MSSQLHound
 
 </Accordion>
+<Accordion title="SCCM" icon="people-group" size={22}>
+
+#### SCCM_SQL_Collector
+
+**Description**
+
+PoC script to collect SCCM attack paths from a SCCM site DB. Credits to [@sanjivkawa](https://x.com/sanjivkawa) for SQLRecon, which is where most of the scaffolding code to allow for connecting to SQL came from (thanks Sanj!)
+
+**Authors/Maintainers**
+- [Dave Cossa](https://x.com/G0ldenGunSec)
+
+**Repos**
+- https://github.com/G0ldenGunSec/SCCM_SQL_Collector
+</Accordion>
 <Accordion title="Snowflake" icon={<SO_Icon />}>
 
 #### SnowHound


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new OpenGraph Library entry for SCCM_SQL_Collector under a new SCCM accordion, placed between MSSQLHound and Snowflake.
  - Entry includes description, authors/maintainers, and repository link for quick access.
  - Improves discoverability of SCCM-related resources within the library.
  - No functional, code, or API changes—documentation update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->