### PR TITLE
Og tools & Edge Names

### DIFF
--- a/docs/opengraph/best-practices.mdx
+++ b/docs/opengraph/best-practices.mdx
@@ -135,7 +135,7 @@ Sorry, but “MemberOf” is already taken, so you will need to use a different 
 
 If your graph model does not create **paths** connecting **non-adjacent** nodes, you should be using a **relational database**, not a **graph database**. You are using the **wrong** tool for the job!
 
-## Requirement 4: Edges Names and Characters
+## Requirement 4: Edges Names and Allowed Characters
 
 Edges names cannot contain dash `-`. It is highly recommended to use Pascal Case and no special characters.
 

--- a/docs/opengraph/best-practices.mdx
+++ b/docs/opengraph/best-practices.mdx
@@ -135,6 +135,14 @@ Sorry, but “MemberOf” is already taken, so you will need to use a different 
 
 If your graph model does not create **paths** connecting **non-adjacent** nodes, you should be using a **relational database**, not a **graph database**. You are using the **wrong** tool for the job!
 
+## Requirement 4: Edges Names and Characters
+
+Edges names cannot contain dash `-`. It is highly recommended to use Pascal Case and no special characters.
+
+From [tuple.nl](https://www.tuple.nl/en/knowledge-base/pascal-case): Pascal Case is a naming convention used in programming where compound words are written without spaces, and each word starts with an uppercase letter. It is commonly used for naming variables, functions, classes, and other identifiers in code. Pascal Case helps create descriptive and easily distinguishable names, contributing to the clarity of your code. 
+
+See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/syntax/naming/) for more details. 
+
 <Note>
 This article is based on [Andy](https://www.linkedin.com/in/robbinsandy/)'s blog [Attack Graph Model Design Requirements and Examples](https://specterops.io/blog/2025/08/01/attack-graph-model-design-requirements-and-examples/) that goes beyond what's described here. 
 </Note>

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -13,7 +13,7 @@ The OpenGraph library provides a list of projects created by BloodHound communit
 
 Have you built a cool project using OpenGraph and want it featured here? Already got your project in the list and need to update something? Open a ["Library Change" issue](https://github.com/SpecterOps/bloodhound-docs/issues) on the BloodHound Docs repo and we'll get it added for you!
 
-Submissions from the community will have a <Icon icon="people-group" color="#ffffff" size={18}/> icon next to them while those by SpecterOps employees will have a <SO_Icon_Inline size={18}/>SpecterOps icon.
+Submissions from the community will have a <Icon icon="people-group" color="#ffffff" size={18}/> icon next to them while those by SpecterOps employees will have a <SO_Icon_Inline size={18}/> SpecterOps icon.
 
 ## OpenGraph Library
 

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -13,7 +13,7 @@ The OpenGraph library provides a list of projects created by BloodHound communit
 
 Have you built a cool project using OpenGraph and want it featured here? Already got your project in the list and need to update something? Open a ["Library Change" issue](https://github.com/SpecterOps/bloodhound-docs/issues) on the BloodHound Docs repo and we'll get it added for you!
 
-Submissions from the community will have a <Icon icon="people-group" color="#ffffff" /> icon next to them while those by SpecterOps employees will have a SpecterOps icon.
+Submissions from the community will have a <Icon icon="people-group" color="#ffffff" size={18}/> icon next to them while those by SpecterOps employees will have a <SO_Icon_Inline size={18}/>SpecterOps icon.
 
 ## OpenGraph Library
 
@@ -31,7 +31,7 @@ Whether you’re auditing permissions, responding to incidents, or simply explor
 
 - [Jared Atkinson](https://x.com/jaredcatkinson) @[SpecterOps](https://specterops.io)
 
-**Repos**
+**Repo**
 
 - https://github.com/SpecterOps/1PassHound
 
@@ -48,7 +48,7 @@ AnsibleHound is a BloodHound OpenGraph collector for [Ansible AWX](https://githu
 - [@Ramoreik](https://github.com/Ramoreik)
 - [@s-lck](https://github.com/s-lck)
 
-**Repos**
+**Repo**
 
 - https://github.com/TheSleekBoyCompany/AnsibleHound
 
@@ -65,7 +65,7 @@ With GitHound, you get a clear, interactive graph of your GitHub permissions lan
 **Authors/Maintainers**
 - [Jared Atkinson](https://x.com/jaredcatkinson) @[SpecterOps](https://specterops.io)
 
-**Repos**
+**Repo**
 - https://github.com/SpecterOps/GitHound
 
 
@@ -80,7 +80,7 @@ Credit and tons of props to the SpecterOps team for the main implementation, for
 - [Derrick Polakoff](https://www.linkedin.com/in/derrick-polakoff-54a34a237) @[CorvraLabs](https://github.com/CorvraLabs)
  
 
-**Repos**
+**Repo**
 - https://github.com/CorvraLabs/GithHoundPy
 
 </Accordion>
@@ -94,7 +94,7 @@ JamfHound is a python3 project designed to collect and identify attack-paths in 
 **Authors/Maintainers**
 - [Lance Cain](https://www.linkedin.com/in/lance-cain-3ab262184) @[SpecterOps](https://specterops.io)
 
-**Repos**
+**Repo**
 - https://github.com/SpecterOps/jamfhound
 
 </Accordion>
@@ -109,7 +109,7 @@ Collects BloodHound OpenGraph compatible data from one or more [MSSQL](https://w
 **Authors/Maintainers**
 - [Chris Thompson](https://x.com/_Mayyhem) @[SpecterOps](https://specterops.io)
 
-**Repos**
+**Repo**
 - https://github.com/SpecterOps/MSSQLHound
 
 </Accordion>
@@ -124,7 +124,7 @@ PoC script to collect SCCM attack paths from a SCCM site DB. Credits to [@sanjiv
 **Authors/Maintainers**
 - [Dave Cossa](https://x.com/G0ldenGunSec)
 
-**Repos**
+**Repo**
 - https://github.com/G0ldenGunSec/SCCM_SQL_Collector
 </Accordion>
 <Accordion title="Snowflake" icon={<SO_Icon />}>
@@ -140,7 +140,7 @@ This provides a comprehensive view of access and potential attack paths within t
 **Authors/Maintainers**
 - [Jared Atkinson](https://x.com/jaredcatkinson) @[SpecterOps](https://specterops.io)
 
-**Repos**
+**Repo**
 - https://github.com/SpecterOps/SnowHound
 </Accordion>
 <Accordion title="vCenter" icon="people-group">
@@ -154,7 +154,7 @@ vCenterHound connects to one or more [vCenters](https://www.vmware.com/products/
 **Authors/Maintainers**
 - [Mor David](https://x.com/m0rd4vid) @[mordavid.com](https://www.mordavid.com/)
 
-**Repos**
+**Repo**
 - https://github.com/MorDavid/vCenterHound
 
 </Accordion>
@@ -162,7 +162,39 @@ vCenterHound connects to one or more [vCenters](https://www.vmware.com/products/
 
 ## OpenGraph Tools
 
-#### BloodHound OpenGraph Helper Library
+#### <SO_Icon_Inline size={22}/> bhopengraph
+
+**Description**
+
+This module provides Python classes for creating and managing graph structures that are compatible with BloodHound OpenGraph. The classes follow the BloodHound OpenGraph schema and best practices.
+
+If you don't know about BloodHound OpenGraph yet, a great introduction can be found here: https://bloodhound.specterops.io/opengraph/best-practices
+
+The complete documentation of this library can be found here: https://bhopengraph.readthedocs.io/en/latest/
+
+**Authors/Maintainers**
+- [Remi Gascou](https://x.com/podalirius_)
+
+**Repo**
+- https://github.com/p0dalirius/bhopengraph
+
+
+#### <SO_Icon_Inline size={22}/> BloodHoundOperator
+
+**Description**
+PowerShell client for BloodHound Community Edition and BloodHound Enterprise
+
+Learn more:
+- Release blog post: BloodHound Operator — Dog Whispering Reloaded
+- Presentation at PowerShell Conference Europe: The Dog Ate My Homework - A new chapter in my BloodHound adventures with PowerShell
+
+**Authors/Maintainers**
+- [SadProcessor](https://x.com/sadprocessor)
+
+**Repo**
+- https://github.com/SadProcessor/BloodHoundOperator
+
+#### <Icon icon="people-group" size={22}/> BloodHound OpenGraph Helper Library
 
 **Description**
 
@@ -171,6 +203,6 @@ A Python library for creating BloodHound OpenGraph JSON data that conforms to th
 **Authors/Maintainers**
 - [Luke Roberts](https://x.com/rookuu_)
 
-**Repos**
+**Repo**
 - https://github.com/rookuu/bloodhound-opengraph
 

--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -191,7 +191,7 @@ See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/
                 "match_by": "id",
                 "value": "server-5678"
             },
-            "kind": "has_session",
+            "kind": "HasSession",
             "properties": {
                 "timestamp": "2025-04-16T12:00:00Z",
                 "duration_minutes": 45
@@ -208,7 +208,7 @@ See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/
                 "value": "file-server-1",
                 "kind": "Server"
             },
-            "kind": "accessed_resource",
+            "kind": "AccessedResource",
             "properties": {
                 "via": "SMB",
                 "sensitive": true
@@ -221,7 +221,7 @@ See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/
             "end": {
                 "value": "domain-controller-9"
             },
-            "kind": "admin_to",
+            "kind": "AdminTo",
             "properties": {
                 "reason": "elevated_permissions",
                 "confirmed": false
@@ -236,7 +236,7 @@ See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/
                 "match_by": "id",
                 "value": "network-42"
             },
-            "kind": "connected_to",
+            "kind": "ConnectedTo",
             "properties": null
         }
     ]

--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -113,8 +113,11 @@ An array of kind labels for the node. The first element is treated as the node's
 
 ## Edges
 
+Edges names cannot contain dash `-`. It is highly recommended to use Pascal Case and no special characters.
 
+From [tuple.nl](https://www.tuple.nl/en/knowledge-base/pascal-case): Pascal Case is a naming convention used in programming where compound words are written without spaces, and each word starts with an uppercase letter. It is commonly used for naming variables, functions, classes, and other identifiers in code. Pascal Case helps create descriptive and easily distinguishable names, contributing to the clarity of your code. 
 
+See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/syntax/naming/) for more details. 
 
 ### Edge JSON
 ``` JSON

--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -153,7 +153,7 @@ See Neo4j [Naming and Conventions](https://neo4j.com/docs/cypher-manual/current/
                     "type": "string",
                     "enum": ["id", "name"],
                     "default": "id",
-                    "description": "Whether to match the start node by its unique object ID or by its name property."
+                    "description": "Whether to match the end node by its unique object ID or by its name property."
                 },
                 "value": {
                     "type": "string",


### PR DESCRIPTION
Fix: Added OpenGraph Tools
Fix: Added Edges naming and convention to Best Practices & Schema page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added “Requirement 4: Edges Names and Characters,” clarifying edge-name rules (no dashes; prefer PascalCase; avoid special characters) with external references.
  - Updated OpenGraph schema to reflect edge-naming guidance and corrected end.match_by description to reference the end node.
  - Updated OpenGraph library docs: standardized “Repo” label, set explicit icon sizing/inline SpecterOps icons, and expanded Tools with bhopengraph, BloodHoundOperator, and BloodHound OpenGraph Helper Library (with links).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->