### PR TITLE
Adds Entra ID to Library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -79,14 +79,22 @@ A tool to help pentesters quickly identify privileged principals and second-orde
 
 This PoC community project provides a sample `PowerShell` script that collects Microsoft Entra ID permissions related to [Temporary Access Passes (TAPs)](https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-temporary-access-pass) and [Passkeys (FIDO2 security keys or mobile devices)](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2) and exports the data in [BloodHound OpenGraph](https://specterops.io/opengraph/) format.
 
-TAPs and Passkeys can be registered by privileged malicious actors for other users. By authenticating with one of these methods afterwards, they can bypass MFA requirements and perform privilege elevation. This is in principle similar to the [AZResetPassword](/resources/edges/az-reset-password) edge, but with stronger requirements and more serious impact, but also more attractive to adversaries as it doesn’t result in the target user losing their ability to authenticate themselves with a password they know.
-
 **Authors/Maintainers**
 - [Michael Grafnetter](https://x.com/mgrafnetter) @[SpecterOps](https://specterops.io)
 
 **Repo**
 - https://github.com/MichaelGrafnetter/EntraAuthPolicyHound
 
+#### <SO_Icon_Inline size={22}/> EntraSSSOHound
+**Description**
+
+Entra ID Seamless Single Sign-On (Seamless SSO) is a feature that non-interactively signs users into cloud applications whenever they are connected to Active Directory. EntraSSSOHound extends BloodHound CE with OpenGraph-format coverage, modeling how Active Directory computers can compromise synced Entra ID users through the trust established between the trusted on-premises computer and Entra ID.
+
+**Authors/Maintainers**
+- [Daniel Heinsen](https://x.com/hotnops) @[SpecterOps](https://specterops.io)
+
+**Repo**
+- https://github.com/SpecterOps/EntraSSSOHound
 </Accordion>
 <Accordion title="GitHub" icon={<SO_Icon />}>
 

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -74,7 +74,7 @@ A tool to help pentesters quickly identify privileged principals and second-orde
 </Accordion>
 <Accordion title="Entra ID" icon={<SO_Icon />}>
 
-#### <SO_Icon_Inline size={22}/> Entra ID Authentication Policy Data Collector
+#### <SO_Icon_Inline size={22}/> EntraAuthPolicyHound
 **Description**
 
 This PoC community project provides a sample `PowerShell` script that collects Microsoft Entra ID permissions related to [Temporary Access Passes (TAPs)](https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-temporary-access-pass) and [Passkeys (FIDO2 security keys or mobile devices)](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2) and exports the data in [BloodHound OpenGraph](https://specterops.io/opengraph/) format.
@@ -82,10 +82,10 @@ This PoC community project provides a sample `PowerShell` script that collects M
 TAPs and Passkeys can be registered by privileged malicious actors for other users. By authenticating with one of these methods afterwards, they can bypass MFA requirements and perform privilege elevation. This is in principle similar to the [AZResetPassword](/resources/edges/az-reset-password) edge, but with stronger requirements and more serious impact, but also more attractive to adversaries as it doesn’t result in the target user losing their ability to authenticate themselves with a password they know.
 
 **Authors/Maintainers**
-- [Michael Grafnetter](https://github.com/MichaelGrafnetter) @[SpecterOps](https://specterops.io)
+- [Michael Grafnetter](https://x.com/mgrafnetter) @[SpecterOps](https://specterops.io)
 
 **Repo**
-- https://github.com/MichaelGrafnetter/bh-entra-tap-passkey-collector
+- https://github.com/MichaelGrafnetter/EntraAuthPolicyHound
 
 </Accordion>
 <Accordion title="GitHub" icon={<SO_Icon />}>

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -72,6 +72,22 @@ A tool to help pentesters quickly identify privileged principals and second-orde
 - https://github.com/VirtueSecurity/IAMhounddog
 
 </Accordion>
+<Accordion title="Entra ID" icon={<SO_Icon />}>
+
+#### <SO_Icon_Inline size={22}/> Entra ID Authentication Policy Data Collector
+**Description**
+
+This PoC community project provides a sample `PowerShell` script that collects Microsoft Entra ID permissions related to [Temporary Access Passes (TAPs)](https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-temporary-access-pass) and [Passkeys (FIDO2 security keys or mobile devices)](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2) and exports the data in [BloodHound OpenGraph](https://specterops.io/opengraph/) format.
+
+TAPs and Passkeys can be registered by privileged malicious actors for other users. By authenticating with one of these methods afterwards, they can bypass MFA requirements and perform privilege elevation. This is in principle similar to the [AZResetPassword](/resources/edges/az-reset-password) edge, but with stronger requirements and more serious impact, but also more attractive to adversaries as it doesn’t result in the target user losing their ability to authenticate themselves with a password they know.
+
+**Authors/Maintainers**
+- [Michael Grafnetter](https://github.com/MichaelGrafnetter) @[SpecterOps](https://specterops.io)
+
+**Repo**
+- https://github.com/MichaelGrafnetter/bh-entra-tap-passkey-collector
+
+</Accordion>
 <Accordion title="GitHub" icon={<SO_Icon />}>
 
 #### <SO_Icon_Inline size={22}/> GitHound


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Entra ID" accordion to the OpenGraph Library page.
  * Included two Entra ID entries: EntraAuthPolicyHound and EntraSSSOHound.
  * Each entry contains title, description, authors, and repository link.
  * Placed alongside existing entries without modifying other content.
  * Improves discoverability of Entra ID resources; no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->