### PR TITLE
K8s lib

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -155,16 +155,16 @@ JamfHound is a python3 project designed to collect and identify attack-paths in 
 </Accordion>
 <Accordion title="Kubernetes" icon={<SO_Icon />}>
 
-#### <SO_Icon_Inline size={22}/> OpenGraph dlt
+#### <SO_Icon_Inline size={22}/> OpenGraph DLT
 **Description**
 
-A lightweight CLI for collecting service-specific resources and turning it into OpenGraph/BloodHound datasets. The long–term goal is to plug in multiple collectors; Kubernetes is the first source and serves as the reference implementation for future integrations. The kubernetes collector makes use of an (embedded) DuckDB database, which may not be needed for your usecase :)
+A lightweight CLI for collecting service-specific resources and turning it into OpenGraph/BloodHound datasets. The long–term goal is to plug in multiple collectors; Kubernetes is the first source and serves as the reference implementation for future integrations. The kubernetes collector makes use of an (embedded) DuckDB database, which may not be needed for your usecase.
 
 **Authors/Maintainers**
 - [Joey Dreijer](https://github.com/d3vzer0) @[SpecterOps](https://specterops.io)
 
 **Repo**
-- https://github.com/d3vzer0/OpenGraph-dlt/tree/main
+- https://github.com/d3vzer0/OpenGraph-dlt
 
 </Accordion>
 <Accordion title="MSSQL" icon={<SO_Icon />}>


### PR DESCRIPTION
Adding entry to the library.
Joey's OpenGraph-dlt for Kuberneteses

Renaming the category JamfHound to Jamf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenGraph Library: Renamed the JamfHound accordion to Jamf and expanded its description, adding clearer context on Jamf Pro tenants and related field updates.
  * Added a new Kubernetes accordion introducing OpenGraph DLT, including a description, authors/maintainers, and repository reference to improve discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->