### PR TITLE
fix: Session collection

### DIFF
--- a/docs/collect-data/enterprise-collection/least-privileged-collection.mdx
+++ b/docs/collect-data/enterprise-collection/least-privileged-collection.mdx
@@ -49,7 +49,7 @@ To collect session data from domain controllers, the collector service account c
   <img src="/assets/least-priv-gpo-defang-printop.png" alt=""/>
 </Frame>
 
-To collect session data from Windows workstations and member servers, the collector service account can be added to the local Print Operators group on each device. The best way to accomplish this is likely via Group Policy Preferences.
+To collect session data from Windows member servers, the collector service account can be added to the local Print Operators group on each device. The best way to accomplish this is likely via Group Policy Preferences.
 
 For example, if our Tier One SharpHound collector gMSA is a member of the Allow_NetwkstaUserEnum_T1 group, a GPO configured like this and linked to any OUs where Tier One assets are located will grant the SharpHound collector session enumeration rights.
 
@@ -58,6 +58,10 @@ For example, if our Tier One SharpHound collector gMSA is a member of the Allow_
 </Frame>
 
 <Tip>Local group membership can also be managed via the Restricted Groups GPO setting category. This is a legacy setting. Group Policy Preferences is more robust and less likely to create security or denial of service (DoS) issues.</Tip>
+
+Collecting session data from domain-joined Windows desktops will require membership in the local Administrators group on each endpoint, which is best handled via Group Policy Preferences. Utilizing a service account that is a member of Domain Admins is strongly discouraged.
+
+There may be other options for collecting session data from the environment, such as parsing Windows event logs from all forest domain controllers, specifically Event ID 4624.
 
 ## Certificate Services
 

--- a/docs/collect-data/permissions.mdx
+++ b/docs/collect-data/permissions.mdx
@@ -89,6 +89,8 @@ SharpHound collects this information utilizing the [NetWkstaUserEnum](https://le
 
 Members of the local Administrators group may call this function. For least-privilege collection, members of the local Print Operators group may also call this function on Windows Server operating systems.
 
+<Note> Windows desktop operating systems do not have a local Print Operators group. Utilize membership in the local Administrators group or an alternate collection method as described in [Least-Privileged Collection](/collect-data/enterprise-collection/least-privileged-collection#sessions).</Note>
+
 ## Certificate Services
 
 Information about the Active Directory Certificate Service hierarchy within your Active Directory environment makes up the basic information necessary to identify ADCS attack paths within your environment. This information includes:


### PR DESCRIPTION
Print Operators only exists on Windows Server OS. Least-priv collection of Session data on Windows desktop OS does not work as there is no print operators group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified least-privileged collection guidance: Local Print Operators rights apply only on Windows Server; Windows desktop OS lacks this option.
  * Recommended alternatives for desktop and domain-joined devices (e.g., event-log parsing, Event ID 4624) as complements or replacements.
  * Narrowed NetWkstaUserEnum guidance to Windows Server.
  * Added cautions about requiring local Administrators and avoiding Domain Admins; referenced restricted group policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->