### PR TITLE
Add tip for using OpenGraph as data collector to quickstarts

### DIFF
--- a/docs/get-started/quickstart/community-edition-quickstart.mdx
+++ b/docs/get-started/quickstart/community-edition-quickstart.mdx
@@ -3,6 +3,7 @@ title: BloodHound Community Edition Quickstart
 ---
 
 import SampleData from '/snippets/sample-data.mdx';
+import OpengraphLibrary from '/snippets/opengraph-library.mdx';
 
 <img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only"/>
 
@@ -189,9 +190,7 @@ BloodHound CE analyzes data collected by its two collector services, each collec
 * Active Directory, collected by SharpHound CE
 * Entra ID (formerly Azure AD), collected by AzureHound CE
 
-<Tip>
-Extend BloodHound's analysis beyond Active Directory and Entra ID with additional data collectors. The [OpenGraph Library](/opengraph/library) showcases collectors built by the community and SpecterOps employees for platforms like AWS, GitHub, Snowflake, and more.
-</Tip>
+<OpengraphLibrary/>
 
 ### Download collectors
 

--- a/docs/get-started/quickstart/enterprise-quickstart.mdx
+++ b/docs/get-started/quickstart/enterprise-quickstart.mdx
@@ -2,6 +2,8 @@
 title: BloodHound Enterprise Quickstart
 ---
 
+import OpengraphLibrary from '/snippets/opengraph-library.mdx';
+
    <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 Get started with your BloodHound Enterprise instance and start identifying and remediating security risks.
@@ -18,6 +20,8 @@ BloodHound Enterprise analyzes data collected by its two collector services, eac
 * Entra ID (formerly Azure AD) and Azure IaaS, collected by AzureHound Enterprise
 
 You can run the two services from the same Windows system. AzureHound Enterprise also supports Docker and Kubernetes.
+
+<OpengraphLibrary/>
 
 ## Ingest with SharpHound Enterprise (Active Directory)
 

--- a/docs/snippets/opengraph-library.mdx
+++ b/docs/snippets/opengraph-library.mdx
@@ -1,0 +1,3 @@
+<Tip>
+Extend BloodHound's analysis beyond Active Directory and Entra ID with additional data collectors. The [OpenGraph Library](/opengraph/library) showcases collectors built by the community and SpecterOps employees for platforms like AWS, GitHub, Snowflake, and more.
+</Tip>


### PR DESCRIPTION
## Purpose

This pull request (PR) updates the quickstart pages with a tip about using the OpenGraph Library to collect and analyze data from other platforms.

It seeks to address internal feedback originally reported on the [BHCE quickstart](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart#option-2-more-realistic-%3A-ingest-your-data-with-data-collectors). My assumption is that since OpenGraph applies to both BHCE and BHE, the note belongs in both quickstarts (which is why I've proposed a snippet).

>[!NOTE]
>If this doesn't apply to both editions, I can revert [`e6659da`](https://github.com/SpecterOps/bloodhound-docs/pull/75/commits/e6659dae4a6aa89c12960fbfc2c5c36055ba3c01).

## Notes for future consideration

While reviewing the docs, it was unclear to me whether a single BloodHound instance supports multiple data sets from different collectors (aside from SharpHound and AzureHound). For example:

1. Does data from other OpenGraph collectors enrich AD/Entra ID data or is it meant to be separate?
2. Does it make sense to use OpenGraph collectors independently of AD/Entra ID data?
   - Or Is that the intended value-add of OpenGraph in BloodHound (i.e., improving the accessibility of modeling graph data)?
4. Are there any limitations or best practices we should share related to the number (or combination) of collectors that you use?

I'm not sure if those are valid questions since I'm still onboarding, but if they are it would be good to have answers in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added an OpenGraph Library tip highlighting community- and SpecterOps-backed data collectors (e.g., AWS, GitHub, Snowflake) to extend analysis.
  - Integrated the tip into both Community and Enterprise Quickstart guides for better discovery.
  - Updated terminology to “Entra ID (formerly Azure AD)” for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->