### PR TITLE
Add PingOneHound project to OpenGraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -204,11 +204,11 @@ NetworkHound connects to Active Directory Domain Controllers, discovers computer
 
 PingOne is an identity provider (IDP) product from the Ping Identity Corporation. PingOneHound collects the data necessary to:
 
-- Identity, analyze, and execute PingOne attack paths
+- Identify, analyze, and execute PingOne attack paths
 - Easily audit object-level permissions
 
 **Authors/Maintainers**
-- [Andy Robbins](https://www.linkedin.com/in/robbinsandy/)
+- [Andy Robbins](https://www.linkedin.com/in/robbinsandy/) @[SpecterOps](https://specterops.io)
 
 **Repo**
 - https://github.com/andyrobbins/PingOneHound


### PR DESCRIPTION
This pull request adds an entry for the new PingOneHound project to the [OpenGraph library](https://bloodhound.specterops.io/opengraph/library).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Ping" entry to the OpenGraph Library describing PingOneHound (identifies PingOne attack paths and audits object-level permissions), with maintainer info for Andy Robbins (LinkedIn) and the project repository link.
  * Placed the new entry in the library catalog ahead of the existing SCCM entry to expand the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->