### PR TITLE
Add Rapid7 InsightVM and update to Kubernetes

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -219,7 +219,7 @@ PingOne is an identity provider (IDP) product from the Ping Identity Corporation
 #### <SO_Icon_Inline size={22}/> OpenGraph DLT (Rapid7 InsightVM)
 **Description**
 
-A lightweight CLI for collecting service-specific resources and turning it into OpenGraph/BloodHound datasets. Specifically the Rapid7 InsightVM collector. This collector allows you to ingest Vulnerability Management data from a local InsightVM machine and display them in a graph. Attack paths "HasVulnerability" indicates if machines are identified to have a certain vulnerbility. The collector makes use of an (embedded) DuckDB database, which may not be needed for your use case.
+A lightweight CLI for collecting service-specific resources and turning it into OpenGraph/BloodHound datasets. Specifically the Rapid7 InsightVM collector. This collector allows you to ingest Vulnerability Management data from a local InsightVM machine and display them in a graph. Attack paths "HasVulnerability" indicates if machines are identified to have a certain vulnerability. The collector makes use of an (embedded) DuckDB database, which may not be needed for your use case.
 
 **Authors/Maintainers**
 * [Joey Dreijer](https://github.com/d3vzer0) @[SpecterOps](https://specterops.io/)


### PR DESCRIPTION
Added one new OG implementation and minor doc update to existing. Integration idea created by me and integrated as part of DLT project by Joey.

Resolves #81 and #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified Kubernetes context by updating the OpenGraph DLT header to "OpenGraph DLT (Kubernetes)" in relevant docs.
  * Added a new Rapid7 InsightVM OpenGraph DLT section, including description, authors/maintainers, and repository information to document the integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->