### PR TITLE
Add company affiliation for TaskHound author

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -321,7 +321,7 @@ Windows Privileged Scheduled Task Discovery Tool for fun and profit.
 TaskHound hunts for Windows scheduled tasks that run with privileged accounts and stored credentials. It enumerates tasks over SMB, parses XMLs, and identifies high-value attack opportunities through BloodHound export support.
 
 **Authors/Maintainers**
-- [Robin 'r0BIT' Unglaub](https://www.linkedin.com/in/robin-unglaub/) 
+- [Robin 'r0BIT' Unglaub](https://www.linkedin.com/in/robin-unglaub/) @[ProSec GmbH](https://www.prosec-networks.com)
 
 **Repo**
 - https://github.com/1r0BIT/TaskHound


### PR DESCRIPTION
## Purpose

This pull request (PR) adds company affiliation for the author of the TaskHound [OpenGraph](https://bloodhound.specterops.io/opengraph/library) project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainer affiliation information for the Windows TaskHound entry in the OpenGraph Library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->