### PR TITLE
Add ShareHound project to OpenGraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -312,6 +312,18 @@ vCenterHound connects to one or more [vCenters](https://www.vmware.com/products/
 </Accordion>
 <Accordion title="Windows" icon="people-group">
 
+#### <SO_Icon_Inline size={22}/> ShareHound
+
+**Description**
+
+ShareHound is an OpenGraph collector that maps network shares, permissions, and paths at scale to help identify attack paths to network shares.
+
+**Authors/Maintainers**
+- [Remi Gascou](https://x.com/podalirius_) @[SpecterOps](https://specterops.io)
+
+**Repo**
+- https://github.com/p0dalirius/sharehound
+
 #### <Icon icon="people-group" size={22}/> TaskHound
 
 **Description**


### PR DESCRIPTION
## Purpose

This pull request (PR) adds the ShareHound project to the [OpenGraph library](https://bloodhound.specterops.io/opengraph/library).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added a new library entry to the OpenGraph Library documentation with descriptions, maintainer information, and repository reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->