### PR TITLE
Link to DAWGs repo for CySQL references

### DIFF
--- a/docs/analyze-data/cypher-supported.mdx
+++ b/docs/analyze-data/cypher-supported.mdx
@@ -11,7 +11,7 @@ This article describes how to use Cypher Search within BloodHound. Users of Bloo
 
 # Supported Query Components
 
-Below are the currently supported openCypher query components translated by CySQL.
+Below are the currently supported openCypher query components translated by [CySQL](https://github.com/SpecterOps/DAWGS/blob/main/cypher/Cypher%20Syntax%20Support.md).
 
 ## Pattern Matching
 ### Node Matching


### PR DESCRIPTION
## Purpose

This pull request (PR) adds a link to the DAWGs repo in the initial reference to `CySQL` on the [Supported Cypher Syntax](https://bloodhound.specterops.io/analyze-data/cypher-supported) page.

This question came up in Slack and the DAWGs repo was confirmed to contain the relevant technical details for CySQL.

I also noticed that what we have on the docs site appears to be copied from a [markdown file](https://github.com/SpecterOps/DAWGS/blob/main/cypher/Cypher%20Syntax%20Support.md) in the DAWGs repo. I haven't done a diff to see if our docs are up to date. If there are any differences, I'll address them in a separate PR.

>[!NOTE]
>The only meaningful difference between the [file](https://github.com/SpecterOps/bloodhound-docs/blob/main/docs/analyze-data/cypher-supported.mdx?plain=1#L266-L309) in this repo and the [file](https://github.com/SpecterOps/bloodhound-docs/pull/18/files#diff-f6b513e428c39598af6fbdccbc5a07c34ef17f18b676e9fd71724f68438d6d00) in the DAWGs repo is related to **Quantifier Expressions**. Support for these expressions appears to have been added in v8.1.0 (#52).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Pattern Matching section in documentation with an improved reference link for easier navigation to related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->