### PR TITLE
Adding AtlassianHound

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -95,7 +95,7 @@ A tool to help pentesters quickly identify privileged principals and second-orde
 #### <SO_Icon_Inline size={22}/> AtlassianHound
 **Description**
 
-This project collects foundational Jira and Confluence access data and exports it in the BloodHound OpenGraph format using the [bhopengraph](https://github.com/p0dalirius/bhopengraph/tree/main) Python library (gr33ts @[p0dalirius](https://x.com/podalirius_)). It should support both Atlassian Cloud and Data Center deployments (I dont have a on-prem to test against. PRs welcome lol)
+This project collects foundational Jira and Confluence access data and exports it in the BloodHound OpenGraph format using the [bhopengraph](https://github.com/p0dalirius/bhopengraph/tree/main) Python library (gr33ts @[p0dalirius](https://x.com/podalirius_)). This project should support both Atlassian Cloud and on-premises deployments, however it has been tested on Atlassian Cloud deployments only; contributions for on-premises deployments are welcome.
 
 **Authors/Maintainers**
 - [Craig Wright](https://x.com/werdhaihai) @[SpecterOps](https://specterops.io)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new AtlassianHound OpenGraph entry under a new Atlassian accordion in the docs. Includes a clear title and description referencing Jira and Confluence data export via OpenGraph, plus authors/maintainers and repository URL for easy discovery and attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->