### PR TITLE
Add OpenGraph workaround for post-processed edges

### DIFF
--- a/docs/opengraph/schema.mdx
+++ b/docs/opengraph/schema.mdx
@@ -249,8 +249,20 @@ Post-processing in BloodHound refers to the analysis phase where the system crea
 
 After ingesting data, BloodHound analyzes the graph state and adds edges it considers useful. BloodHound regenerates "post-processed" edges after it builds a complete graph. Before regenerating post-processed edges, BloodHound deletes any existing ones. As a result, BloodHound removes any post-processed edges that you add directly to an OpenGraph payload.
 
-See the following list of edges that BloodHound creates during post-processing:
+<Accordion title="Show post-processed edges">
+BloodHound creates the following edges during post-processing:
 
+- [`ADCSESC1`](/resources/edges/adcs-esc1)
+- [`ADCSESC3`](/resources/edges/adcs-esc3)
+- [`ADCSESC4`](/resources/edges/adcs-esc4)
+- [`ADCSESC6a`](/resources/edges/adcs-esc6a)
+- [`ADCSESC6b`](/resources/edges/adcs-esc6b)
+- [`ADCSESC9a`](/resources/edges/adcs-esc9a)
+- [`ADCSESC9b`](/resources/edges/adcs-esc9b)
+- [`ADCSESC10a`](/resources/edges/adcs-esc10a)
+- [`ADCSESC10b`](/resources/edges/adcs-esc10b)
+- [`ADCSESC13`](/resources/edges/adcs-esc13)
+- [`AddMember`](/resources/edges/add-member)
 - [`AdminTo`](/resources/edges/admin-to)
 - [`AZAddOwner`](/resources/edges/az-add-owner)
 - [`AZMGAddMember`](/resources/edges/az-mg-add-member)
@@ -258,6 +270,30 @@ See the following list of edges that BloodHound creates during post-processing:
 - [`AZMGAddSecret`](/resources/edges/az-mg-add-secret)
 - [`AZMGGrantAppRoles`](/resources/edges/az-mg-grant-app-roles)
 - [`AZMGGrantRole`](/resources/edges/az-mg-grant-role)
+- [`AZRoleApprover`](/resources/edges/az-role-approver)
+- [`CanPSRemote`](/resources/edges/can-ps-remote)
+- [`CanRDP`](/resources/edges/can-rdp)
+- [`CoerceAndRelayNTLMToADCS`](/resources/edges/coerce-and-relay-ntlm-to-adcs)
+- [`CoerceAndRelayNTLMToLDAP`](/resources/edges/coerce-and-relay-ntlm-to-ldap)
+- [`CoerceAndRelayNTLMToLDAPS`](/resources/edges/coerce-and-relay-ntlm-to-ldaps)
+- [`CoerceAndRelayNTLMToSMB`](/resources/edges/coerce-and-relay-ntlm-to-smb)
+- [`DCSync`](/resources/edges/dc-sync)
+- [`EnrollOnBehalfOf`](/resources/edges/enroll-on-behalf-of)
+- [`EnterpriseCAFor`](/resources/edges/enterprise-ca-for)
+- [`ExecuteDCOM`](/resources/edges/execute-dcom)
+- [`ExtendedByPolicy`](/resources/edges/extended-by-policy)
+- [`GoldenCert`](/resources/edges/golden-cert)
+- [`HasTrustKeys`](/resources/edges/has-trust-keys)
+- [`IssuedSignedBy`](/resources/edges/issued-signed-by)
+- [`Owns`](/resources/edges/owns)
+- [`ProtectAdminGroups`](/resources/edges/protect-admin-groups)
+- [`SyncLAPSPassword`](/resources/edges/sync-laps-password)
+- [`SyncedToADUser`](/resources/edges/synced-to-ad-user)
+- [`SyncedToEntraUser`](/resources/edges/synced-to-entra-user)
+- [`TrustedForNTAuth`](/resources/edges/trusted-for-nt-auth)
+- [`WriteOwner`](/resources/edges/write-owner)
+
+</Accordion>
 
 You can work around this behavior by including the supporting edges that cause the post-processing step to generate the edge that you want.
 


### PR DESCRIPTION
## Purpose

This pull request (PR) adds a workaround for nuances about how post-processed edges behave in OpenGraph based on https://github.com/SpecterOps/BloodHound/issues/1977.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Post-processing section explaining how post-processing regenerates or removes graph edges, how it affects pre-existing edges at runtime, and examples for triggering or avoiding post-processing.
  * Added an Optional Metadata Field subsection documenting a new source_kind field that appends to node kinds during ingest, with usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->