### PR TITLE
docs: add port 135 for NTLM relay collection

### DIFF
--- a/docs/install-data-collector/install-sharphound/system-requirements.mdx
+++ b/docs/install-data-collector/install-sharphound/system-requirements.mdx
@@ -37,6 +37,7 @@ To collect Active Directory data with SharpHound and ingest it into BloodHound f
     * [LDAP channel signing](https://www.hub.trimarcsecurity.com/post/ldap-channel-binding-and-signing) is used for all queries.
 * \[Optional\] If performing privileged collection (see [Why perform privileged collection in SharpHound](/collect-data/enterprise-collection/privileged-collection))
     * SMB/RPC on 445/TCP to all in-scope domain-joined Windows systems
+    * SMB/RPC on 135/TCP to all in-scope domain-joined Windows systems for NTLM relay-based collection
     * Approximately 60-100kB network bandwidth per collection to each in-scope domain-joined Windows system
 * \[Optional\] If performing DC Registry and CA Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions))
     * SMB/RPC on 445/TCP to all DCs and domain-joined CAs
@@ -49,6 +50,7 @@ The SharpHound Enterprise service will run as a domain-joined account and will u
 * Granted "Log on as a service" User Rights Assignment on the SharpHound Enterprise server
 * \[Optional\] If performing privileged collection (see [Why perform privileged collection in SharpHound](/collect-data/enterprise-collection/privileged-collection))
     * Member of the local Administrators group on all in-scope domain-joined Windows systems
+    * SharpHound's privileged collection may also use RPC over 135/TCP to support NTLM relay-based collection. When enabling privileged/NTLM relay collection, ensure any firewall rules and endpoint protections allow RPC endpoint mapper traffic (135/TCP) as required.
 * \[Optional\] If performing DC Registry and CA Registry collection (see [DC Registry and CA Registry details](/collect-data/permissions))
     * Member of the local Administrators group on all domain controllers and domain-joined certificate authorities
 * \[Optional\]: If Active Directory tombstoning is enabled


### PR DESCRIPTION
## Purpose

This pull request (PR) adds updated networking details to the [SharpHound system requirements](https://bloodhound.specterops.io/install-data-collector/install-sharphound/system-requirements).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated system requirements documentation to include NTLM relay-based collection prerequisites for domain-joined Windows systems
* Added network configuration details covering RPC endpoint mapper traffic on 135/TCP
* Clarified firewall and endpoint considerations for enabling privileged NTLM relay collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->