### PR TITLE
OpenGraph FAQ entry for vanishing nodes

### DIFF
--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -61,7 +61,7 @@ One of the benefits of BloodHound Enterprise Edition is active management of the
 
 Every node must be linked to another node. Use one of the following methods to link your OpenGraph nodes:
 
-- Ensure each node defined in the payload has at least one edge connecting it to another node (either predefined or otherwise defined in the payload). Including an edge that links the node to an existing object is the simplest method.
+- Ensure each node defined in the payload has at least one edge connecting it to another node (either predefined or otherwise defined in the payload). This is the simplest method to resolve orphaned nodes.
 - Anchor your OpenGraph data to a lightweight root node (an arbitrary node that orphaned nodes can be connected to without impacting the rest of the graph design).
 
    For example, create a single root node (such as `(:OGRoot)`) and add a containment edge (such as `(:OGRoot)-[:OGContains]->(:YourNode)`) to keep nodes from being orphaned and pruned. Use an edge kind that you exclude from your path queries if you don't want it to affect pathfinding.


### PR DESCRIPTION
## Purpose

This pull request (PR) adds a new OpenGraph FAQ entry for "vanishing nodes" as requested in BED-6771.

## Staging

https://specterops-bed-6771-og-orphaned-nodes.mintlify.app/opengraph/faq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two OpenGraph FAQ accordion entries explaining why ingested OpenGraph nodes may disappear and how AD/AZ nodes can be affected after OpenGraph deletions; each includes "What this means", edition-applicability notes, concrete payload guidance, a recommended two-step workaround for uploading/linking subgraphs, an interim linking strategy, and a note about ongoing design improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->