### PR TITLE
SecretHound

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -106,7 +106,7 @@ This project collects foundational Jira and Confluence access data and exports i
 
 SecretHound converts secret scanning results from various sources into a BloodHound OpenGraph format. You can read the associated blog [here](https://specterops.io/blog/2025/11/13/taming-the-attack-graph-a-many-subgraphs-approach-to-attack-path-analysis/). It leverages @p0dalirius's [bhopengraph](https://github.com/p0dalirius/bhopengraph) library.
 
-This project's primary goal is to expand the graph quickly using a single edge: `ContainsCredentialsFor`. Currently, SecretHound will map secrets to 141 technology subgraphs (using the default `taxonomy/taxonomy.json` system). This translates to potentially 141 possible hybrid attack paths. It includes existing subgraphs accessible through the `kind` array values of: `AZBase` for Azure/Entra ID, `GHBase` for GitHub, and `GCPBase` for Google Cloud Platform. Generic secrets get mapped to an abstract `kind` (i.e., `StargateNetwork`) that is a catchall. Most of my testing was around git repositories.
+This project's primary goal is to expand the graph quickly using a single edge: `ContainsCredentialsFor`. Currently, SecretHound will map secrets to 141 technology subgraphs (using the default `taxonomy/taxonomy.json` system). This translates to potentially 141 possible hybrid attack paths. It includes existing subgraphs accessible through the `kind` array values of: `AZBase` for Azure/Entra ID, `GHBase` for GitHub, and `GCPBase` for Google Cloud Platform. Generic secrets get mapped to an abstract `kind` (i.e., `StargateNetwork`) that is a catchall. Most of the testing was around git repositories.
 
 **Supported Scanners:**
 - GitHub Secret Scanning


### PR DESCRIPTION
Add SecretHound under the Credentials section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the OpenGraph Library catalog with many new and updated project entries, renamed items, and reorganized sections (notably under Credentials).
  * Added richer descriptions and metadata for numerous projects (authors, repos, supported scanners) and improved accordion content/formatting for clearer reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->