### PR TITLE
docs: clarify initial members certification option

### DIFF
--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -89,8 +89,8 @@ Unless you're defining a rule as part of the zone or label creation process, be 
 
     <Note>See [Certification](/analyze-data/privilege-zones/certification) to learn more.</Note>
 
-    * **Initial members**: Only the first set of objects in the rule are certified automatically
-    * **All members**: Every object, including those tied to initial members, is certified automatically
+    * **Initial members**: Only objects directly matched by the rule are certified automatically (excludes objects added through [expansion](#rule-expansion), such as OUs and GPOs)
+    * **All members**: Every object is certified automatically, including those added through expansion
     * **Off**: All certification is manual
 
       <img src="/images/privzones/define-zone-rule.png" alt="Define a rule" title="Define a rule" style={{ width:"100%" }} />


### PR DESCRIPTION
## Purpose

This pull request (PR) clarifies how the **Initial members** [automatic certification](https://bloodhound.specterops.io/analyze-data/privilege-zones/rules#define-a-rule) option works when creating rules for privilege zones.

## Staging

https://specterops-pzm-clarifications.mintlify.app/analyze-data/privilege-zones/rules#define-a-rule

<img width="699" height="601" alt="Screenshot 2025-12-03 at 8 22 54 AM" src="https://github.com/user-attachments/assets/9e42d846-b9df-4be5-bbea-a898feea8bf6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated certification behavior documentation: "Initial members" now certifies only directly rule-matched objects (excluding expanded items), while "All members" certifies all objects including those from expansion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->