### PR TITLE
Add: BloodSOCer and ADAttributeHound

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -405,7 +405,7 @@ TaskHound hunts for Windows scheduled tasks that run with privileged accounts an
 </Accordion>
 </AccordionGroup>
 
-## Non Attack Paths Projects
+## Non-Attack Paths Projects
 
 <AccordionGroup>
 <Accordion title="Mitre ATT&CK" icon={<SO_Icon />}>


### PR DESCRIPTION
Adding ADAttributeHound to the Library
Adding a new section/library called "Non Attack Paths Projects"
Adding BloodSOCer to the new section
Edit text in the warning so it covers both libraries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked OpenGraph library intro spacing and header separation for clarity.
  * Added ADAttributeHound to the Active Directory section with description, preview image, authors/maintainers, and repo link.
  * Added BloodSOCer under a new "Non-Attack Paths Projects" section with description, authors/maintainers, and repo link.
  * Adjusted spacing so new entries display alongside existing OpenGraph items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->