### PR TITLE
docs: add troubleshooting section for PZM rules

### DIFF
--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -205,7 +205,7 @@ When an object matches rules in multiple zones, only the highest-priority zone i
 
 For example, if an object is tagged by both a Tier Zero rule and a Tier One rule, it will only appear in the Tier Zero zone.
 
-**Solution**: Review your **Zone Order** and check whether objects are being claimed by higher-priority zones. You can verify this by checking the higher-priority zones for the missing objects.
+**Solution**: Review your **Zone Order** and check whether objects are being tagged by higher-priority zones. You can verify this by checking the higher-priority zones for the missing objects.
 
 ### Object deleted from graph
 


### PR DESCRIPTION
## Purpose

This pull request (PR) adds a troubleshooting section to help users understand why their rules might not show expected objects in Privilege Zones.

## Staging

https://specterops-pzm-rule-nuances.mintlify.app/analyze-data/privilege-zones/rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance under Label rules pointing users to troubleshooting for missing objects.
  * New "Troubleshoot missing objects" section explains domain filter mismatches, zone precedence conflicts, and cases where objects were removed from the graph, with suggested remedies.
  * Note: the troubleshooting section was inadvertently added twice and may appear duplicated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->