### PR TITLE
Add HoundTrainer in Tools' section

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -508,7 +508,7 @@ If you don't know about BloodHound OpenGraph yet, a great introduction can be fo
 
 **Description**
 
-HoundTrainer is a tool for managing custom node types and cypher queries in BloodHound.
+HoundTrainer is a tool for managing custom node types and Cypher queries in BloodHound.
 
 **Authors/Maintainers**
 - [Tom O'Neill](https://github.com/toneillcodes)


### PR DESCRIPTION
Closes : Issue #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added HoundTrainer to the OpenGraph documentation, appearing in both the OpenGraph Library and the OpenGraph Tools (gopengraph) sections, with a project description, authors/maintainers, and repository URL for reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->