### PR TITLE
fix: slack community link

### DIFF
--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -85,9 +85,9 @@ BloodHound CE is free, open-source, and focused on enabling penetration testers 
 ## Need help?
 <CardGroup>
     <Card title="BloodHound Enterprise Support" icon="square-question">
-        [**Submit a request**](https://support.bloodhoundenterprise.io/requests/new) for dedicated support or ask in the [**BloodHound user Slack community**](https://ghst.ly/BHSlack).
+        [**Submit a request**](https://support.bloodhoundenterprise.io/requests/new) for dedicated support or ask in the [**BloodHound user Slack community**](https://slack.specterops.io).
     </Card>
     <Card title="BloodHound Community Edition Support" icon="users">
-        Ask in the [**BloodHound user Slack community**](https://ghst.ly/BHSlack).
+        Ask in the [**BloodHound user Slack community**](https://slack.specterops.io).
         </Card>
 </CardGroup>

--- a/docs/reference/overview.mdx
+++ b/docs/reference/overview.mdx
@@ -7,7 +7,7 @@ Use it to extend the use of the BloodHound product to work with other tools in y
 
 Endpoint availability is noted using the `Community` and `Enterprise` tags.
 
-To get help with BloodHound Community Edition, join our [Slack community](https://ghst.ly/BHSlack/).
+To get help with BloodHound Community Edition, join our [Slack community](https://slack.specterops.io).
 **BloodHound Enterprise** customers can [submit tickets](../resources/community-support/getting-help).
 
 ## Authentication

--- a/docs/resources/community-support/getting-help.mdx
+++ b/docs/resources/community-support/getting-help.mdx
@@ -11,7 +11,7 @@ We at SpecterOps love the security community, and BloodHound as it stands today 
 
 SpecterOps employees have made countless community contributions through blog posts, public research, and open-source security tooling. We have trained thousands of students in our adversary-focused training courses and helped hundreds of customers with adversary simulation and detection assessments.
 
-Join us in the [BloodHound Gang Slack](https://ghst.ly/BHSlack) where the community of BloodHound and adversary-focused security is gathered.
+Join us in the [BloodHound Gang Slack](https://slack.specterops.io) where the community of BloodHound and adversary-focused security is gathered.
 
 Have a bug report, feature request, or contribution? See below.
 
@@ -25,7 +25,7 @@ For non-issue inquiries, BloodHound Enterprise customers can contact their dedic
 
 **BloodHound Community Edition** does not come with support from SpecterOps.
 
-Users can open an issue on the [BloodHound repo](https://github.com/SpecterOps/BloodHound) or ask for assistance in the community Slack: [BloodHound Gang](https://ghst.ly/BHSlack).
+Users can open an issue on the [BloodHound repo](https://github.com/SpecterOps/BloodHound) or ask for assistance in the community Slack: [BloodHound Gang](https://slack.specterops.io).
 
 If you're looking for official support, you may need BloodHound Enterprise. [Contact us for more information](https://bloodhoundenterprise.io/contact-us/), or learn more about the benefits of BloodHound Enterprise and see how BloodHound Enterprise can be an invaluable addition to your organization's security toolbox with a demo by clicking the button below.
 


### PR DESCRIPTION
## Purpose

This pull request (PR) replaces the short link for the Slack community workspace to a permanent URL as recommended in the internal support slack channel.

There's still a short link in the OpenAPI spec, but I didn't want to change that in the docs because it'll just get overwritten the next time we fetch it from the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack community support links across documentation to direct users to the new unified Slack workspace for BloodHound assistance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->