### PR TITLE
docs: remove deprecated Azure region

### DIFF
--- a/docs/install-data-collector/install-azurehound/create-configuration.mdx
+++ b/docs/install-data-collector/install-azurehound/create-configuration.mdx
@@ -57,7 +57,7 @@ Follow the steps below to create your AzureHound Enterprise configuration file u
   1. Start the AzureHound Enterprise CLI tool with the `configure` command.
 
       ```text
-      C:\Users\Administrator.ROOT\Downloads\azurehound-v2.0.5\azurehound-windows-amd64>azurehound.exe configure
+      C:\Users\Administrator.ROOT\Downloads\azurehound-v2.8.2\azurehound-windows-amd64>azurehound.exe configure
       ```
 
       To see all available options, run `azurehound.exe -h`.


### PR DESCRIPTION
## Purpose

This pull request (PR) removes `germany` from the list of Azure regions in the AzureHound configuration docs.

See BED-4601 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AzureHound Enterprise CLI version displayed from v2.0.5 to v2.8.2.
  * Removed the "germany" option from the Azure region selection, narrowing available regions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->