### PR TITLE
Add sample data for OpenGraph extensions

### DIFF
--- a/docs/snippets/sample-data.mdx
+++ b/docs/snippets/sample-data.mdx
@@ -22,7 +22,7 @@
       </Tab>
 
       <Tab title="k-nexus-global" icon="diagram-project">
-        Download the [k-nexus-global sample data](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/add-extension-sample-data/docs/assets/sample-data/k-nexusglobal-bhce-20260330.zip).
+        Download the [k-nexus-global sample data](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/k-nexusglobal-bhce-20260330.zip).
 
         **k-nexus-global** data generated with SharpHound, AzureHound, GitHound, OktaHound, and JamfHound includes:
 

--- a/docs/snippets/sample-data.mdx
+++ b/docs/snippets/sample-data.mdx
@@ -1,16 +1,38 @@
 <Steps>
   <Step title="Download sample data">
-    Download sample data for [Active Directory](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/ad_sampledata.zip) or [Azure](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/entra_sampledata.zip).
+    <Tabs>
+      <Tab title="Active Directory" icon="building">
+        Download sample data for [Active Directory](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/ad_sampledata.zip).
 
-    **Active Directory Sample Data** generated with SharpHound includes:
-    * 3 collected domains with trusts between them
-    * Additional, visible, trusted domains without collections
-    * Coverage for local permissions
-    * Multiple ADCS escalation paths
+        **Active Directory sample data** generated with SharpHound includes:
 
-    **Azure Sample Data** generated with AzureHound includes:
-    * Full collection of an Azure environment
-    * Support for user-sync hybrid paths when ingested alongside the example AD data
+        - 3 collected domains with trusts between them
+        - Additional, visible, trusted domains without collections
+        - Coverage for local permissions
+        - Multiple ADCS escalation paths
+      </Tab>
+
+      <Tab title="Azure" icon="cloud">
+        Download sample data for [Azure](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/entra_sampledata.zip).
+
+        **Azure sample data** generated with AzureHound includes:
+
+        - Full collection of an Azure environment
+        - Support for user-sync hybrid paths when ingested alongside the example AD data
+      </Tab>
+
+      <Tab title="k-nexus-global" icon="diagram-project">
+        Download the [k-nexus-global sample data](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/add-extension-sample-data/docs/assets/sample-data/k-nexusglobal-bhce-20260330.zip).
+
+        **k-nexus-global** data generated with SharpHound, AzureHound, GitHound, OktaHound, and JamfHound includes:
+
+        - 2 collected domains with trust
+        - 2 Okta tenants, including 1 with AD user sync and 1 with Okta Org2Org
+        - 1 GitHub Enterprise account with Enterprise Managed User via Okta
+        - 1 Jamf tenant with Okta SSO enabled
+        - 1 Entra tenant
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Upload sample data to BloodHound CE">


### PR DESCRIPTION
## Purpose

This pull request (PR) adds sample data for the GitHound, JamfHound, and OktaHound OpenGraph extensions.

## Staging

https://specterops-add-extension-sample-data.mintlify.app/get-started/quickstart/ce-ingest-sample-data#k-nexus-global

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned the sample data download section with a tabbed interface for easier dataset selection between Active Directory, Azure, and k-nexus-global options.
  * Added a new k-nexus-global dataset with expanded data source coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->