### PR TITLE
Clarify App Id vs Installation ID for GitHound session creation

### DIFF
--- a/docs/opengraph/extensions/githound/collect-data.mdx
+++ b/docs/opengraph/extensions/githound/collect-data.mdx
@@ -59,7 +59,7 @@ $session = New-GitHubSession -OrganizationName "YourOrgName" -Token (Get-Clipboa
 
 ```powershell
 . ./githound.ps1
-$session = New-GitHubJwtSession -OrganizationName "YourOrgName" -ClientId "your-client-id" -PrivateKeyPath "./your-app.pem" -AppId 123456789
+$session = New-GitHubJwtSession -OrganizationName "YourOrgName" -ClientId "your-client-id" -PrivateKeyPath "./your-app.pem" -AppId "your-installation-id"
 ```
 
 ## Run the Collector


### PR DESCRIPTION
The current documentation implies that the app ID should be used in this parameter, however this API [actually requires the installation ID for the target organization](https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10&versionId=free-pro-team%40latest&category=apps#create-an-installation-access-token-for-an-app). 

Rather than updating the code and making potentially breaking changes for anyone already using this, I'm proposing a clarification in the documentation. This does work with a quoted string, and should address the issue without code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Corrected the GitHub App session setup example to display the proper format for the installation ID parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->