### PR TITLE
OpenGraph: Add GitlabHound to library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -250,6 +250,27 @@ Credit and tons of props to the SpecterOps team for the main implementation, for
 - https://github.com/CorvraLabs/GitHoundPy
 
 </Accordion>
+<Accordion title="GitLab" icon="people-group">
+#### <Icon icon="people-group" size={22}/> GitLabHound
+
+**Description**
+
+GitLabHound is a BloodHound OpenGraph collector for GitLab to generate a navigable attack-path graph composed of:
+
+- Core GitLab resources: users, groups, roles, projects, repositories, branches, CI/CD pipelines and jobs
+- Hybrid identities using SSO from Active Directory and Entra ID
+- Cross-cloud paths through OIDC trust relationships
+- Domain-joined Windows runners with shell executors
+- Secrets leaked through public resources
+- Renovate dependency bot abuse
+
+**Authors/Maintainers**
+- [Marc André Tanner](https://x.com/marcandretanner) @[Compass Security](https://compass-security.com/)
+
+**Repo**
+- https://github.com/CompassSecurity/GitLabHound
+
+</Accordion>
 <Accordion title="Google Cloud Platform (GCP)" icon="people-group">
 
 #### <Icon icon="people-group" size={22}/> GCP-Hound


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new GitLab security reference to the OpenGraph Library, covering GitLab resource models, identity management, CI/CD pipelines, and security considerations including secret leakage and bot abuse risks.
  * Reorganized library documentation structure with updated entry ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->