### PR TITLE
chore: link openhound to release notes

### DIFF
--- a/docs/resources/release-notes/2026-04-13.mdx
+++ b/docs/resources/release-notes/2026-04-13.mdx
@@ -17,7 +17,7 @@ import featureFlagNote from "/snippets/feature-flag.mdx";
   {/*BED-7312*/}
   ## OpenHound Data Collector Framework
 
-  Collect and convert data from GitHub, Jamf, and Okta with OpenHound, a standardized framework for building and running OpenGraph collectors and converters.
+  Collect and convert data from GitHub, Jamf, and Okta with [OpenHound](/openhound/overview), a standardized framework for building and running OpenGraph collectors and converters.
 
   OpenHound is built in Python and powered by the [Data Load Tool (DLT)](https://dlthub.com/docs/intro) library so you can follow a consistent workflow to collect, process, and convert data from external sources into BloodHound-compatible graphs. You can run OpenHound as a containerized service or as a standalone CLI application.
 </Update>
@@ -101,7 +101,7 @@ import featureFlagNote from "/snippets/feature-flag.mdx";
 
   - Node labels now display below nodes and include a second line identifying the source platform and type (for example, _Active Directory | Group_). Long labels are truncated with an ellipsis and show the full text on selection.
   
-  - Edges now feature higher contrast directional arrows that connect directly to nodes instead of node labels, making it easier to follow relationship paths at default zoom levels.
+  - Edges now feature higher-contrast directional arrows that connect directly to nodes instead of node labels, making it easier to follow relationship paths at default zoom levels.
   
   - The Entity panel now closes when clicking on the graph background to clear selection, giving you more space to explore the graph without manually closing the panel.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Made OpenHound reference in release notes clickable and linked to its overview page.
  * Improved wording in Graph Readability Improvements section for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->