### PR TITLE
Remove broken sample data

### DIFF
--- a/docs/snippets/sample-data.mdx
+++ b/docs/snippets/sample-data.mdx
@@ -20,18 +20,6 @@
         - Full collection of an Azure environment
         - Support for user-sync hybrid paths when ingested alongside the example AD data
       </Tab>
-
-      <Tab title="k-nexus-global" icon="diagram-project">
-        Download the [k-nexus-global sample data](https://raw.githubusercontent.com/SpecterOps/BloodHound-Docs/main/docs/assets/sample-data/k-nexusglobal-bhce-20260330.zip).
-
-        **k-nexus-global** data generated with SharpHound, AzureHound, GitHound, OktaHound, and JamfHound includes:
-
-        - 2 collected domains with trust
-        - 2 Okta tenants, including 1 with AD user sync and 1 with Okta Org2Org
-        - 1 GitHub Enterprise account with Enterprise Managed User via Okta
-        - 1 Jamf tenant with Okta SSO enabled
-        - 1 Entra tenant
-      </Tab>
     </Tabs>
   </Step>
 


### PR DESCRIPTION
Reverts #248 because of workflow issues and invalid data that fails on latest release (v9.0.1).

I'll work on a revised version in the meantime.