### PR TITLE
Fix link path for GitHub collector configuration

### DIFF
--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -65,7 +65,7 @@ For more information on collector-specific configuration, visit the configuratio
 
 <CardGroup cols={3}>
 
-  <Card title="Github" href="openhound/collectors/github/collect-data#configure-openhound">
+  <Card title="Github" href="/openhound/collectors/github/collect-data#configure-openhound">
     View the configuration parameters for the Github collector.
   </Card>
 


### PR DESCRIPTION
The link on the public website currently 404s -- this fixes the link to point to the anchor on the correct page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a documentation link reference in the configuration guide to correctly direct to the GitHub collector configuration page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->