### PR TITLE
Fix typo in Okta collector name

### DIFF
--- a/docs/opengraph/extensions/okta/overview.mdx
+++ b/docs/opengraph/extensions/okta/overview.mdx
@@ -32,7 +32,7 @@ You should also account for users who are non-privileged in Okta but hold admini
 The Okta extension supports two collector paths:
 
 - [OpenHound Okta collector](/openhound/collectors/okta/overview): The SpecterOps-supported Okta collector. This is the primary documented path for collecting Okta data for BloodHound.
-- [GitHound collector](https://github.com/SpecterOps/OktaHound): An alternative Okta collector that also targets the Okta extension schema.
+- [OktaHound collector](https://github.com/SpecterOps/OktaHound): An alternative Okta collector that also targets the Okta extension schema.
 
 ## Okta Free Trial
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Okta extension documentation to improve naming clarity for the alternative collector option. The change enhances documentation accuracy and provides better alignment with Okta schema standards, making it easier for users to work with the Okta extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->