### PR TITLE
BP-2573: Update API reference for v9.1.0

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13867,22 +13867,34 @@
                 "type": "object",
                 "properties": {
                   "deleteCollectedGraphData": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all collected graph nodes and edges. Cannot be combined with deleteSourceKinds or deleteRelationships.\n"
+                  },
+                  "deleteSourceKinds": {
+                    "type": "array",
+                    "description": "A list of source kind IDs (from the source_kinds table) whose associated graph nodes and source kind records will be deleted. Use 0 as a special value to delete all \"sourceless\" nodes - nodes that exist in the graph but are not attributed to any source kind. Non-existent IDs will result in a 400 error.\n",
+                    "items": {
+                      "type": "integer"
+                    }
                   },
                   "deleteRelationships": {
                     "type": "array",
+                    "description": "A list of relationship kind names (e.g. \"HasSession\") whose edges will be deleted from the graph. Each value must be a valid, known relationship kind. Cannot be combined with deleteCollectedGraphData.\n",
                     "items": {
                       "type": "string"
                     }
                   },
                   "deleteFileIngestHistory": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all file ingest job history records."
                   },
                   "deleteDataQualityHistory": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all data quality history records."
                   },
                   "deleteAssetGroupSelectors": {
                     "type": "array",
+                    "description": "A list of asset group IDs whose custom selectors will be deleted. Triggers a re-analysis after deletion.\n",
                     "items": {
                       "type": "integer"
                     }
@@ -19315,6 +19327,15 @@
                 "type": "string",
                 "format": "date-time",
                 "readOnly": true
+              },
+              "created_by": {
+                "description": "The ID of the user who created the token",
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.uuid"
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
## Purpose

This pull request (PR) updates the OpenAPI spec that we use to generate the REST API reference for the v9.1.0 release.


Only optional request and response properties were added to existing resources.

- No new endpoints were added
- No existing operations changed
- No new operations were added to existing paths
- No existing paths/endpoints changed


See attachment for oasdiff: 
[openapi_change_v9.1.0.log](https://github.com/user-attachments/files/27180625/openapi_change_v9.1.0.log)

## Staging

https://specterops-bp-2573-api-reference.mintlify.app/reference/overview