### PR TITLE
GH-282: Add WinSSHound to opengraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -99,6 +99,18 @@ ProfileHound collects information from the `\\<target>\C$\Users\` directory on d
 **Repo**
 - https://github.com/m4lwhere/profilehound
 
+#### <Icon icon="people-group" size={22}/> WinSSHound
+
+**Description**
+
+WinSSHound maps lateral movement paths through misconfigured SSH services in Active Directory environments.
+
+**Authors/Maintainers**
+- [Robin Unglaub](https://www.linkedin.com/in/robin-unglaub/) @[ProSec GmbH](https://www.prosec-networks.com/)
+
+**Repo**
+- https://github.com/1r0BIT/WinSSHound
+
 </Accordion>
 <Accordion title="Amazon Web Service (AWS)" icon="people-group">
 #### <Icon icon="people-group" size={22}/> IAMhounddog

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -103,7 +103,7 @@ ProfileHound collects information from the `\\<target>\C$\Users\` directory on d
 
 **Description**
 
-WinSSHound maps lateral movement paths through misconfigured SSH services in Active Directory environments.
+WinSSHound maps lateral movement paths through misconfigured native and third-party SSH servers in Active Directory environments.
 
 **Authors/Maintainers**
 - [Robin Unglaub](https://www.linkedin.com/in/robin-unglaub/) @[ProSec GmbH](https://www.prosec-networks.com/)


### PR DESCRIPTION
Closes #282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "WinSSHound" entry to the OpenGraph Library documentation under the Active Directory (AD) section, including description, authors/maintainers, and repository information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/bloodhound-docs/pull/283)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->