### PR TITLE
Remove Okta_Group from principal_kinds

### DIFF
--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -188,7 +188,6 @@ Environments are platform-specific groupings of nodes that BloodHound Enterprise
     "source_kind": "Okta",
     "principal_kinds": [
       "Okta_User",
-      "Okta_Group",
       "Okta_Application",
       "Okta_ApiServiceIntegration"
     ]
@@ -314,7 +313,6 @@ The following example schema is based on Okta to illustrate how the different co
       "source_kind": "Okta",
       "principal_kinds": [
         "Okta_User",
-        "Okta_Group",
         "Okta_Application",
         "Okta_ApiServiceIntegration"
       ]


### PR DESCRIPTION
Remove Okta_Group from principal_kinds in OG extension examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JSON schema examples to reflect changes in supported principal kinds configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/bloodhound-docs/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->