### PR TITLE
BP-2604: Update API reference for v9.2.0

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16,7 +16,7 @@
   },
   "servers": [
     {
-      "url": "https://your-tenant.bloodhoundenterprise.io",
+      "url": "/",
       "description": "This is the base path for all endpoints, relative to the domain where the API is being hosted."
     }
   ],
@@ -7023,6 +7023,17 @@
           "Community",
           "Enterprise"
         ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by type, valid types are node or edge, e.g. \"eq:node\"",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string-strict"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -7046,6 +7057,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
           },
           "401": {
             "$ref": "#/components/responses/unauthorized"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16,7 +16,7 @@
   },
   "servers": [
     {
-      "url": "/",
+      "url": "https://your-tenant.bloodhoundenterprise.io",
       "description": "This is the base path for all endpoints, relative to the domain where the API is being hosted."
     }
   ],


### PR DESCRIPTION
## Purpose

This pull request (PR) updates the OpenAPI spec that we use to generate the REST API reference for the v9.2.0 release.

Only optional request and response properties were added to existing resources.

- No new endpoints were added
- No existing operations changed
- No new operations were added to existing paths
- No existing paths/endpoints changed


See attachment for oasdiff: 
[openapi_change.log](https://github.com/user-attachments/files/28068046/openapi_change.log)

## Staging

https://specterops-bp-2604-api-reference.mintlify.app/reference/overview