### PR TITLE
GH-299: Add RacfHound to the OpenGraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -494,6 +494,20 @@ PingOne is an identity provider (IDP) product from the Ping Identity Corporation
 - https://github.com/andyrobbins/PingOneHound
 
 </Accordion>
+<Accordion title="Resource Access Control Facility (RACF)" icon="people-group">
+#### <Icon icon="people-group" size={22}/> RacfHound
+
+**Description**
+
+RacfHound is a BloodHound ingestor for the RACF database in z/OS mainframes. The collector works through SSH and does not require an IRRDBU00 dump of the RACF DB. Current supported classes are USER, GROUP, SURROGAT, UNIXPRIV, FACILITY, DATASET, GCICSTRN and TCICSTRN.
+
+**Authors/Maintainers**
+- [Alexander Henriksson](https://linkedin.com/in/alexhenriksson)
+
+**Repo**
+- https://github.com/4-L3X/racfhound
+
+</Accordion>
 <Accordion title="runZero" icon="people-group">
 #### <Icon icon="people-group" size={22}/> runZeroHound
 


### PR DESCRIPTION
Closes #299 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RacfHound (Resource Access Control Facility) library entry to the documentation, including resource details and repository information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/bloodhound-docs/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->