### PR TITLE
BED-8189: Update default admin email

### DIFF
--- a/docs/manage-bloodhound/bh-config.mdx
+++ b/docs/manage-bloodhound/bh-config.mdx
@@ -337,6 +337,7 @@ An operator may use the below example to author a JSON configuration:
     "connection": "postgresql://bhe:bhe4eva@localhost/bhe"
   },
   "default_admin": {
+    "principal_name": "admin",
     "password": "admin",
     "email_address": "admin@example.com",
     "first_name": "Initial",

--- a/docs/manage-bloodhound/bh-config.mdx
+++ b/docs/manage-bloodhound/bh-config.mdx
@@ -337,8 +337,8 @@ An operator may use the below example to author a JSON configuration:
     "connection": "postgresql://bhe:bhe4eva@localhost/bhe"
   },
   "default_admin": {
-    "principal_name": "admin",
     "password": "admin",
+    "email_address": "admin@example.com",
     "first_name": "Initial",
     "last_name": "Admin",
     "expire_now": true

--- a/docs/snippets/sample-data.mdx
+++ b/docs/snippets/sample-data.mdx
@@ -30,7 +30,7 @@
     1. Click **Upload** to begin the data ingest process.
 
     <Note>
-      The default admin email is `spam@example.com` and will appear as the user ingesting the data.
+      The default admin email is `admin@example.com` and will appear as the user ingesting the data.
     </Note>
   </Step>
 </Steps>


### PR DESCRIPTION
Minor doc updates for next release related to BED-8189:

- Update the default admin email address in the shared snippet
- Update example config with default admin email and remove deprecated field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated default admin configuration example to include `email_address` field
  * Corrected default admin email address in sample data documentation from placeholder to standard admin email

<!-- end of auto-generated comment: release notes by coderabbit.ai -->