### PR TITLE
BP-2669: Upgrade PostgreSQL to 18 and migrate data

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,6 +37,7 @@
                 ]
               },
               "get-started/custom-installation",
+              "get-started/upgrade-postgres",
               {
                 "group": "Security Boundaries",
                 "pages": [
@@ -675,7 +676,8 @@
               "on-premises/overview",
               "on-premises/architecture",
               "on-premises/system-requirements",
-              "on-premises/install"
+              "on-premises/install",
+              "on-premises/upgrade-postgres"
             ]
           },
           {

--- a/docs/get-started/custom-installation.mdx
+++ b/docs/get-started/custom-installation.mdx
@@ -25,13 +25,13 @@ Use cases for custom installation include:
 This installation method provides more control over each configuration file and works well for running multiple BHCE instances on a single machine.
 
 <Steps>
-  
+
   <Step title="Install Docker Desktop">
-  
+
     Follow the instructions in the [Docker documentation](https://docs.docker.com/get-started/get-docker/) to install Docker Desktop for your operating system.
 
     <Note>Docker Desktop must be running to build and test BHCE. Start Docker Desktop on your machine.</Note>
-  
+
   </Step>
 
   <Step title="Create installation directory">
@@ -42,7 +42,7 @@ This installation method provides more control over each configuration file and 
     mkdir bhce
     cd bhce
     ```
-  
+
   </Step>
 
   <Step title="Download configuration files">
@@ -51,7 +51,7 @@ This installation method provides more control over each configuration file and 
 
     - [`docker-compose.yml`](https://github.com/SpecterOps/BloodHound/blob/main/examples/docker-compose/docker-compose.yml)
     - [`bloodhound.config.json`](https://github.com/SpecterOps/BloodHound/blob/main/examples/docker-compose/bloodhound.config.json)
-  
+
   </Step>
 
   <Step title="Add configuration files">
@@ -68,7 +68,7 @@ This installation method provides more control over each configuration file and 
 
     <Step title="Start BloodHound">
 
-    Now that your files are ready, you can bring the containers up using the following command: 
+    Now that your files are ready, you can bring the containers up using the following command:
     ```bash
     docker compose up
     ```
@@ -138,7 +138,7 @@ The code repository contains all the necessary files to build BHCE. Follow these
     ```bash
     just init
     ```
-  
+
   </Step>
 
   <Step title="Start development environment">
@@ -154,20 +154,20 @@ The code repository contains all the necessary files to build BHCE. Follow these
   <Step title="Compile BHCE">
 
     The BloodHound team maintains a Python tool called [`stbernard`](https://github.com/SpecterOps/BloodHound/wiki/packages/go/stbernard/README.md) for building and testing the project.
-    
+
     To build locally, run the following command:
 
     ```bash
     just build
     ```
-    
+
     The build process generates all artifacts in the `dist/` directory.
 
     <Tip>
     See the following resources for next steps:
 
     - [Source code wiki](https://github.com/SpecterOps/BloodHound/wiki/Development#quick-start) on GitHub for testing and debugging details.
-    
+
     - [Customizations](/get-started/custom-installation#customizations) section below to modify your installation as needed.
     </Tip>
 
@@ -226,7 +226,7 @@ If you are currently using a Neo4j backend database and want to change to Postgr
       },
       "version": 1,
       "work_dir": "/opt/bloodhound/work"
-    }                        
+    }
     ```
 
   </Step>
@@ -522,7 +522,7 @@ To secure BHCE with HTTPS, add your certificate information to the `tls` block i
   <Step title="Configure TLS settings">
 
     In the `bloodhound.config.json` file, set `cert_file` and `key_file` to the paths where the certificate and key will be available **inside the container**.
-    
+
     These values must match the container-side destination of the volume mount you add in the next step, not the location of the files on your host:
 
     ```json title="bloodhound.config.json"
@@ -569,11 +569,11 @@ To secure BHCE with HTTPS, add your certificate information to the `tls` block i
   <Step title="Verify HTTPS">
 
     Browse to `https://127.0.0.1:8080` and confirm that BloodHound loads over HTTPS.
-    
+
     The default URL is `http://127.0.0.1:8080`, so make sure to change the protocol to `https://` in the address bar.
 
     The listening port is unchanged. TLS is negotiated on the same port that the BloodHound service binds to by default (`8080`).
-    
+
     <Note>
       Browsers display a certificate warning when you use a self-signed certificate; this is expected and does not occur with a CA-issued certificate.
     </Note>
@@ -599,7 +599,7 @@ Follow these steps to run multiple BHCE instances on a single machine.
   <Step title="Change default BHCE port">
 
     In the `docker-compose.yml` file, update the BloodHound service port binding to use a different port.
-    
+
     The following example uses port `8585` instead of the default `8080` port:
 
     ```yaml
@@ -632,12 +632,12 @@ Follow these steps to run multiple BHCE instances on a single machine.
 
 ### Expose BHCE outside of `localhost`
 
-You might need to access your BHCE instance from another computer than the one it is installed on. The default installation does not 
+You might need to access your BHCE instance from another computer than the one it is installed on. The default installation does not
 expose the port outside of `localhost`. To do it, you will need to change the IP address that the BloodHound UI binds to.
 
 In the `docker-compose.yml` file, update the BloodHound service port binding to use a different IP Address.
 
-The following example uses IP `0.0.0.0` to bind the port `8080` to _all_ interfaces and IP Addresses on the machine. If the machine has multiple IP Addresses, you can set that specific IP Address. 
+The following example uses IP `0.0.0.0` to bind the port `8080` to _all_ interfaces and IP Addresses on the machine. If the machine has multiple IP Addresses, you can set that specific IP Address.
 
 ```yaml
 - ${BLOODHOUND_HOST:-0.0.0.0}:${BLOODHOUND_PORT:-8080}:8080

--- a/docs/get-started/custom-installation.mdx
+++ b/docs/get-started/custom-installation.mdx
@@ -185,6 +185,8 @@ PostgreSQL provides significant advantages over Neo4j as a backend database, par
 
 <Note>For information on supported Cypher syntax in PostgreSQL, see [Supported Cypher Syntax](/analyze-data/cypher-supported).</Note>
 
+<Note>If you are upgrading an existing installation from PostgreSQL 16 to 18, see [Upgrade PostgreSQL](/get-started/upgrade-postgres).</Note>
+
 #### PostgreSQL
 
 If you are currently using a Neo4j backend database and want to change to PostgreSQL, follow these steps.
@@ -297,7 +299,7 @@ If you are currently using a Neo4j backend database and want to change to Postgr
 
         services:
           app-db:
-            image: docker.io/library/postgres:16
+            image: docker.io/library/postgres:18
             environment:
               - PGUSER=${POSTGRES_USER:-bloodhound}
               - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
@@ -307,7 +309,7 @@ If you are currently using a Neo4j backend database and want to change to Postgr
             # ports:
             #   - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
             volumes:
-              - postgres-data:/var/lib/postgresql/data
+              - postgres-data:/var/lib/postgresql
             healthcheck:
               test:
                 [
@@ -385,7 +387,7 @@ If you are currently using a PostgreSQL backend database and want to change to N
         app-db:
           labels:
             name: "bhce_postgres"
-          image: docker.io/library/postgres:16
+          image: docker.io/library/postgres:18
           environment:
             - PGUSER=${POSTGRES_USER:-bloodhound}
             - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
@@ -395,7 +397,7 @@ If you are currently using a PostgreSQL backend database and want to change to N
           # ports:
           #   - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
           volumes:
-            - postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql
           healthcheck:
             test:
               [

--- a/docs/get-started/custom-installation.mdx
+++ b/docs/get-started/custom-installation.mdx
@@ -185,11 +185,11 @@ PostgreSQL provides significant advantages over Neo4j as a backend database, par
 
 <Note>For information on supported Cypher syntax in PostgreSQL, see [Supported Cypher Syntax](/analyze-data/cypher-supported).</Note>
 
-<Note>If you are upgrading an existing installation from PostgreSQL 16 to 18, see [Upgrade PostgreSQL](/get-started/upgrade-postgres).</Note>
-
 #### PostgreSQL
 
 If you are currently using a Neo4j backend database and want to change to PostgreSQL, follow these steps.
+
+<Note>We recommend using PostgreSQL 18 for new installations. To upgrade an existing installation from PostgreSQL 16 to 18, see [Upgrade PostgreSQL](/get-started/upgrade-postgres).</Note>
 
 <Steps>
 

--- a/docs/get-started/custom-installation.mdx
+++ b/docs/get-started/custom-installation.mdx
@@ -642,3 +642,7 @@ The following example uses IP `0.0.0.0` to bind the port `8080` to _all_ interfa
 ```yaml
 - ${BLOODHOUND_HOST:-0.0.0.0}:${BLOODHOUND_PORT:-8080}:8080
 ```
+
+<Warning>
+  Binding to `0.0.0.0` can expose BloodHound to untrusted networks. Only do this behind appropriate network controls (for example, firewall rules, VPN, or a restricted reverse proxy), and ensure HTTPS and strong non-default credentials are in place.
+</Warning>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -47,351 +47,170 @@ The upgrade scripts perform the following steps in order:
 
 ## Run the upgrade script
 
-<Tabs>
-  <Tab title="Linux/macOS (bash)">
+Save the following script to a file (for example, `upgrade-pg.ps1`) and run it in PowerShell with `.\upgrade-pg.ps1`.
 
-    Save the following script to a file (for example, `upgrade-pg.sh`) and run it with `bash upgrade-pg.sh`.
+```powershell
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
+.DESCRIPTION
+    Walks through dumping the PG 16 database, backing up the Docker volume,
+    upgrading to PG 18, and restoring the data. Requires Docker with the
+    Compose V2 plugin.
+#>
 
-    ```bash
-    #!/usr/bin/env bash
-    # Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
-    # Walks through dumping the PG 16 database, backing up the Docker volume,
-    # upgrading to PG 18, and restoring the data. Requires Docker with the
-    # Compose V2 plugin.
+$ErrorActionPreference = "Stop"
 
-    set -euo pipefail
+function Write-Step  { param([string]$Msg) Write-Host "`n=== $Msg ===" -ForegroundColor Cyan }
+function Write-Ok    { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
 
-    step()  { echo -e "\n\033[0;36m=== $* ===\033[0m"; }
-    ok()    { echo -e "\033[0;32m$*\033[0m"; }
-    warn()  { echo -e "\033[0;33m$*\033[0m"; }
+# ── 1. Gather inputs ────────────────────────────────────────────────────────
+Write-Step "BloodHound PostgreSQL 16 -> 18 Migration"
 
-    # ── 1. Gather inputs ────────────────────────────────────────────────────────
-    step "BloodHound PostgreSQL 16 -> 18 Migration"
+$defaultDir = Join-Path $HOME ".config" "bloodhound"
+$composeDir = Read-Host "Enter the directory containing docker-compose.yml (default: $defaultDir)"
+if ([string]::IsNullOrWhiteSpace($composeDir)) { $composeDir = $defaultDir }
+$composeDir = [System.IO.Path]::GetFullPath($composeDir.Replace("~", $HOME))
+$composeFile = Join-Path $composeDir "docker-compose.yml"
 
-    default_dir="${HOME}/.config/bloodhound"
-    read -rp "Enter the directory containing docker-compose.yml (default: ${default_dir}): " compose_dir
-    compose_dir="${compose_dir:-${default_dir}}"
-    compose_dir="$(cd "${compose_dir/#\~/$HOME}" && pwd)"
-    compose_file="${compose_dir}/docker-compose.yml"
+if (-not (Test-Path $composeFile)) {
+    Write-Error "docker-compose.yml not found at $composeFile"; exit 1
+}
 
-    if [[ ! -f "${compose_file}" ]]; then
-        echo "Error: docker-compose.yml not found at ${compose_file}" >&2; exit 1
-    fi
+$defaultDump = Join-Path $composeDir "pg16_backup.dump"
+$dumpPath = Read-Host "Enter path for the database dump file (default: $defaultDump)"
+if ([string]::IsNullOrWhiteSpace($dumpPath)) { $dumpPath = $defaultDump }
+$dumpPath = [System.IO.Path]::GetFullPath($dumpPath.Replace("~", $HOME))
 
-    default_dump="${compose_dir}/pg16_backup.dump"
-    read -rp "Enter path for the database dump file (default: ${default_dump}): " dump_path
-    dump_path="${dump_path:-${default_dump}}"
-    dump_path="${dump_path/#\~/$HOME}"
+# ── 2. Read credentials (.env then defaults) ────────────────────────────────
+$pgUser = "bloodhound"; $pgPass = "bloodhoundcommunityedition"; $pgDb = "bloodhound"
 
-    # ── 2. Read credentials (.env then defaults) ────────────────────────────────
-    pg_user="bloodhound"
-    pg_pass="bloodhoundcommunityedition"
-    pg_db="bloodhound"
-
-    env_file="${compose_dir}/.env"
-    if [[ -f "${env_file}" ]]; then
-        echo "Reading overrides from ${env_file} ..."
-        while IFS='=' read -r key val; do
-            [[ "${key}" =~ ^[[:space:]]*# ]] && continue
-            key="${key#"${key%%[![:space:]]*}"}"   # trim leading
-            key="${key%"${key##*[![:space:]]}"}"   # trim trailing
-            val="${val#"${val%%[![:space:]]*}"}"   # trim leading
-            val="${val%"${val##*[![:space:]]}"}"   # trim trailing
-            case "${key}" in
-                POSTGRES_USER)     pg_user="${val}" ;;
-                POSTGRES_PASSWORD) pg_pass="${val}" ;;
-                POSTGRES_DB)       pg_db="${val}"   ;;
-            esac
-        done < "${env_file}"
-    fi
-    echo "Credentials: user=${pg_user}  db=${pg_db}"
-
-    # ── 3. Resolve volume name ──────────────────────────────────────────────────
-    project_name="$(basename "${compose_dir}" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
-    volume_name="${project_name}_postgres-data"
-
-    if ! docker volume ls --format '{{.Name}}' | grep -qx "${volume_name}"; then
-        echo "Error: Docker volume '${volume_name}' not found. Is BloodHound installed?" >&2; exit 1
-    fi
-    echo "Project: ${project_name}   Volume: ${volume_name}"
-
-    # ── 4. Confirm ──────────────────────────────────────────────────────────────
-    warn "\nThis script will:"
-    echo "  1. Stop the BloodHound app (keep PG 16 running)"
-    echo "  2. Dump the PG 16 database to: ${dump_path}"
-    echo "  3. Stop all containers"
-    echo "  4. Create a backup copy of the PostgreSQL data volume"
-    echo "  5. Update docker-compose.yml to use PostgreSQL 18"
-    echo "  6. Start PG 18 and restore the database"
-    echo "  7. Start the full BloodHound stack"
-
-    read -rp $'\nProceed? (y/N): ' confirm
-    [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
-
-    # ── Helper: run docker compose with project context ──────────────────────────
-    dc() {
-        docker compose -f "${compose_file}" --project-directory "${compose_dir}" "$@"
+$envFile = Join-Path $composeDir ".env"
+if (Test-Path $envFile) {
+    Write-Host "Reading overrides from $envFile ..."
+    Get-Content $envFile | ForEach-Object {
+        if ($_ -match '^\s*POSTGRES_USER\s*=\s*(.+)$')     { $pgUser = $Matches[1].Trim() }
+        if ($_ -match '^\s*POSTGRES_PASSWORD\s*=\s*(.+)$')  { $pgPass = $Matches[1].Trim() }
+        if ($_ -match '^\s*POSTGRES_DB\s*=\s*(.+)$')        { $pgDb   = $Matches[1].Trim() }
     }
+}
+Write-Host "Credentials: user=$pgUser  db=$pgDb"
 
-    # ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
-    step "Stopping BloodHound application container"
-    dc stop bloodhound
-    ok "BloodHound app stopped."
+# ── 3. Resolve volume name ──────────────────────────────────────────────────
+$projectName = (Split-Path $composeDir -Leaf).ToLower() -replace '[^a-z0-9_-]',''
+$volumeName  = "${projectName}_postgres-data"
 
-    step "Ensuring PostgreSQL 16 is running"
-    dc start app-db
-    sleep 5
+$volExists = docker volume ls --format "{{.Name}}" | Where-Object { $_ -eq $volumeName }
+if (-not $volExists) {
+    Write-Error "Docker volume '$volumeName' not found. Is BloodHound installed?"
+    exit 1
+}
+Write-Host "Project: $projectName   Volume: $volumeName"
 
-    # ── 6. Dump database ────────────────────────────────────────────────────────
-    step "Dumping PostgreSQL 16 database"
-    dc exec app-db pg_dump -U "${pg_user}" -d "${pg_db}" -Fc -Z 9 -f /tmp/pg16_backup.dump
-    dc cp app-db:/tmp/pg16_backup.dump "${dump_path}"
+# ── 4. Confirm ──────────────────────────────────────────────────────────────
+Write-Warn "`nThis script will:"
+Write-Host "  1. Stop the BloodHound app (keep PG 16 running)"
+Write-Host "  2. Dump the PG 16 database to: $dumpPath"
+Write-Host "  3. Stop all containers"
+Write-Host "  4. Create a backup copy of the PostgreSQL data volume"
+Write-Host "  5. Update docker-compose.yml to use PostgreSQL 18"
+Write-Host "  6. Start PG 18 and restore the database"
+Write-Host "  7. Start the full BloodHound stack"
 
-    dump_size="$(wc -c < "${dump_path}")"
-    ok "Database dumped (${dump_size} bytes) -> ${dump_path}"
+$confirm = Read-Host "`nProceed? (y/N)"
+if ($confirm -notin @('y','Y')) { Write-Host "Cancelled."; exit 0 }
 
-    # ── 7. Stop everything ──────────────────────────────────────────────────────
-    step "Stopping all containers"
-    dc down
-    ok "All containers stopped."
+# ── Helper: run docker compose with project context ──────────────────────────
+function Invoke-DC {
+    $dcArgs = @("-f", $composeFile, "--project-directory", $composeDir) + $args
+    & docker compose @dcArgs
+    if ($LASTEXITCODE -ne 0) { throw "docker compose failed (exit $LASTEXITCODE)" }
+}
 
-    # ── 8. Copy the volume ──────────────────────────────────────────────────────
-    step "Backing up PostgreSQL data volume"
-    backup_vol="${volume_name}-pg16-backup"
-    docker volume create "${backup_vol}" > /dev/null
-    docker run --rm \
-        -v "${volume_name}:/source:ro" \
-        -v "${backup_vol}:/backup" \
-        alpine sh -c "cp -a /source/. /backup/"
-    ok "Volume copied to: ${backup_vol}"
+# ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
+Write-Step "Stopping BloodHound application container"
+Invoke-DC stop bloodhound
+Write-Ok "BloodHound app stopped."
 
-    # ── 9. Update docker-compose.yml ────────────────────────────────────────────
-    step "Updating docker-compose.yml to PostgreSQL 18"
-    bak_file="${compose_dir}/docker-compose.yml.pg16.bak"
-    cp "${compose_file}" "${bak_file}"
-    echo "Compose file backed up to: ${bak_file}"
+Write-Step "Ensuring PostgreSQL 16 is running"
+Invoke-DC start app-db
+Start-Sleep -Seconds 5
 
-    # Update image tag
-    sed -i.tmp "s|image: docker\.io/library/postgres:16|image: docker.io/library/postgres:18|g" "${compose_file}"
-    # PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
-    sed -i.tmp "s|postgres-data:/var/lib/postgresql/data|postgres-data:/var/lib/postgresql|g" "${compose_file}"
-    rm -f "${compose_file}.tmp"
+# ── 6. Dump database ────────────────────────────────────────────────────────
+Write-Step "Dumping PostgreSQL 16 database"
+Invoke-DC exec app-db pg_dump -U $pgUser -d $pgDb -Fc -Z 9 -f /tmp/pg16_backup.dump
+Invoke-DC cp app-db:/tmp/pg16_backup.dump $dumpPath
 
-    if ! grep -q "postgres:18" "${compose_file}"; then
-        echo "Error: Could not find postgres:18 after update — check compose file manually." >&2; exit 1
-    fi
-    ok "docker-compose.yml updated (image + volume mount path)."
+$dumpSize = (Get-Item $dumpPath).Length
+Write-Ok "Database dumped ($dumpSize bytes) -> $dumpPath"
 
-    # ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
-    step "Removing old PostgreSQL data volume"
-    docker volume rm "${volume_name}" > /dev/null
-    ok "Old volume removed (backup preserved at ${backup_vol})."
+# ── 7. Stop everything ──────────────────────────────────────────────────────
+Write-Step "Stopping all containers"
+Invoke-DC down
+Write-Ok "All containers stopped."
 
-    step "Starting PostgreSQL 18"
-    dc up -d app-db
+# ── 8. Copy the volume ──────────────────────────────────────────────────────
+Write-Step "Backing up PostgreSQL data volume"
+$backupVol = "${volumeName}-pg16-backup"
+docker volume create $backupVol | Out-Null
+docker run --rm -v "${volumeName}:/source:ro" -v "${backupVol}:/backup" `
+    alpine sh -c "cp -a /source/. /backup/"
+Write-Ok "Volume copied to: $backupVol"
 
-    echo "Waiting for PostgreSQL 18 to become healthy..."
-    health=""
-    for i in $(seq 1 30); do
-        sleep 2
-        health="$(docker inspect --format '{{.State.Health.Status}}' "${project_name}-app-db-1" 2>/dev/null || true)"
-        [[ "${health}" == "healthy" ]] && break
-    done
-    [[ "${health}" == "healthy" ]] || warn "Container not yet healthy — continuing anyway."
+# ── 9. Update docker-compose.yml ────────────────────────────────────────────
+Write-Step "Updating docker-compose.yml to PostgreSQL 18"
+$bakFile = Join-Path $composeDir "docker-compose.yml.pg16.bak"
+Copy-Item $composeFile $bakFile
+Write-Host "Compose file backed up to: $bakFile"
 
-    # ── 11. Restore database ────────────────────────────────────────────────────
-    step "Restoring database into PostgreSQL 18"
-    dc cp "${dump_path}" app-db:/tmp/pg16_backup.dump
-    dc exec app-db pg_restore -U "${pg_user}" -d "${pg_db}" --clean --if-exists /tmp/pg16_backup.dump
-    ok "Database restored."
+$content = Get-Content $composeFile -Raw
+$updated = $content -replace 'image:\s*docker\.io/library/postgres:16', 'image: docker.io/library/postgres:18'
+if ($updated -eq $content) { Write-Error "Could not find postgres:16 image reference in compose file"; exit 1 }
+# PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
+$updated = $updated -replace 'postgres-data:/var/lib/postgresql/data', 'postgres-data:/var/lib/postgresql'
+[System.IO.File]::WriteAllText($composeFile, $updated)
+Write-Ok "docker-compose.yml updated (image + volume mount path)."
 
-    # ── 12. Start full stack ─────────────────────────────────────────────────────
-    step "Starting full BloodHound stack"
-    dc up -d
-    ok "BloodHound stack is starting."
+# ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
+Write-Step "Removing old PostgreSQL data volume"
+docker volume rm $volumeName | Out-Null
+Write-Ok "Old volume removed (backup preserved at $backupVol)."
 
-    # ── Done ─────────────────────────────────────────────────────────────────────
-    step "Migration Complete"
-    ok "PostgreSQL upgraded from 16 to 18."
-    echo "  Database dump : ${dump_path}"
-    echo "  Volume backup : ${backup_vol}"
-    echo "  Compose backup: ${bak_file}"
-    warn "\nOnce verified, you can clean up with:"
-    echo "  docker volume rm ${backup_vol}"
-    echo "  rm '${bak_file}'"
-    echo "  rm '${dump_path}'"
-    ```
+Write-Step "Starting PostgreSQL 18"
+Invoke-DC up -d app-db
 
-  </Tab>
-  <Tab title="Windows (PowerShell)">
+Write-Host "Waiting for PostgreSQL 18 to become healthy..."
+for ($i = 0; $i -lt 30; $i++) {
+    Start-Sleep -Seconds 2
+    $health = docker inspect --format "{{.State.Health.Status}}" "${projectName}-app-db-1" 2>$null
+    if ($health -eq "healthy") { break }
+}
+if ($health -ne "healthy") { Write-Warn "Container not yet healthy — continuing anyway." }
 
-    Save the following script to a file (for example, `upgrade-pg.ps1`) and run it in PowerShell with `.\upgrade-pg.ps1`.
+# ── 11. Restore database ────────────────────────────────────────────────────
+Write-Step "Restoring database into PostgreSQL 18"
+Invoke-DC cp $dumpPath app-db:/tmp/pg16_backup.dump
+Invoke-DC exec app-db pg_restore -U $pgUser -d $pgDb --clean --if-exists /tmp/pg16_backup.dump
+Write-Ok "Database restored."
 
-    ```powershell
-    #Requires -Version 5.1
-    <#
-    .SYNOPSIS
-        Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
-    .DESCRIPTION
-        Walks through dumping the PG 16 database, backing up the Docker volume,
-        upgrading to PG 18, and restoring the data. Requires Docker with the
-        Compose V2 plugin.
-    #>
+# ── 12. Start full stack ─────────────────────────────────────────────────────
+Write-Step "Starting full BloodHound stack"
+Invoke-DC up -d
+Write-Ok "BloodHound stack is starting."
 
-    $ErrorActionPreference = "Stop"
-
-    function Write-Step  { param([string]$Msg) Write-Host "`n=== $Msg ===" -ForegroundColor Cyan }
-    function Write-Ok    { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
-    function Write-Warn  { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
-
-    # ── 1. Gather inputs ────────────────────────────────────────────────────────
-    Write-Step "BloodHound PostgreSQL 16 -> 18 Migration"
-
-    $defaultDir = Join-Path $HOME ".config" "bloodhound"
-    $composeDir = Read-Host "Enter the directory containing docker-compose.yml (default: $defaultDir)"
-    if ([string]::IsNullOrWhiteSpace($composeDir)) { $composeDir = $defaultDir }
-    $composeDir = [System.IO.Path]::GetFullPath($composeDir.Replace("~", $HOME))
-    $composeFile = Join-Path $composeDir "docker-compose.yml"
-
-    if (-not (Test-Path $composeFile)) {
-        Write-Error "docker-compose.yml not found at $composeFile"; exit 1
-    }
-
-    $defaultDump = Join-Path $composeDir "pg16_backup.dump"
-    $dumpPath = Read-Host "Enter path for the database dump file (default: $defaultDump)"
-    if ([string]::IsNullOrWhiteSpace($dumpPath)) { $dumpPath = $defaultDump }
-    $dumpPath = [System.IO.Path]::GetFullPath($dumpPath.Replace("~", $HOME))
-
-    # ── 2. Read credentials (.env then defaults) ────────────────────────────────
-    $pgUser = "bloodhound"; $pgPass = "bloodhoundcommunityedition"; $pgDb = "bloodhound"
-
-    $envFile = Join-Path $composeDir ".env"
-    if (Test-Path $envFile) {
-        Write-Host "Reading overrides from $envFile ..."
-        Get-Content $envFile | ForEach-Object {
-            if ($_ -match '^\s*POSTGRES_USER\s*=\s*(.+)$')     { $pgUser = $Matches[1].Trim() }
-            if ($_ -match '^\s*POSTGRES_PASSWORD\s*=\s*(.+)$')  { $pgPass = $Matches[1].Trim() }
-            if ($_ -match '^\s*POSTGRES_DB\s*=\s*(.+)$')        { $pgDb   = $Matches[1].Trim() }
-        }
-    }
-    Write-Host "Credentials: user=$pgUser  db=$pgDb"
-
-    # ── 3. Resolve volume name ──────────────────────────────────────────────────
-    $projectName = (Split-Path $composeDir -Leaf).ToLower() -replace '[^a-z0-9_-]',''
-    $volumeName  = "${projectName}_postgres-data"
-
-    $volExists = docker volume ls --format "{{.Name}}" | Where-Object { $_ -eq $volumeName }
-    if (-not $volExists) {
-        Write-Error "Docker volume '$volumeName' not found. Is BloodHound installed?"
-        exit 1
-    }
-    Write-Host "Project: $projectName   Volume: $volumeName"
-
-    # ── 4. Confirm ──────────────────────────────────────────────────────────────
-    Write-Warn "`nThis script will:"
-    Write-Host "  1. Stop the BloodHound app (keep PG 16 running)"
-    Write-Host "  2. Dump the PG 16 database to: $dumpPath"
-    Write-Host "  3. Stop all containers"
-    Write-Host "  4. Create a backup copy of the PostgreSQL data volume"
-    Write-Host "  5. Update docker-compose.yml to use PostgreSQL 18"
-    Write-Host "  6. Start PG 18 and restore the database"
-    Write-Host "  7. Start the full BloodHound stack"
-
-    $confirm = Read-Host "`nProceed? (y/N)"
-    if ($confirm -notin @('y','Y')) { Write-Host "Cancelled."; exit 0 }
-
-    # ── Helper: run docker compose with project context ──────────────────────────
-    function Invoke-DC {
-        $dcArgs = @("-f", $composeFile, "--project-directory", $composeDir) + $args
-        & docker compose @dcArgs
-        if ($LASTEXITCODE -ne 0) { throw "docker compose failed (exit $LASTEXITCODE)" }
-    }
-
-    # ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
-    Write-Step "Stopping BloodHound application container"
-    Invoke-DC stop bloodhound
-    Write-Ok "BloodHound app stopped."
-
-    Write-Step "Ensuring PostgreSQL 16 is running"
-    Invoke-DC start app-db
-    Start-Sleep -Seconds 5
-
-    # ── 6. Dump database ────────────────────────────────────────────────────────
-    Write-Step "Dumping PostgreSQL 16 database"
-    Invoke-DC exec app-db pg_dump -U $pgUser -d $pgDb -Fc -Z 9 -f /tmp/pg16_backup.dump
-    Invoke-DC cp app-db:/tmp/pg16_backup.dump $dumpPath
-
-    $dumpSize = (Get-Item $dumpPath).Length
-    Write-Ok "Database dumped ($dumpSize bytes) -> $dumpPath"
-
-    # ── 7. Stop everything ──────────────────────────────────────────────────────
-    Write-Step "Stopping all containers"
-    Invoke-DC down
-    Write-Ok "All containers stopped."
-
-    # ── 8. Copy the volume ──────────────────────────────────────────────────────
-    Write-Step "Backing up PostgreSQL data volume"
-    $backupVol = "${volumeName}-pg16-backup"
-    docker volume create $backupVol | Out-Null
-    docker run --rm -v "${volumeName}:/source:ro" -v "${backupVol}:/backup" `
-        alpine sh -c "cp -a /source/. /backup/"
-    Write-Ok "Volume copied to: $backupVol"
-
-    # ── 9. Update docker-compose.yml ────────────────────────────────────────────
-    Write-Step "Updating docker-compose.yml to PostgreSQL 18"
-    $bakFile = Join-Path $composeDir "docker-compose.yml.pg16.bak"
-    Copy-Item $composeFile $bakFile
-    Write-Host "Compose file backed up to: $bakFile"
-
-    $content = Get-Content $composeFile -Raw
-    $updated = $content -replace 'image:\s*docker\.io/library/postgres:16', 'image: docker.io/library/postgres:18'
-    if ($updated -eq $content) { Write-Error "Could not find postgres:16 image reference in compose file"; exit 1 }
-    # PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
-    $updated = $updated -replace 'postgres-data:/var/lib/postgresql/data', 'postgres-data:/var/lib/postgresql'
-    [System.IO.File]::WriteAllText($composeFile, $updated)
-    Write-Ok "docker-compose.yml updated (image + volume mount path)."
-
-    # ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
-    Write-Step "Removing old PostgreSQL data volume"
-    docker volume rm $volumeName | Out-Null
-    Write-Ok "Old volume removed (backup preserved at $backupVol)."
-
-    Write-Step "Starting PostgreSQL 18"
-    Invoke-DC up -d app-db
-
-    Write-Host "Waiting for PostgreSQL 18 to become healthy..."
-    for ($i = 0; $i -lt 30; $i++) {
-        Start-Sleep -Seconds 2
-        $health = docker inspect --format "{{.State.Health.Status}}" "${projectName}-app-db-1" 2>$null
-        if ($health -eq "healthy") { break }
-    }
-    if ($health -ne "healthy") { Write-Warn "Container not yet healthy — continuing anyway." }
-
-    # ── 11. Restore database ────────────────────────────────────────────────────
-    Write-Step "Restoring database into PostgreSQL 18"
-    Invoke-DC cp $dumpPath app-db:/tmp/pg16_backup.dump
-    Invoke-DC exec app-db pg_restore -U $pgUser -d $pgDb --clean --if-exists /tmp/pg16_backup.dump
-    Write-Ok "Database restored."
-
-    # ── 12. Start full stack ─────────────────────────────────────────────────────
-    Write-Step "Starting full BloodHound stack"
-    Invoke-DC up -d
-    Write-Ok "BloodHound stack is starting."
-
-    # ── Done ─────────────────────────────────────────────────────────────────────
-    Write-Step "Migration Complete"
-    Write-Ok "PostgreSQL upgraded from 16 to 18."
-    Write-Host "  Database dump : $dumpPath"
-    Write-Host "  Volume backup : $backupVol"
-    Write-Host "  Compose backup: $bakFile"
-    Write-Warn "`nOnce verified, you can clean up with:"
-    Write-Host "  docker volume rm $backupVol"
-    Write-Host "  Remove-Item '$bakFile'"
-    Write-Host "  Remove-Item '$dumpPath'"
-    ```
-
-  </Tab>
-</Tabs>
+# ── Done ─────────────────────────────────────────────────────────────────────
+Write-Step "Migration Complete"
+Write-Ok "PostgreSQL upgraded from 16 to 18."
+Write-Host "  Database dump : $dumpPath"
+Write-Host "  Volume backup : $backupVol"
+Write-Host "  Compose backup: $bakFile"
+Write-Warn "`nOnce verified, you can clean up with:"
+Write-Host "  docker volume rm $backupVol"
+Write-Host "  Remove-Item '$bakFile'"
+Write-Host "  Remove-Item '$dumpPath'"
+```
 
 ## Verify the upgrade
 

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -50,7 +50,7 @@ The upgrade scripts perform the following steps in order:
 Save the following script to a file and run it.
 
 <Tabs>
-  <Tab title="PowerShell">
+  <Tab title="PowerShell (all platforms)">
 
     Save the script as `upgrade-pg.ps1` and run it with `.\upgrade-pg.ps1`.
 
@@ -453,7 +453,7 @@ After you have verified that the upgrade was successful and your data is intact,
 Replace the placeholder values with the actual paths and volume name printed by the script.
 
 <Tabs>
-  <Tab title="PowerShell">
+  <Tab title="PowerShell (all platforms)">
 
     ```powershell
     docker volume rm <backup-volume-name>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -24,7 +24,7 @@ The upgrade scripts on this page automate the migration by dumping your existing
 
 - Docker with the Compose V2 plugin (`docker compose`, not `docker-compose`)
 - Sufficient free disk space for the database dump file and a volume backup
-- PowerShell 5.1 or later
+- PowerShell 5.1 or later (all platforms), or bash (Linux/macOS)
 - Your BloodHound CE installation must be accessible and running before you begin
 
 ## Before you begin
@@ -47,9 +47,14 @@ The upgrade scripts perform the following steps in order:
 
 ## Run the upgrade script
 
-Save the following script to a file (for example, `upgrade-pg.ps1`) and run it in PowerShell with `.\upgrade-pg.ps1`.
+Save the following script to a file and run it.
 
-```powershell
+<Tabs>
+  <Tab title="PowerShell">
+
+    Save the script as `upgrade-pg.ps1` and run it with `.\upgrade-pg.ps1`.
+
+    ```powershell
 #Requires -Version 5.1
 <#
 .SYNOPSIS
@@ -229,7 +234,183 @@ Write-Warn "`nOnce verified, you can clean up with:"
 Write-Host "  docker volume rm $backupVol"
 Write-Host "  Remove-Item '$bakFile'"
 Write-Host "  Remove-Item '$dumpPath'"
-```
+    ```
+
+  </Tab>
+  <Tab title="Linux/macOS (bash)">
+
+    Save the script as `upgrade-pg.sh`, make it executable with `chmod +x upgrade-pg.sh`, and run it with `./upgrade-pg.sh`.
+
+    ```bash
+#!/usr/bin/env bash
+# Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
+# Requires Docker with the Compose V2 plugin.
+set -euo pipefail
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+step()  { printf '\n\033[36m=== %s ===\033[0m\n' "$1"; }
+ok()    { printf '\033[32m%s\033[0m\n' "$1"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$1"; }
+die()   { printf '\033[31mError: %s\033[0m\n' "$1" >&2; exit 1; }
+
+dc() { docker compose -f "$COMPOSE_FILE" --project-directory "$COMPOSE_DIR" "$@"; }
+
+# ── 1. Gather inputs ────────────────────────────────────────────────────────
+step "BloodHound PostgreSQL 16 -> 18 Migration"
+
+DEFAULT_DIR="$HOME/.config/bloodhound"
+read -rp "Enter the directory containing docker-compose.yml (default: $DEFAULT_DIR): " COMPOSE_DIR
+COMPOSE_DIR="${COMPOSE_DIR:-$DEFAULT_DIR}"
+COMPOSE_DIR="${COMPOSE_DIR/#\~/$HOME}"
+COMPOSE_DIR="$(cd "$COMPOSE_DIR" && pwd)"
+COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
+
+[ -f "$COMPOSE_FILE" ] || die "docker-compose.yml not found at $COMPOSE_FILE"
+
+DEFAULT_DUMP="$COMPOSE_DIR/pg16_backup.dump"
+read -rp "Enter path for the database dump file (default: $DEFAULT_DUMP): " DUMP_PATH
+DUMP_PATH="${DUMP_PATH:-$DEFAULT_DUMP}"
+DUMP_PATH="${DUMP_PATH/#\~/$HOME}"
+
+# ── 2. Read credentials (.env then defaults) ────────────────────────────────
+PG_USER="bloodhound"
+PG_DB="bloodhound"
+
+ENV_FILE="$COMPOSE_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+    echo "Reading overrides from $ENV_FILE ..."
+    _val="$(grep -E '^\s*POSTGRES_USER\s*=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | xargs || true)" && [ -n "$_val" ] && PG_USER="$_val"
+    _val="$(grep -E '^\s*POSTGRES_DB\s*=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | xargs || true)" && [ -n "$_val" ] && PG_DB="$_val"
+fi
+echo "Credentials: user=$PG_USER  db=$PG_DB"
+
+# ── 3. Resolve project and volume names via Docker Compose ───────────────────
+PROJECT_NAME="$(docker compose -f "$COMPOSE_FILE" --project-directory "$COMPOSE_DIR" \
+    config --format json | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")"
+[ -n "$PROJECT_NAME" ] || die "Could not determine Compose project name."
+
+PG_VOL_DECL="$(docker compose -f "$COMPOSE_FILE" --project-directory "$COMPOSE_DIR" \
+    config --volumes | grep 'postgres-data' | head -n1)"
+[ -n "$PG_VOL_DECL" ] || die "No 'postgres-data' volume declared in compose config."
+
+VOLUME_NAME="${PROJECT_NAME}_${PG_VOL_DECL}"
+
+docker volume ls --format '{{.Name}}' | grep -qx "$VOLUME_NAME" \
+    || die "Docker volume '$VOLUME_NAME' not found. Is BloodHound installed?"
+
+echo "Project: $PROJECT_NAME   Volume: $VOLUME_NAME"
+
+# ── 4. Confirm ──────────────────────────────────────────────────────────────
+warn ""
+warn "This script will:"
+echo "  1. Stop the BloodHound app (keep PG 16 running)"
+echo "  2. Dump the PG 16 database to: $DUMP_PATH"
+echo "  3. Stop all containers"
+echo "  4. Create a backup copy of the PostgreSQL data volume"
+echo "  5. Update docker-compose.yml to use PostgreSQL 18"
+echo "  6. Start PG 18 and restore the database"
+echo "  7. Start the full BloodHound stack"
+
+read -rp $'\nProceed? (y/N): ' CONFIRM
+[[ "$CONFIRM" =~ ^[yY]$ ]] || { echo "Cancelled."; exit 0; }
+
+# ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
+step "Stopping BloodHound application container"
+dc stop bloodhound
+ok "BloodHound app stopped."
+
+step "Ensuring PostgreSQL 16 is running"
+dc start app-db
+sleep 5
+
+# ── 6. Dump database ────────────────────────────────────────────────────────
+step "Dumping PostgreSQL 16 database"
+dc exec app-db pg_dump -U "$PG_USER" -d "$PG_DB" -Fc -Z 9 -f /tmp/pg16_backup.dump
+dc cp app-db:/tmp/pg16_backup.dump "$DUMP_PATH"
+
+DUMP_SIZE="$(stat -f%z "$DUMP_PATH" 2>/dev/null || stat -c%s "$DUMP_PATH")"
+ok "Database dumped ($DUMP_SIZE bytes) -> $DUMP_PATH"
+
+# ── 7. Stop everything ──────────────────────────────────────────────────────
+step "Stopping all containers"
+dc down
+ok "All containers stopped."
+
+# ── 8. Copy the volume ──────────────────────────────────────────────────────
+step "Backing up PostgreSQL data volume"
+BACKUP_VOL="${VOLUME_NAME}-pg16-backup"
+docker volume create "$BACKUP_VOL" > /dev/null
+docker run --rm -v "${VOLUME_NAME}:/source:ro" -v "${BACKUP_VOL}:/backup" \
+    alpine sh -c "cp -a /source/. /backup/"
+ok "Volume copied to: $BACKUP_VOL"
+
+# ── 9. Update docker-compose.yml ────────────────────────────────────────────
+step "Updating docker-compose.yml to PostgreSQL 18"
+BAK_FILE="$COMPOSE_DIR/docker-compose.yml.pg16.bak"
+cp "$COMPOSE_FILE" "$BAK_FILE"
+echo "Compose file backed up to: $BAK_FILE"
+
+# Replace image tag
+if ! grep -q 'docker.io/library/postgres:16' "$COMPOSE_FILE"; then
+    die "Could not find postgres:16 image reference in compose file"
+fi
+sed -i.tmp 's|image: *docker\.io/library/postgres:16|image: docker.io/library/postgres:18|' "$COMPOSE_FILE"
+
+# PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
+if ! grep -q 'postgres-data:/var/lib/postgresql/data' "$BAK_FILE"; then
+    die "Could not find postgres-data:/var/lib/postgresql/data volume mount in compose file"
+fi
+sed -i.tmp 's|postgres-data:/var/lib/postgresql/data|postgres-data:/var/lib/postgresql|' "$COMPOSE_FILE"
+rm -f "${COMPOSE_FILE}.tmp"
+ok "docker-compose.yml updated (image + volume mount path)."
+
+# ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
+step "Removing old PostgreSQL data volume"
+docker volume rm "$VOLUME_NAME" > /dev/null
+ok "Old volume removed (backup preserved at $BACKUP_VOL)."
+
+step "Starting PostgreSQL 18"
+dc up -d app-db
+
+# Resolve the actual container name for app-db from Compose
+APP_DB_CONTAINER="$(docker compose -f "$COMPOSE_FILE" --project-directory "$COMPOSE_DIR" \
+    ps --format '{{.Name}}' app-db | head -n1 | xargs)"
+[ -n "$APP_DB_CONTAINER" ] || die "Could not determine container name for app-db service."
+
+echo "Waiting for PostgreSQL 18 to become healthy ($APP_DB_CONTAINER)..."
+for i in $(seq 1 30); do
+    sleep 2
+    HEALTH="$(docker inspect --format '{{.State.Health.Status}}' "$APP_DB_CONTAINER" 2>/dev/null || true)"
+    [ "$HEALTH" = "healthy" ] && break
+done
+[ "$HEALTH" = "healthy" ] || die "Container '$APP_DB_CONTAINER' is not healthy (status: $HEALTH). Aborting migration."
+
+# ── 11. Restore database ────────────────────────────────────────────────────
+step "Restoring database into PostgreSQL 18"
+dc cp "$DUMP_PATH" app-db:/tmp/pg16_backup.dump
+dc exec app-db pg_restore -U "$PG_USER" -d "$PG_DB" --clean --if-exists /tmp/pg16_backup.dump
+ok "Database restored."
+
+# ── 12. Start full stack ─────────────────────────────────────────────────────
+step "Starting full BloodHound stack"
+dc up -d
+ok "BloodHound stack is starting."
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+step "Migration Complete"
+ok "PostgreSQL upgraded from 16 to 18."
+echo "  Database dump : $DUMP_PATH"
+echo "  Volume backup : $BACKUP_VOL"
+echo "  Compose backup: $BAK_FILE"
+warn ""
+warn "Once verified, you can clean up with:"
+echo "  docker volume rm $BACKUP_VOL"
+echo "  rm '$BAK_FILE'"
+echo "  rm '$DUMP_PATH'"
+    ```
+
+  </Tab>
+</Tabs>
 
 ## Verify the upgrade
 
@@ -271,8 +452,23 @@ After you have verified that the upgrade was successful and your data is intact,
 
 Replace the placeholder values with the actual paths and volume name printed by the script.
 
-```powershell
-docker volume rm <backup-volume-name>
-Remove-Item 'C:\path\to\docker-compose.yml.pg16.bak'
-Remove-Item 'C:\path\to\pg16_backup.dump'
-```
+<Tabs>
+  <Tab title="PowerShell">
+
+    ```powershell
+    docker volume rm <backup-volume-name>
+    Remove-Item 'C:\path\to\docker-compose.yml.pg16.bak'
+    Remove-Item 'C:\path\to\pg16_backup.dump'
+    ```
+
+  </Tab>
+  <Tab title="Linux/macOS (bash)">
+
+    ```bash
+    docker volume rm <backup-volume-name>
+    rm '/path/to/docker-compose.yml.pg16.bak'
+    rm '/path/to/pg16_backup.dump'
+    ```
+
+  </Tab>
+</Tabs>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -85,22 +85,32 @@ if ([string]::IsNullOrWhiteSpace($dumpPath)) { $dumpPath = $defaultDump }
 $dumpPath = [System.IO.Path]::GetFullPath($dumpPath.Replace("~", $HOME))
 
 # ── 2. Read credentials (.env then defaults) ────────────────────────────────
-$pgUser = "bloodhound"; $pgPass = "bloodhoundcommunityedition"; $pgDb = "bloodhound"
+$pgUser = "bloodhound"; $pgDb = "bloodhound"
 
 $envFile = Join-Path $composeDir ".env"
 if (Test-Path $envFile) {
     Write-Host "Reading overrides from $envFile ..."
     Get-Content $envFile | ForEach-Object {
         if ($_ -match '^\s*POSTGRES_USER\s*=\s*(.+)$')     { $pgUser = $Matches[1].Trim() }
-        if ($_ -match '^\s*POSTGRES_PASSWORD\s*=\s*(.+)$')  { $pgPass = $Matches[1].Trim() }
         if ($_ -match '^\s*POSTGRES_DB\s*=\s*(.+)$')        { $pgDb   = $Matches[1].Trim() }
     }
 }
 Write-Host "Credentials: user=$pgUser  db=$pgDb"
 
-# ── 3. Resolve volume name ──────────────────────────────────────────────────
-$projectName = (Split-Path $composeDir -Leaf).ToLower() -replace '[^a-z0-9_-]',''
-$volumeName  = "${projectName}_postgres-data"
+# ── 3. Resolve project and volume names via Docker Compose ───────────────────
+$dcBase = @("-f", $composeFile, "--project-directory", $composeDir)
+
+$projectName = (docker compose @dcBase config --format json | ConvertFrom-Json).name
+if ([string]::IsNullOrWhiteSpace($projectName)) {
+    Write-Error "Could not determine Compose project name."; exit 1
+}
+
+$declaredVols = @(docker compose @dcBase config --volumes)
+$pgVolDecl = $declaredVols | Where-Object { $_ -match 'postgres-data' } | Select-Object -First 1
+if (-not $pgVolDecl) {
+    Write-Error "No 'postgres-data' volume declared in compose config."; exit 1
+}
+$volumeName = "${projectName}_${pgVolDecl}"
 
 $volExists = docker volume ls --format "{{.Name}}" | Where-Object { $_ -eq $volumeName }
 if (-not $volExists) {
@@ -169,7 +179,10 @@ $content = Get-Content $composeFile -Raw
 $updated = $content -replace 'image:\s*docker\.io/library/postgres:16', 'image: docker.io/library/postgres:18'
 if ($updated -eq $content) { Write-Error "Could not find postgres:16 image reference in compose file"; exit 1 }
 # PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
+# It manages version-specific subdirectories under that path automatically.
+$beforeMount = $updated
 $updated = $updated -replace 'postgres-data:/var/lib/postgresql/data', 'postgres-data:/var/lib/postgresql'
+if ($updated -eq $beforeMount) { Write-Error "Could not find postgres-data:/var/lib/postgresql/data volume mount in compose file"; exit 1 }
 [System.IO.File]::WriteAllText($composeFile, $updated)
 Write-Ok "docker-compose.yml updated (image + volume mount path)."
 
@@ -181,13 +194,19 @@ Write-Ok "Old volume removed (backup preserved at $backupVol)."
 Write-Step "Starting PostgreSQL 18"
 Invoke-DC up -d app-db
 
-Write-Host "Waiting for PostgreSQL 18 to become healthy..."
+# Resolve the actual container name for app-db from Compose
+$appDbContainer = (docker compose @dcBase ps --format "{{.Name}}" app-db).Trim()
+if ([string]::IsNullOrWhiteSpace($appDbContainer)) {
+    Write-Error "Could not determine container name for app-db service."; exit 1
+}
+
+Write-Host "Waiting for PostgreSQL 18 to become healthy ($appDbContainer)..."
 for ($i = 0; $i -lt 30; $i++) {
     Start-Sleep -Seconds 2
-    $health = docker inspect --format "{{.State.Health.Status}}" "${projectName}-app-db-1" 2>$null
+    $health = docker inspect --format "{{.State.Health.Status}}" $appDbContainer 2>$null
     if ($health -eq "healthy") { break }
 }
-if ($health -ne "healthy") { Write-Warn "Container not yet healthy — continuing anyway." }
+if ($health -ne "healthy") { Write-Error "Container '$appDbContainer' is not healthy (status: $health). Aborting migration."; exit 1 }
 
 # ── 11. Restore database ────────────────────────────────────────────────────
 Write-Step "Restoring database into PostgreSQL 18"
@@ -235,7 +254,7 @@ After the script finishes running, confirm that the database is healthy and your
     ```bash
     docker compose exec app-db psql -U [POSTGRES_USER] -d [POSTGRES_DB] -c "SELECT version();"
     ```
-    
+
     The output should include `PostgreSQL 18`.
 
   </Step>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -24,7 +24,7 @@ The upgrade scripts on this page automate the migration by dumping your existing
 
 - Docker with the Compose V2 plugin (`docker compose`, not `docker-compose`)
 - Sufficient free disk space for the database dump file and a volume backup
-- PowerShell 5.1 or later (Windows), or bash (Linux/macOS)
+- PowerShell 5.1 or later
 - Your BloodHound CE installation must be accessible and running before you begin
 
 ## Before you begin
@@ -250,27 +250,10 @@ After the script finishes running, confirm that the database is healthy and your
 
 After you have verified that the upgrade was successful and your data is intact, remove the temporary files and backup volume created during the migration.
 
-<Tabs>
-  <Tab title="Linux/macOS (bash)">
+Replace the placeholder values with the actual paths and volume name printed by the script.
 
-    Replace the placeholder values with the actual paths and volume name printed by the script.
-
-    ```bash
-    docker volume rm <backup-volume-name>
-    rm ~/path/to/docker-compose.yml.pg16.bak
-    rm ~/path/to/pg16_backup.dump
-    ```
-
-  </Tab>
-  <Tab title="Windows (PowerShell)">
-
-    Replace the placeholder values with the actual paths and volume name printed by the script.
-
-    ```powershell
-    docker volume rm <backup-volume-name>
-    Remove-Item 'C:\path\to\docker-compose.yml.pg16.bak'
-    Remove-Item 'C:\path\to\pg16_backup.dump'
-    ```
-
-  </Tab>
-</Tabs>
+```powershell
+docker volume rm <backup-volume-name>
+Remove-Item 'C:\path\to\docker-compose.yml.pg16.bak'
+Remove-Item 'C:\path\to\pg16_backup.dump'
+```

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -1,0 +1,467 @@
+---
+title: Upgrade PostgreSQL
+description: Migrate BloodHound Community Edition from PostgreSQL 16 to 18 using the provided upgrade scripts for Windows and Linux/macOS.
+sidebarTitle: Upgrade PostgreSQL
+---
+
+<img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only" />
+
+BloodHound Community Edition is upgrading its bundled PostgreSQL database from version 16 to version 18. PostgreSQL 18 delivers meaningful performance improvements and sets the foundation for faster in-place upgrades in future releases. However, the upgrade introduces a **breaking change** to the Docker volume mount path that prevents a simple image tag update.
+
+<Warning>
+  The PostgreSQL 18 Docker image uses a different volume mount path than version 16. Starting a PostgreSQL 18 container against an existing PostgreSQL 16 volume will fail. You must migrate your data using the scripts provided on this page.
+
+  | PostgreSQL version | Volume mount path |
+  |---|---|
+  | 16 (and earlier) | `/var/lib/postgresql/data` |
+  | 18 (and later) | `/var/lib/postgresql` |
+</Warning>
+
+The upgrade scripts on this page automate the migration by dumping your existing data, backing up the Docker volume, updating your `docker-compose.yml`, and restoring the data into a fresh PostgreSQL 18 container.
+
+## Prerequisites
+
+- Docker with the Compose V2 plugin (`docker compose`, not `docker-compose`)
+- Sufficient free disk space for the database dump file and a volume backup (allow at least 2× your current PostgreSQL volume size)
+- PowerShell 5.1 or later (Windows), or bash (Linux/macOS)
+- Your BloodHound CE installation must be accessible and running before you begin
+
+<Note>
+  If you installed BloodHound CE using the BloodHound CLI, your `docker-compose.yml` is located at `~/.config/bloodhound` by default.
+</Note>
+
+## Before you begin
+
+<Warning>
+  Back up your data before running the upgrade script. The scripts automatically create a copy of your PostgreSQL Docker volume, but you should verify that your data is intact independently before and after the migration.
+</Warning>
+
+The upgrade scripts perform the following steps in order:
+
+| Step | What it does |
+|---|---|
+| 1. Stop app, keep database running | Stops the BloodHound application container while leaving PostgreSQL 16 running so the database can be dumped cleanly |
+| 2. Dump the database | Exports the PostgreSQL 16 database to a compressed dump file on your host |
+| 3. Stop all containers | Brings down all containers before modifying the volume |
+| 4. Back up the data volume | Copies the PostgreSQL 16 Docker volume to a backup volume for safety |
+| 5. Update `docker-compose.yml` | Changes the image tag to `postgres:18` and updates the volume mount path; saves a backup of the original compose file |
+| 6. Start PostgreSQL 18 and restore | Removes the old volume, starts PostgreSQL 18, and restores the database from the dump file |
+| 7. Start the full stack | Brings up all BloodHound CE containers |
+
+## Run the upgrade script
+
+<Tabs>
+  <Tab title="Linux/macOS (bash)">
+
+    Save the following script to a file (for example, `upgrade-pg.sh`) and run it with `bash upgrade-pg.sh`.
+
+    ```bash
+    #!/usr/bin/env bash
+    # Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
+    # Walks through dumping the PG 16 database, backing up the Docker volume,
+    # upgrading to PG 18, and restoring the data. Requires Docker with the
+    # Compose V2 plugin.
+
+    set -euo pipefail
+
+    step()  { echo -e "\n\033[0;36m=== $* ===\033[0m"; }
+    ok()    { echo -e "\033[0;32m$*\033[0m"; }
+    warn()  { echo -e "\033[0;33m$*\033[0m"; }
+
+    # ── 1. Gather inputs ────────────────────────────────────────────────────────
+    step "BloodHound PostgreSQL 16 -> 18 Migration"
+
+    default_dir="${HOME}/.config/bloodhound"
+    read -rp "Enter the directory containing docker-compose.yml (default: ${default_dir}): " compose_dir
+    compose_dir="${compose_dir:-${default_dir}}"
+    compose_dir="$(cd "${compose_dir/#\~/$HOME}" && pwd)"
+    compose_file="${compose_dir}/docker-compose.yml"
+
+    if [[ ! -f "${compose_file}" ]]; then
+        echo "Error: docker-compose.yml not found at ${compose_file}" >&2; exit 1
+    fi
+
+    default_dump="${compose_dir}/pg16_backup.dump"
+    read -rp "Enter path for the database dump file (default: ${default_dump}): " dump_path
+    dump_path="${dump_path:-${default_dump}}"
+    dump_path="${dump_path/#\~/$HOME}"
+
+    # ── 2. Read credentials (.env then defaults) ────────────────────────────────
+    pg_user="bloodhound"
+    pg_pass="bloodhoundcommunityedition"
+    pg_db="bloodhound"
+
+    env_file="${compose_dir}/.env"
+    if [[ -f "${env_file}" ]]; then
+        echo "Reading overrides from ${env_file} ..."
+        while IFS='=' read -r key val; do
+            [[ "${key}" =~ ^[[:space:]]*# ]] && continue
+            key="${key// /}"
+            val="${val// /}"
+            case "${key}" in
+                POSTGRES_USER)     pg_user="${val}" ;;
+                POSTGRES_PASSWORD) pg_pass="${val}" ;;
+                POSTGRES_DB)       pg_db="${val}"   ;;
+            esac
+        done < "${env_file}"
+    fi
+    echo "Credentials: user=${pg_user}  db=${pg_db}"
+
+    # ── 3. Resolve volume name ──────────────────────────────────────────────────
+    project_name="$(basename "${compose_dir}" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
+    volume_name="${project_name}_postgres-data"
+
+    if ! docker volume ls --format '{{.Name}}' | grep -qx "${volume_name}"; then
+        echo "Error: Docker volume '${volume_name}' not found. Is BloodHound installed?" >&2; exit 1
+    fi
+    echo "Project: ${project_name}   Volume: ${volume_name}"
+
+    # ── 4. Confirm ──────────────────────────────────────────────────────────────
+    warn "\nThis script will:"
+    echo "  1. Stop the BloodHound app (keep PG 16 running)"
+    echo "  2. Dump the PG 16 database to: ${dump_path}"
+    echo "  3. Stop all containers"
+    echo "  4. Create a backup copy of the PostgreSQL data volume"
+    echo "  5. Update docker-compose.yml to use PostgreSQL 18"
+    echo "  6. Start PG 18 and restore the database"
+    echo "  7. Start the full BloodHound stack"
+
+    read -rp $'\nProceed? (y/N): ' confirm
+    [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+
+    # ── Helper: run docker compose with project context ──────────────────────────
+    dc() {
+        docker compose -f "${compose_file}" --project-directory "${compose_dir}" "$@"
+    }
+
+    # ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
+    step "Stopping BloodHound application container"
+    dc stop bloodhound
+    ok "BloodHound app stopped."
+
+    step "Ensuring PostgreSQL 16 is running"
+    dc start app-db
+    sleep 5
+
+    # ── 6. Dump database ────────────────────────────────────────────────────────
+    step "Dumping PostgreSQL 16 database"
+    dc exec app-db pg_dump -U "${pg_user}" -d "${pg_db}" -Fc -Z 9 -f /tmp/pg16_backup.dump
+    dc cp app-db:/tmp/pg16_backup.dump "${dump_path}"
+
+    dump_size="$(wc -c < "${dump_path}")"
+    ok "Database dumped (${dump_size} bytes) -> ${dump_path}"
+
+    # ── 7. Stop everything ──────────────────────────────────────────────────────
+    step "Stopping all containers"
+    dc down
+    ok "All containers stopped."
+
+    # ── 8. Copy the volume ──────────────────────────────────────────────────────
+    step "Backing up PostgreSQL data volume"
+    backup_vol="${volume_name}-pg16-backup"
+    docker volume create "${backup_vol}" > /dev/null
+    docker run --rm \
+        -v "${volume_name}:/source:ro" \
+        -v "${backup_vol}:/backup" \
+        alpine sh -c "cp -a /source/. /backup/"
+    ok "Volume copied to: ${backup_vol}"
+
+    # ── 9. Update docker-compose.yml ────────────────────────────────────────────
+    step "Updating docker-compose.yml to PostgreSQL 18"
+    bak_file="${compose_dir}/docker-compose.yml.pg16.bak"
+    cp "${compose_file}" "${bak_file}"
+    echo "Compose file backed up to: ${bak_file}"
+
+    # Update image tag
+    sed -i.tmp "s|image: docker\.io/library/postgres:16|image: docker.io/library/postgres:18|g" "${compose_file}"
+    # PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
+    sed -i.tmp "s|postgres-data:/var/lib/postgresql/data|postgres-data:/var/lib/postgresql|g" "${compose_file}"
+    rm -f "${compose_file}.tmp"
+
+    if ! grep -q "postgres:18" "${compose_file}"; then
+        echo "Error: Could not find postgres:18 after update — check compose file manually." >&2; exit 1
+    fi
+    ok "docker-compose.yml updated (image + volume mount path)."
+
+    # ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
+    step "Removing old PostgreSQL data volume"
+    docker volume rm "${volume_name}" > /dev/null
+    ok "Old volume removed (backup preserved at ${backup_vol})."
+
+    step "Starting PostgreSQL 18"
+    dc up -d app-db
+
+    echo "Waiting for PostgreSQL 18 to become healthy..."
+    health=""
+    for i in $(seq 1 30); do
+        sleep 2
+        health="$(docker inspect --format '{{.State.Health.Status}}' "${project_name}-app-db-1" 2>/dev/null || true)"
+        [[ "${health}" == "healthy" ]] && break
+    done
+    [[ "${health}" == "healthy" ]] || warn "Container not yet healthy — continuing anyway."
+
+    # ── 11. Restore database ────────────────────────────────────────────────────
+    step "Restoring database into PostgreSQL 18"
+    dc cp "${dump_path}" app-db:/tmp/pg16_backup.dump
+    dc exec app-db pg_restore -U "${pg_user}" -d "${pg_db}" --clean --if-exists /tmp/pg16_backup.dump
+    ok "Database restored."
+
+    # ── 12. Start full stack ─────────────────────────────────────────────────────
+    step "Starting full BloodHound stack"
+    dc up -d
+    ok "BloodHound stack is starting."
+
+    # ── Done ─────────────────────────────────────────────────────────────────────
+    step "Migration Complete"
+    ok "PostgreSQL upgraded from 16 to 18."
+    echo "  Database dump : ${dump_path}"
+    echo "  Volume backup : ${backup_vol}"
+    echo "  Compose backup: ${bak_file}"
+    warn "\nOnce verified, you can clean up with:"
+    echo "  docker volume rm ${backup_vol}"
+    echo "  rm '${bak_file}'"
+    echo "  rm '${dump_path}'"
+    ```
+
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+
+    Save the following script to a file (for example, `upgrade-pg.ps1`) and run it in PowerShell with `.\upgrade-pg.ps1`.
+
+    ```powershell
+    #Requires -Version 5.1
+    <#
+    .SYNOPSIS
+        Migrates BloodHound Community Edition PostgreSQL from 16 to 18.
+    .DESCRIPTION
+        Walks through dumping the PG 16 database, backing up the Docker volume,
+        upgrading to PG 18, and restoring the data. Requires Docker with the
+        Compose V2 plugin.
+    #>
+
+    $ErrorActionPreference = "Stop"
+
+    function Write-Step  { param([string]$Msg) Write-Host "`n=== $Msg ===" -ForegroundColor Cyan }
+    function Write-Ok    { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+    function Write-Warn  { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
+
+    # ── 1. Gather inputs ────────────────────────────────────────────────────────
+    Write-Step "BloodHound PostgreSQL 16 -> 18 Migration"
+
+    $defaultDir = Join-Path $HOME ".config" "bloodhound"
+    $composeDir = Read-Host "Enter the directory containing docker-compose.yml (default: $defaultDir)"
+    if ([string]::IsNullOrWhiteSpace($composeDir)) { $composeDir = $defaultDir }
+    $composeDir = [System.IO.Path]::GetFullPath($composeDir.Replace("~", $HOME))
+    $composeFile = Join-Path $composeDir "docker-compose.yml"
+
+    if (-not (Test-Path $composeFile)) {
+        Write-Error "docker-compose.yml not found at $composeFile"; exit 1
+    }
+
+    $defaultDump = Join-Path $composeDir "pg16_backup.dump"
+    $dumpPath = Read-Host "Enter path for the database dump file (default: $defaultDump)"
+    if ([string]::IsNullOrWhiteSpace($dumpPath)) { $dumpPath = $defaultDump }
+    $dumpPath = [System.IO.Path]::GetFullPath($dumpPath.Replace("~", $HOME))
+
+    # ── 2. Read credentials (.env then defaults) ────────────────────────────────
+    $pgUser = "bloodhound"; $pgPass = "bloodhoundcommunityedition"; $pgDb = "bloodhound"
+
+    $envFile = Join-Path $composeDir ".env"
+    if (Test-Path $envFile) {
+        Write-Host "Reading overrides from $envFile ..."
+        Get-Content $envFile | ForEach-Object {
+            if ($_ -match '^\s*POSTGRES_USER\s*=\s*(.+)$')     { $pgUser = $Matches[1].Trim() }
+            if ($_ -match '^\s*POSTGRES_PASSWORD\s*=\s*(.+)$')  { $pgPass = $Matches[1].Trim() }
+            if ($_ -match '^\s*POSTGRES_DB\s*=\s*(.+)$')        { $pgDb   = $Matches[1].Trim() }
+        }
+    }
+    Write-Host "Credentials: user=$pgUser  db=$pgDb"
+
+    # ── 3. Resolve volume name ──────────────────────────────────────────────────
+    $projectName = (Split-Path $composeDir -Leaf).ToLower() -replace '[^a-z0-9_-]',''
+    $volumeName  = "${projectName}_postgres-data"
+
+    $volExists = docker volume ls --format "{{.Name}}" | Where-Object { $_ -eq $volumeName }
+    if (-not $volExists) {
+        Write-Error "Docker volume '$volumeName' not found. Is BloodHound installed?"
+        exit 1
+    }
+    Write-Host "Project: $projectName   Volume: $volumeName"
+
+    # ── 4. Confirm ──────────────────────────────────────────────────────────────
+    Write-Warn "`nThis script will:"
+    Write-Host "  1. Stop the BloodHound app (keep PG 16 running)"
+    Write-Host "  2. Dump the PG 16 database to: $dumpPath"
+    Write-Host "  3. Stop all containers"
+    Write-Host "  4. Create a backup copy of the PostgreSQL data volume"
+    Write-Host "  5. Update docker-compose.yml to use PostgreSQL 18"
+    Write-Host "  6. Start PG 18 and restore the database"
+    Write-Host "  7. Start the full BloodHound stack"
+
+    $confirm = Read-Host "`nProceed? (y/N)"
+    if ($confirm -notin @('y','Y')) { Write-Host "Cancelled."; exit 0 }
+
+    # ── Helper: run docker compose with project context ──────────────────────────
+    function Invoke-DC {
+        $dcArgs = @("-f", $composeFile, "--project-directory", $composeDir) + $args
+        & docker compose @dcArgs
+        if ($LASTEXITCODE -ne 0) { throw "docker compose failed (exit $LASTEXITCODE)" }
+    }
+
+    # ── 5. Stop app, keep PG 16 alive ───────────────────────────────────────────
+    Write-Step "Stopping BloodHound application container"
+    Invoke-DC stop bloodhound
+    Write-Ok "BloodHound app stopped."
+
+    Write-Step "Ensuring PostgreSQL 16 is running"
+    Invoke-DC start app-db
+    Start-Sleep -Seconds 5
+
+    # ── 6. Dump database ────────────────────────────────────────────────────────
+    Write-Step "Dumping PostgreSQL 16 database"
+    Invoke-DC exec app-db pg_dump -U $pgUser -d $pgDb -Fc -Z 9 -f /tmp/pg16_backup.dump
+    Invoke-DC cp app-db:/tmp/pg16_backup.dump $dumpPath
+
+    $dumpSize = (Get-Item $dumpPath).Length
+    Write-Ok "Database dumped ($dumpSize bytes) -> $dumpPath"
+
+    # ── 7. Stop everything ──────────────────────────────────────────────────────
+    Write-Step "Stopping all containers"
+    Invoke-DC down
+    Write-Ok "All containers stopped."
+
+    # ── 8. Copy the volume ──────────────────────────────────────────────────────
+    Write-Step "Backing up PostgreSQL data volume"
+    $backupVol = "${volumeName}-pg16-backup"
+    docker volume create $backupVol | Out-Null
+    docker run --rm -v "${volumeName}:/source:ro" -v "${backupVol}:/backup" `
+        alpine sh -c "cp -a /source/. /backup/"
+    Write-Ok "Volume copied to: $backupVol"
+
+    # ── 9. Update docker-compose.yml ────────────────────────────────────────────
+    Write-Step "Updating docker-compose.yml to PostgreSQL 18"
+    $bakFile = Join-Path $composeDir "docker-compose.yml.pg16.bak"
+    Copy-Item $composeFile $bakFile
+    Write-Host "Compose file backed up to: $bakFile"
+
+    $content = Get-Content $composeFile -Raw
+    $updated = $content -replace 'image:\s*docker\.io/library/postgres:16', 'image: docker.io/library/postgres:18'
+    if ($updated -eq $content) { Write-Error "Could not find postgres:16 image reference in compose file"; exit 1 }
+    # PG 18+ expects the mount at /var/lib/postgresql (not /var/lib/postgresql/data).
+    $updated = $updated -replace 'postgres-data:/var/lib/postgresql/data', 'postgres-data:/var/lib/postgresql'
+    [System.IO.File]::WriteAllText($composeFile, $updated)
+    Write-Ok "docker-compose.yml updated (image + volume mount path)."
+
+    # ── 10. Remove old volume, start PG 18 ──────────────────────────────────────
+    Write-Step "Removing old PostgreSQL data volume"
+    docker volume rm $volumeName | Out-Null
+    Write-Ok "Old volume removed (backup preserved at $backupVol)."
+
+    Write-Step "Starting PostgreSQL 18"
+    Invoke-DC up -d app-db
+
+    Write-Host "Waiting for PostgreSQL 18 to become healthy..."
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Seconds 2
+        $health = docker inspect --format "{{.State.Health.Status}}" "${projectName}-app-db-1" 2>$null
+        if ($health -eq "healthy") { break }
+    }
+    if ($health -ne "healthy") { Write-Warn "Container not yet healthy — continuing anyway." }
+
+    # ── 11. Restore database ────────────────────────────────────────────────────
+    Write-Step "Restoring database into PostgreSQL 18"
+    Invoke-DC cp $dumpPath app-db:/tmp/pg16_backup.dump
+    Invoke-DC exec app-db pg_restore -U $pgUser -d $pgDb --clean --if-exists /tmp/pg16_backup.dump
+    Write-Ok "Database restored."
+
+    # ── 12. Start full stack ─────────────────────────────────────────────────────
+    Write-Step "Starting full BloodHound stack"
+    Invoke-DC up -d
+    Write-Ok "BloodHound stack is starting."
+
+    # ── Done ─────────────────────────────────────────────────────────────────────
+    Write-Step "Migration Complete"
+    Write-Ok "PostgreSQL upgraded from 16 to 18."
+    Write-Host "  Database dump : $dumpPath"
+    Write-Host "  Volume backup : $backupVol"
+    Write-Host "  Compose backup: $bakFile"
+    Write-Warn "`nOnce verified, you can clean up with:"
+    Write-Host "  docker volume rm $backupVol"
+    Write-Host "  Remove-Item '$bakFile'"
+    Write-Host "  Remove-Item '$dumpPath'"
+    ```
+
+  </Tab>
+</Tabs>
+
+## Verify the upgrade
+
+After the script completes, confirm that the database is healthy and your data is intact.
+
+<Steps>
+  <Step title="Check the container status">
+
+    Run the following command to confirm all containers are running:
+
+    ```bash
+    docker compose ps
+    ```
+
+    The `app-db` container should show a status of `healthy`.
+
+  </Step>
+  <Step title="Confirm the PostgreSQL version">
+
+    Run the following command to confirm that PostgreSQL 18 is running:
+
+    <Tabs>
+      <Tab title="Linux/macOS (bash)">
+        ```bash
+        docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
+        ```
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
+        ```
+      </Tab>
+    </Tabs>
+
+    The output should include `PostgreSQL 18`.
+
+  </Step>
+  <Step title="Log in to BloodHound CE">
+
+    Open your browser and navigate to BloodHound CE (default: `http://127.0.0.1:8080`). Log in and confirm that your data is accessible.
+
+  </Step>
+</Steps>
+
+## Clean up
+
+After you have verified that the upgrade was successful and your data is intact, remove the temporary files and backup volume created during the migration.
+
+<Tabs>
+  <Tab title="Linux/macOS (bash)">
+
+    Replace the placeholder values with the actual paths and volume name printed by the script.
+
+    ```bash
+    docker volume rm <backup-volume-name>
+    rm ~/path/to/docker-compose.yml.pg16.bak
+    rm ~/path/to/pg16_backup.dump
+    ```
+
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+
+    Replace the placeholder values with the actual paths and volume name printed by the script.
+
+    ```powershell
+    docker volume rm <backup-volume-name>
+    Remove-Item 'C:\path\to\docker-compose.yml.pg16.bak'
+    Remove-Item 'C:\path\to\pg16_backup.dump'
+    ```
+
+  </Tab>
+</Tabs>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -1,12 +1,13 @@
 ---
 title: Upgrade PostgreSQL
-description: Migrate BloodHound Community Edition from PostgreSQL 16 to 18 using the provided upgrade scripts for Windows and Linux/macOS.
-sidebarTitle: Upgrade PostgreSQL
+description: Migrate BloodHound Community Edition from PostgreSQL 16 to 18.
 ---
 
 <img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only" />
 
-BloodHound Community Edition is upgrading its bundled PostgreSQL database from version 16 to version 18. PostgreSQL 18 delivers meaningful performance improvements and sets the foundation for faster in-place upgrades in future releases. However, the upgrade introduces a **breaking change** to the Docker volume mount path that prevents a simple image tag update.
+BloodHound Community Edition is upgrading its bundled PostgreSQL database from version 16 to version 18. PostgreSQL 18 enables new capabilities and delivers meaningful performance improvements.
+
+However, the upgrade introduces a **breaking change** to the Docker volume mount path that prevents a simple image tag update.
 
 <Warning>
   The PostgreSQL 18 Docker image uses a different volume mount path than version 16. Starting a PostgreSQL 18 container against an existing PostgreSQL 16 volume will fail. You must migrate your data using the scripts provided on this page.
@@ -22,13 +23,9 @@ The upgrade scripts on this page automate the migration by dumping your existing
 ## Prerequisites
 
 - Docker with the Compose V2 plugin (`docker compose`, not `docker-compose`)
-- Sufficient free disk space for the database dump file and a volume backup (allow at least 2× your current PostgreSQL volume size)
+- Sufficient free disk space for the database dump file and a volume backup
 - PowerShell 5.1 or later (Windows), or bash (Linux/macOS)
 - Your BloodHound CE installation must be accessible and running before you begin
-
-<Note>
-  If you installed BloodHound CE using the BloodHound CLI, your `docker-compose.yml` is located at `~/.config/bloodhound` by default.
-</Note>
 
 ## Before you begin
 
@@ -396,12 +393,12 @@ The upgrade scripts perform the following steps in order:
 
 ## Verify the upgrade
 
-After the script completes, confirm that the database is healthy and your data is intact.
+After the script finishes running, confirm that the database is healthy and your data is intact.
 
 <Steps>
   <Step title="Check the container status">
 
-    Run the following command to confirm all containers are running:
+    Confirm all containers are running:
 
     ```bash
     docker compose ps
@@ -412,21 +409,12 @@ After the script completes, confirm that the database is healthy and your data i
   </Step>
   <Step title="Confirm the PostgreSQL version">
 
-    Run the following command to confirm that PostgreSQL 18 is running:
+    Confirm that PostgreSQL 18 is running:
 
-    <Tabs>
-      <Tab title="Linux/macOS (bash)">
-        ```bash
-        docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
-        ```
-      </Tab>
-      <Tab title="Windows (PowerShell)">
-        ```powershell
-        docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
-        ```
-      </Tab>
-    </Tabs>
-
+    ```bash
+    docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
+    ```
+    
     The output should include `PostgreSQL 18`.
 
   </Step>

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -93,8 +93,10 @@ The upgrade scripts perform the following steps in order:
         echo "Reading overrides from ${env_file} ..."
         while IFS='=' read -r key val; do
             [[ "${key}" =~ ^[[:space:]]*# ]] && continue
-            key="${key// /}"
-            val="${val// /}"
+            key="${key#"${key%%[![:space:]]*}"}"   # trim leading
+            key="${key%"${key##*[![:space:]]}"}"   # trim trailing
+            val="${val#"${val%%[![:space:]]*}"}"   # trim leading
+            val="${val%"${val##*[![:space:]]}"}"   # trim trailing
             case "${key}" in
                 POSTGRES_USER)     pg_user="${val}" ;;
                 POSTGRES_PASSWORD) pg_pass="${val}" ;;
@@ -412,7 +414,7 @@ After the script finishes running, confirm that the database is healthy and your
     Confirm that PostgreSQL 18 is running:
 
     ```bash
-    docker compose exec app-db psql -U bloodhound -d bloodhound -c "SELECT version();"
+    docker compose exec app-db psql -U [POSTGRES_USER] -d [POSTGRES_DB] -c "SELECT version();"
     ```
     
     The output should include `PostgreSQL 18`.

--- a/docs/get-started/upgrade-postgres.mdx
+++ b/docs/get-started/upgrade-postgres.mdx
@@ -5,7 +5,7 @@ description: Migrate BloodHound Community Edition from PostgreSQL 16 to 18.
 
 <img noZoom src="/assets/community-edition-pill-tag.svg" alt="Applies to BloodHound CE only" />
 
-BloodHound Community Edition is upgrading its bundled PostgreSQL database from version 16 to version 18. PostgreSQL 18 enables new capabilities and delivers meaningful performance improvements.
+BloodHound Community Edition is already compatible with PostgreSQL 18. Use this guide to get a head start on the latest PostgreSQL release before it becomes the default bundled version, and to benefit from its new capabilities and performance improvements.
 
 However, the upgrade introduces a **breaking change** to the Docker volume mount path that prevents a simple image tag update.
 

--- a/docs/on-premises/upgrade-postgres.mdx
+++ b/docs/on-premises/upgrade-postgres.mdx
@@ -51,7 +51,7 @@ Confirm the following before you begin:
     Use `pg_dump` to export your existing database to a compressed dump file. Replace the placeholder values with your actual connection details:
 
     ```bash
-    pg_dump -h <host> -p 5432 -U <username> -d <database> -Fc -Z 9 -f pg16_backup.dump
+    pg_dump -h [host] -p 5432 -U [username] -d [database] -Fc -Z 9 -f pg16_backup.dump
     ```
 
     Verify that the dump file was created and has a non-zero size before continuing.
@@ -76,7 +76,7 @@ Confirm the following before you begin:
     After PostgreSQL 18 is running, restore the database from the dump file:
 
     ```bash
-    pg_restore -h <host> -p 5432 -U <username> -d <database> --clean --if-exists pg16_backup.dump
+    pg_restore -h [host] -p 5432 -U [username] -d [database] --clean --if-exists pg16_backup.dump
     ```
 
     Wait for the restore to complete before proceeding.
@@ -120,9 +120,5 @@ After the application restarts, confirm that the database is healthy and your da
 ## Clean up
 
 After you have verified that the upgrade was successful and your data is intact, remove the temporary dump file and any volume backups you created during the migration.
-
-```bash
-rm pg16_backup.dump
-```
 
 Remove any snapshot or volume backups using the tools appropriate for your environment.

--- a/docs/on-premises/upgrade-postgres.mdx
+++ b/docs/on-premises/upgrade-postgres.mdx
@@ -1,14 +1,14 @@
 ---
 title: Upgrade an external PostgreSQL database
-description: Upgrade an external PostgreSQL database from version 16 to 18 for BloodHound Enterprise on-premises deployments.
+description: Upgrade an external PostgreSQL database from version 16 to 18 for on-premises deployments of BloodHound Enterprise.
 sidebarTitle: Upgrade PostgreSQL
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />
 
-This guide applies to on-premises BloodHound Enterprise customers who chose to use an **external** PostgreSQL database instead of the PostgreSQL database bundled with the embedded cluster. If you use the embedded cluster's bundled database, it is managed by Replicated and is not affected by this guide.
+This guide applies to on-premises deployments of BloodHound Enterprise using an **external** PostgreSQL database instead of the PostgreSQL database bundled with the embedded cluster.
 
-BloodHound Enterprise requires PostgreSQL 18. If your external database is still running PostgreSQL 16, follow the steps on this page to upgrade. For context on configuring an external database during installation, see the [Database Configuration](/on-premises/install#database-configuration) step in the install guide.
+PostgreSQL 18 enables new capabilities, delivers meaningful performance improvements, and is required for BloodHound Enterprise. If your external database is still running PostgreSQL 16, follow the steps on this page to upgrade and migrate your data.
 
 <Warning>
   The PostgreSQL 18 Docker image uses a different volume mount path than version 16. If your external database runs in Docker, you cannot simply update the image tag — the volume mount point has changed.
@@ -30,7 +30,7 @@ BloodHound Enterprise requires PostgreSQL 18. If your external database is still
 Confirm the following before you begin:
 
 - You have access to a PostgreSQL 18 instance (or can upgrade your existing host to PostgreSQL 18)
-- You have sufficient disk space for a full database dump (allow at least 1.5× your current database size)
+- You have sufficient disk space for a full database dump
 - Your database administrator is available to adapt commands to your specific environment
 - You know your PostgreSQL connection details (host, port, username, database name)
 
@@ -43,7 +43,7 @@ Confirm the following before you begin:
 <Steps>
   <Step title="Stop BloodHound Enterprise">
 
-    Stop the BloodHound Enterprise application to prevent new writes to the database during the migration.
+    Stop the BloodHound Enterprise application to prevent new writes to the database during the upgrade.
 
     For embedded cluster deployments, you can stop the application using the Replicated Admin Console, or by scaling down the BloodHound deployment:
 
@@ -67,19 +67,12 @@ Confirm the following before you begin:
   </Step>
   <Step title="Back up your data directory">
 
-    If your PostgreSQL instance uses a data volume or directory, create a backup of it before making changes. The exact method depends on your deployment:
-
-    - **Docker**: Copy the volume using `docker run` with an alpine container (see the [CE upgrade guide](/get-started/upgrade-postgres) for an example).
-    - **Bare-metal or VM**: Use your standard snapshot or backup tooling to create a point-in-time copy of the PostgreSQL data directory.
+    If your PostgreSQL instance uses a data volume or directory, create a backup of it before making changes. The exact method depends on your deployment.
 
   </Step>
   <Step title="Upgrade PostgreSQL to version 18">
 
-    Upgrade your PostgreSQL instance to version 18 using the method appropriate for your environment:
-
-    - **Docker**: Update the image tag to `postgres:18` and update the volume mount path from `/var/lib/postgresql/data` to `/var/lib/postgresql`. Remove the old data volume and let PostgreSQL 18 initialize a fresh one.
-    - **Package manager (apt/yum)**: Follow the [official PostgreSQL upgrade documentation](https://www.postgresql.org/docs/18/upgrading.html) for your Linux distribution.
-    - **Managed service (RDS, Cloud SQL, etc.)**: Use your cloud provider's major version upgrade feature.
+    Upgrade your PostgreSQL instance to version 18 using the method appropriate for your environment.
 
     <Note>
       PostgreSQL major version upgrades are not backward-compatible. After upgrading to PostgreSQL 18, you cannot start the service against a PostgreSQL 16 data directory without first restoring from your dump file.

--- a/docs/on-premises/upgrade-postgres.mdx
+++ b/docs/on-premises/upgrade-postgres.mdx
@@ -1,0 +1,149 @@
+---
+title: Upgrade an external PostgreSQL database
+description: Upgrade an external PostgreSQL database from version 16 to 18 for BloodHound Enterprise on-premises deployments.
+sidebarTitle: Upgrade PostgreSQL
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />
+
+This guide applies to on-premises BloodHound Enterprise customers who chose to use an **external** PostgreSQL database instead of the PostgreSQL database bundled with the embedded cluster. If you use the embedded cluster's bundled database, it is managed by Replicated and is not affected by this guide.
+
+BloodHound Enterprise requires PostgreSQL 18. If your external database is still running PostgreSQL 16, follow the steps on this page to upgrade. For context on configuring an external database during installation, see the [Database Configuration](/on-premises/install#database-configuration) step in the install guide.
+
+<Warning>
+  The PostgreSQL 18 Docker image uses a different volume mount path than version 16. If your external database runs in Docker, you cannot simply update the image tag — the volume mount point has changed.
+
+  | PostgreSQL version | Volume mount path |
+  |---|---|
+  | 16 (and earlier) | `/var/lib/postgresql/data` |
+  | 18 (and later) | `/var/lib/postgresql` |
+
+  Starting a PostgreSQL 18 container against an existing PostgreSQL 16 volume will fail.
+</Warning>
+
+## Before you begin
+
+<Warning>
+  Back up your database before starting the upgrade. Verify that your backup is complete and restorable before proceeding.
+</Warning>
+
+Confirm the following before you begin:
+
+- You have access to a PostgreSQL 18 instance (or can upgrade your existing host to PostgreSQL 18)
+- You have sufficient disk space for a full database dump (allow at least 1.5× your current database size)
+- Your database administrator is available to adapt commands to your specific environment
+- You know your PostgreSQL connection details (host, port, username, database name)
+
+<Note>
+  The exact commands in this guide vary depending on how your external database is deployed (Docker, bare-metal, VM, or managed service). Work with your database administrator to adapt the procedure to your environment. For a concrete Docker Compose reference, see the [Community Edition upgrade guide](/get-started/upgrade-postgres).
+</Note>
+
+## Upgrade process
+
+<Steps>
+  <Step title="Stop BloodHound Enterprise">
+
+    Stop the BloodHound Enterprise application to prevent new writes to the database during the migration.
+
+    For embedded cluster deployments, you can stop the application using the Replicated Admin Console, or by scaling down the BloodHound deployment:
+
+    ```bash
+    kubectl scale deployment bloodhound --replicas=0 -n <namespace>
+    ```
+
+    Confirm that the application has stopped and is no longer writing to the database before continuing.
+
+  </Step>
+  <Step title="Dump the PostgreSQL 16 database">
+
+    Use `pg_dump` to export your existing database to a compressed dump file. Replace the placeholder values with your actual connection details:
+
+    ```bash
+    pg_dump -h <host> -p 5432 -U <username> -d <database> -Fc -Z 9 -f pg16_backup.dump
+    ```
+
+    Verify that the dump file was created and has a non-zero size before continuing.
+
+  </Step>
+  <Step title="Back up your data directory">
+
+    If your PostgreSQL instance uses a data volume or directory, create a backup of it before making changes. The exact method depends on your deployment:
+
+    - **Docker**: Copy the volume using `docker run` with an alpine container (see the [CE upgrade guide](/get-started/upgrade-postgres) for an example).
+    - **Bare-metal or VM**: Use your standard snapshot or backup tooling to create a point-in-time copy of the PostgreSQL data directory.
+
+  </Step>
+  <Step title="Upgrade PostgreSQL to version 18">
+
+    Upgrade your PostgreSQL instance to version 18 using the method appropriate for your environment:
+
+    - **Docker**: Update the image tag to `postgres:18` and update the volume mount path from `/var/lib/postgresql/data` to `/var/lib/postgresql`. Remove the old data volume and let PostgreSQL 18 initialize a fresh one.
+    - **Package manager (apt/yum)**: Follow the [official PostgreSQL upgrade documentation](https://www.postgresql.org/docs/18/upgrading.html) for your Linux distribution.
+    - **Managed service (RDS, Cloud SQL, etc.)**: Use your cloud provider's major version upgrade feature.
+
+    <Note>
+      PostgreSQL major version upgrades are not backward-compatible. After upgrading to PostgreSQL 18, you cannot start the service against a PostgreSQL 16 data directory without first restoring from your dump file.
+    </Note>
+
+  </Step>
+  <Step title="Restore the database">
+
+    After PostgreSQL 18 is running, restore the database from the dump file:
+
+    ```bash
+    pg_restore -h <host> -p 5432 -U <username> -d <database> --clean --if-exists pg16_backup.dump
+    ```
+
+    Wait for the restore to complete before proceeding.
+
+  </Step>
+  <Step title="Restart BloodHound Enterprise">
+
+    Start the BloodHound Enterprise application and confirm it connects to the upgraded database successfully.
+
+    For embedded cluster deployments, scale the deployment back up:
+
+    ```bash
+    kubectl scale deployment bloodhound --replicas=1 -n <namespace>
+    ```
+
+  </Step>
+</Steps>
+
+## Verify the upgrade
+
+After the application restarts, confirm that the database is healthy and your data is intact.
+
+<Steps>
+  <Step title="Confirm the PostgreSQL version">
+
+    Connect to your PostgreSQL instance and run the following query to confirm PostgreSQL 18 is running:
+
+    ```sql
+    SELECT version();
+    ```
+
+    The output should include `PostgreSQL 18`.
+
+  </Step>
+  <Step title="Log in to BloodHound Enterprise">
+
+    Open your browser and navigate to your BloodHound Enterprise instance. Log in and verify that your data, collectors, and configuration are intact.
+
+  </Step>
+  <Step title="Monitor application logs">
+
+    Review the BloodHound Enterprise application logs for any database connection errors or migration issues immediately after restart.
+
+  </Step>
+</Steps>
+
+## Clean up
+
+After you have verified that the upgrade was successful and your data is intact, remove the temporary dump file and any volume backups you created during the migration.
+
+```bash
+rm pg16_backup.dump
+```
+
+Remove any snapshot or volume backups using the tools appropriate for your environment.

--- a/docs/on-premises/upgrade-postgres.mdx
+++ b/docs/on-premises/upgrade-postgres.mdx
@@ -45,14 +45,6 @@ Confirm the following before you begin:
 
     Stop the BloodHound Enterprise application to prevent new writes to the database during the upgrade.
 
-    For embedded cluster deployments, you can stop the application using the Replicated Admin Console, or by scaling down the BloodHound deployment:
-
-    ```bash
-    kubectl scale deployment bloodhound --replicas=0 -n <namespace>
-    ```
-
-    Confirm that the application has stopped and is no longer writing to the database before continuing.
-
   </Step>
   <Step title="Dump the PostgreSQL 16 database">
 
@@ -93,12 +85,6 @@ Confirm the following before you begin:
   <Step title="Restart BloodHound Enterprise">
 
     Start the BloodHound Enterprise application and confirm it connects to the upgraded database successfully.
-
-    For embedded cluster deployments, scale the deployment back up:
-
-    ```bash
-    kubectl scale deployment bloodhound --replicas=1 -n <namespace>
-    ```
 
   </Step>
 </Steps>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PostgreSQL v16→v18 upgrade guides for Community and on‑premises Enterprise deployments
  * Updated installation docs to recommend PostgreSQL 18 for new installs and updated Docker Compose examples
  * Documented Docker volume mount path changes and step‑by‑step migration workflows
  * Included an automation upgrade script and platform-specific verification/cleanup guidance
  * Updated site navigation to surface the new upgrade documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Staging

- https://specterops-bp-2669-postgres-upgrade.mintlify.app/get-started/upgrade-postgres
- https://specterops-bp-2669-postgres-upgrade.mintlify.app/on-premises/upgrade-postgres