### PR TITLE
BP-2696: Add warning about known issue with colons in object IDs

### DIFF
--- a/docs/analyze-data/explore/search.mdx
+++ b/docs/analyze-data/explore/search.mdx
@@ -3,6 +3,8 @@ title: Search and pathfinding
 description: Search for objects and visualize relationships between them in the graph.
 ---
 
+import SearchIssueWarning from '/snippets/opengraph/search-issue.mdx';
+
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE" />
 
 After [uploading data](/get-started/quickstart/community-edition-quickstart#get-data-into-bloodhound) to BloodHound, use the **Explore** page to search for objects and visualize their relationships. The graph displays <Tooltip headline="nodes" tip="Part of the graph construct and refers to an entity in the network, such as a user, computer, group, or domain. Two nodes can be connected by an edge." cta="See the docs" href="/resources/nodes/overview">nodes</Tooltip> and <Tooltip headline="edges" tip="Part of the graph construct and refers to a relationship between two nodes, such as group membership or session information." cta="See the docs" href="/resources/edges/overview">edges</Tooltip>, helping you understand your environment and identify potential attack paths.
@@ -37,7 +39,7 @@ Which method you choose depends on your specific use case and what you're trying
 
 The **Search** tab allows you to quickly find specific nodes in the graph by name or object ID. As you type in the search text box, BloodHound automatically suggests nodes that match your search query. You can click on any of the suggestions to select and display that node in the graph.
 
-<Note>Search supports partial matches, so you don't need to type the full name of an object to find it.</Note>
+<SearchIssueWarning method="Search" />
 
 Use cases for the search method include:
 
@@ -75,11 +77,13 @@ group:admin
 
 The **Pathfinding** tab allows you to discover relationships between objects by finding paths between them. This is particularly useful for investigating potential attack paths across identity providers and cloud services in a single graph view.
 
-BloodHound currently supports the **Search** and **Cypher** search methods for OpenGraph data. Pathfinding is available for [structured](/opengraph/extensions/manage#structured-graphs) graphs only.
-
 <Note>
   When [ETAC](/manage-bloodhound/auth/environment-targeted-access-control) applies to your user account, pathfinding returns data from the environments you can access only.
 </Note>
+
+BloodHound currently supports the **Search** and **Cypher** search methods for OpenGraph data. Pathfinding is available for [structured](/opengraph/extensions/manage#structured-graphs) graphs only.
+
+<SearchIssueWarning method="Pathfinding" />
 
 Use cases for the pathfinding search method include:
 

--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -47,6 +47,10 @@ At minimum, each node must include a unique identifier and a `kinds` array.
   | --- | --- |
   | **Good**: globally unique | GUIDs, SIDs, certificate thumbprints |
   | **Avoid**: not guaranteed unique | Usernames, email addresses, hostnames, auto-incremented integers |
+
+  <Warning>
+    Do not use colons (`:`) in node `id` values. BloodHound does not fully support colons in OpenGraph object IDs, which causes node-type filtering issues in [Search and Pathfinding](/analyze-data/explore/search).
+  </Warning>
 </ResponseField>
 <ResponseField name="kinds" type="array" required>
   An array of strings that classify the node. You can include up to three kinds per node. The first value is the primary kind, which controls the node styling in the graph.
@@ -233,3 +237,5 @@ Use the following JSON schema for validation requirements. You can also download
 - **Upload fails on reserved property conflict:** Remove `objectid` from `properties` and keep the identifier only in `id`.
 
 - **Upload rejected due to reserved kind:** Check whether any node kinds begin with the reserved `tag_` prefix in any letter case, including `tag_`, `Tag_`, and `TAG_`. If any node kind uses this prefix, BloodHound rejects the entire upload.
+
+- **Search or pathfinding behaves unexpectedly for a known node:** Confirm the node `id` does not contain a colon (`:`). BloodHound does not currently support colons in OpenGraph object IDs for these workflows.

--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -238,4 +238,4 @@ Use the following JSON schema for validation requirements. You can also download
 
 - **Upload rejected due to reserved kind:** Check whether any node kinds begin with the reserved `tag_` prefix in any letter case, including `tag_`, `Tag_`, and `TAG_`. If any node kind uses this prefix, BloodHound rejects the entire upload.
 
-- **Search or pathfinding behaves unexpectedly for a known node:** Confirm the node `id` does not contain a colon (`:`). BloodHound does not currently support colons in OpenGraph object IDs for these workflows.
+- **Search or Pathfinding behaves unexpectedly for a known node:** Confirm the node `id` does not contain a colon (`:`). BloodHound does not fully support colons in object IDs.

--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -49,7 +49,7 @@ At minimum, each node must include a unique identifier and a `kinds` array.
   | **Avoid**: not guaranteed unique | Usernames, email addresses, hostnames, auto-incremented integers |
 
   <Warning>
-    Do not use colons (`:`) in node `id` values. BloodHound does not fully support colons in OpenGraph object IDs, which causes node-type filtering issues in [Search and Pathfinding](/analyze-data/explore/search).
+    Do not use colons (`:`) in node `id` values. BloodHound does not fully support colons in OpenGraph object IDs.
   </Warning>
 </ResponseField>
 <ResponseField name="kinds" type="array" required>

--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -4,8 +4,6 @@ sidebarTitle: FAQ
 description: "The following are common questions about OpenGraph"
 ---
 
-import SearchIssueWarning from '/snippets/opengraph/search-issue.mdx';
-
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 <AccordionGroup>
@@ -58,10 +56,14 @@ All forms of OpenGraph data support Cypher querying in general.
 </Note>
 
 </Accordion>
-<Accordion title="Why does Search or Pathfinding fail for a known node?">
-If **Search** or **Pathfinding** behaves unexpectedly for a node you know exists, check the node `id` first.
+<Accordion title="Why do nodes disappear when using Search or Pathfinding?">
+This usually happens when a node's object ID contains a colon (`:`).
 
-<SearchIssueWarning method="Search and Pathfinding" />
+Colons are not currently supported in object IDs in BloodHound.
+
+- You cannot enter an object ID that contains a colon in the **Search** bar.
+- You can still select a node by name, even when its object ID contains a colon.
+- If you select a node by name, **Search** or **Pathfinding** can complete, but the node disappears from the search bar afterward.
 
 To avoid this issue, use OpenGraph node IDs that do not contain colons.
 </Accordion>

--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -4,6 +4,8 @@ sidebarTitle: FAQ
 description: "The following are common questions about OpenGraph"
 ---
 
+import SearchIssueWarning from '/snippets/opengraph/search-issue.mdx';
+
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 <AccordionGroup>
@@ -50,6 +52,8 @@ Yes! BloodHound supports **Search** and **Pathfinding** for [_structured_](/open
 For [_generic_](/opengraph/extensions/manage#generic-graphs) graphs, only **Search** is supported.
 
 Pathfinding, findings, and analysis require traversable relationship kinds defined in an extension definition schema. Generic graph data does not define traversability and is treated as non-traversable.
+
+<SearchIssueWarning method="Search and Pathfinding" />
 
 <Note>
 All forms of OpenGraph data support Cypher querying in general.

--- a/docs/opengraph/faq.mdx
+++ b/docs/opengraph/faq.mdx
@@ -53,12 +53,17 @@ For [_generic_](/opengraph/extensions/manage#generic-graphs) graphs, only **Sear
 
 Pathfinding, findings, and analysis require traversable relationship kinds defined in an extension definition schema. Generic graph data does not define traversability and is treated as non-traversable.
 
-<SearchIssueWarning method="Search and Pathfinding" />
-
 <Note>
 All forms of OpenGraph data support Cypher querying in general.
 </Note>
 
+</Accordion>
+<Accordion title="Why does Search or Pathfinding fail for a known node?">
+If **Search** or **Pathfinding** behaves unexpectedly for a node you know exists, check the node `id` first.
+
+<SearchIssueWarning method="Search and Pathfinding" />
+
+To avoid this issue, use OpenGraph node IDs that do not contain colons.
 </Accordion>
 <Accordion title="How can I add my project to the OpenGraph library?">
 Have you built a cool project using OpenGraph and want it featured here? Already got your project in the list and need to update something? Open a ["Library Change" issue](https://github.com/SpecterOps/bloodhound-docs/issues) on the BloodHound Docs repo and we'll get it added for you!

--- a/docs/snippets/opengraph/search-issue.mdx
+++ b/docs/snippets/opengraph/search-issue.mdx
@@ -1,3 +1,5 @@
 <Warning>
-  OpenGraph node [IDs](/opengraph/developer/nodes#param-id) that contain a colon (`:`) are not fully supported. **{method}** interprets all text _before_ a colon as a node-type filter, which can clear the input or interfere with returning the expected results.
+  OpenGraph node [IDs](/opengraph/developer/nodes#param-id) that contain a colon (`:`) are not fully supported. **{method}** interprets all text _before_ a colon as a [node-type filter](/analyze-data/explore/search#filter-by-node-type).
+  
+  Any ID that contains a colon will have part of the ID dropped, resulting in an unrecognized ID. This can clear the input or interfere with returning the expected results.
 </Warning>

--- a/docs/snippets/opengraph/search-issue.mdx
+++ b/docs/snippets/opengraph/search-issue.mdx
@@ -1,0 +1,3 @@
+<Warning>
+  OpenGraph node [IDs](/opengraph/developer/nodes#param-id) that contain a colon (`:`) are not fully supported. **{method}** interprets all text _before_ a colon as a node-type filter, which can clear the input or interfere with returning the expected results.
+</Warning>

--- a/docs/snippets/opengraph/search-issue.mdx
+++ b/docs/snippets/opengraph/search-issue.mdx
@@ -1,5 +1,5 @@
 <Warning>
-  OpenGraph node [IDs](/opengraph/developer/nodes#param-id) that contain a colon (`:`) are not fully supported. **{method}** interprets all text _before_ a colon as a [node-type filter](/analyze-data/explore/search#filter-by-node-type).
+  OpenGraph node [IDs](/opengraph/developer/nodes#param-id) that contain a colon (`:`) are not supported. **{method}** interprets all text _before_ a colon as a [node-type filter](/analyze-data/explore/search#filter-by-node-type).
   
   Any ID that contains a colon will have part of the ID dropped, resulting in an unrecognized ID. This can clear the input or interfere with returning the expected results.
 </Warning>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added warnings explaining that OpenGraph node IDs containing colons (`:`) aren’t fully supported for Search and Pathfinding
  * Updated guidance clarifying how colon-containing values can affect search behavior (including nodes disappearing)
  * Added troubleshooting and FAQ content to help diagnose and resolve unexpected Search/Pathfinding results
  * Improved Search/Pathfinding callouts and reordered an ETAC-related note within the guidance page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Staging

- https://specterops-bp-2696-colons-in-objectids.mintlify.app/opengraph/developer/nodes#param-id
- https://specterops-bp-2696-colons-in-objectids.mintlify.app/analyze-data/explore/search#search
- https://specterops-bp-2696-colons-in-objectids.mintlify.app/analyze-data/explore/search#pathfinding