### PR TITLE
GH-316: Add ClusterHound

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -393,8 +393,8 @@ The collector is compatible with SpecterOps's [OpenGraph extension for Jamf](/op
 ClusterHound brings Kubernetes into BloodHound CE. It collects a cluster's topology and RBAC configuration with kubectl and outputs an OpenGraph JSON file for ingestion, turning multi-hop Kubernetes attack paths (service-account assumption, privilege escalation, host escape, and secret access) into traversable edges you can pathfind across and visualize.
 
 **Authors/Maintainers**
-- [Nathan Dove](https://www.linkedin.com/in/nathan-dove/)
-- [Josh Hickling](https://www.linkedin.com/in/joshua-hickling/)
+- [Nathan Dove](https://www.linkedin.com/in/nathan-dove/) @[KPMG UK](https://kpmg.com/uk/en.html)
+- [Josh Hickling](https://www.linkedin.com/in/joshua-hickling/) @[KPMG UK](https://kpmg.com/uk/en.html)
 
 **Repo**
 - https://github.com/dovesec/ClusterHound

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -384,6 +384,22 @@ The collector is compatible with SpecterOps's [OpenGraph extension for Jamf](/op
 - https://github.com/SpecterOps/openhound-jamf
 
 </Accordion>
+<Accordion title="Kubernetes" icon="people-group">
+
+#### <Icon icon="people-group" size={22}/> ClusterHound
+
+**Description**
+
+ClusterHound brings Kubernetes into BloodHound CE. It collects a cluster's topology and RBAC configuration with kubectl and outputs an OpenGraph JSON file for ingestion, turning multi-hop Kubernetes attack paths (service-account assumption, privilege escalation, host escape, and secret access) into traversable edges you can pathfind across and visualize.
+
+**Authors/Maintainers**
+- [Nathan Dove](https://www.linkedin.com/in/nathan-dove/)
+- [Josh Hickling](https://www.linkedin.com/in/joshua-hickling/)
+
+**Repo**
+- https://github.com/dovesec/ClusterHound
+
+</Accordion>
 <Accordion title="Microsoft Exchange" icon="people-group">
 
 #### <Icon icon="people-group" size={22}/> ExchangeHound


### PR DESCRIPTION
Closes #316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Kubernetes section to the project library featuring the ClusterHound project entry, complete with project description, maintainer details, and direct repository link for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->