### PR TITLE
Make okta and jamf properties snake_case

### DIFF
--- a/docs/opengraph/extensions/jamf/nodes/jamf_account.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_account.mdx
@@ -59,19 +59,19 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | Property Name | Data Type | Description |
 |---|---|---|
 | displayname | string | Full name of the account holder |
-| privilegeSet | string | Privilege set assigned (Administrator, Custom, etc.) |
+| privilege_set | string | Privilege set assigned (Administrator, Custom, etc.) |
 | objectid | string | Unique identifier for the Account |
 | name | string | Username of the account |
 | email | string | Email address associated with the account |
-| siteID | integer | ID of the site the account is assigned to |
-| accessLevel | string | Access level (Full Access, Site Access, Group Access) |
+| site_id | integer | ID of the site the account is assigned to |
+| access_level | string | Access level (Full Access, Site Access, Group Access) |
 | enabled | string | Whether the account is enabled |
-| Tier | integer | Security tier classification (0 for administrators) |
-| localAccount | boolean | Whether this is a local Jamf account (not directory) |
-| privilegesJSSObjects | string[] | JSS Object permissions granted to the account |
-| privilegesJSSActions | string[] | JSS Action permissions granted |
-| privilegesJSSOSettings | string[] | JSS Settings permissions granted |
-| Groups | integer | Group assignment indicator |
+| tier | integer | Security tier classification (0 for administrators) |
+| local_account | boolean | Whether this is a local Jamf account (not directory) |
+| privileges_jss_objects | string[] | JSS Object permissions granted to the account |
+| privileges_jss_actions | string[] | JSS Action permissions granted |
+| privileges_jss_settings | string[] | JSS Settings permissions granted |
+| groups | integer | Group assignment indicator |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_apiclient.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_apiclient.mdx
@@ -50,12 +50,12 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 
 | Property Name | Data Type | Description |
 |---|---|---|
-| displayName | string | Display name of the API client |
+| display_name | string | Display name of the API client |
 | name | string | Name of the API client |
 | enabled | boolean | Whether the API client is enabled |
-| authorizationScopes | string[] | API roles assigned to this client |
+| authorization_scopes | string[] | API roles assigned to this client |
 | privileges | string[] | Resolved list of all privileges from assigned roles |
-| Tier | integer | Security tier classification |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_computer.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_computer.mdx
@@ -51,7 +51,7 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | user_approved_enrollment | boolean | Whether enrollment was user-approved |
 | user_approved_mdm | boolean | Whether MDM was user-approved |
 | device_aad_infos | string | Azure AD device information |
-| siteID | integer | ID of the site the computer belongs to |
+| site_id | integer | ID of the site the computer belongs to |
 | sitename | string | Name of the site |
 | username | string | Assigned username |
 | email_address | string | Assigned user email |
@@ -71,7 +71,7 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | jamf_version | string | Jamf agent version |
 | filevault2_users | string | FileVault 2 enabled users |
 | local_accounts | string | Local user accounts |
-| Tier | integer | Security tier classification |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_computeruser.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_computeruser.mdx
@@ -43,7 +43,7 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | email | string | Email address of the user |
 | objectid | string | Unique identifier for the Computer User |
 | computer | string | ID of the computer this user is assigned to |
-| Tier | integer | Security tier classification |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_disabledaccount.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_disabledaccount.mdx
@@ -61,19 +61,19 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | Property Name | Data Type | Description |
 |---|---|---|
 | displayname | string | Full name of the account holder |
-| privilegeSet | string | Privilege set assigned (Administrator, Custom, etc.) |
+| privilege_set | string | Privilege set assigned (Administrator, Custom, etc.) |
 | objectid | string | Unique identifier for the Account |
 | name | string | Username of the account |
 | email | string | Email address associated with the account |
-| siteID | integer | ID of the site the account is assigned to |
-| accessLevel | string | Access level (Full Access, Site Access, Group Access) |
+| site_id | integer | ID of the site the account is assigned to |
+| access_level | string | Access level (Full Access, Site Access, Group Access) |
 | enabled | string | Whether the account is enabled (always "Disabled") |
-| Tier | integer | Security tier classification (0 for administrators) |
-| localAccount | boolean | Whether this is a local Jamf account (not directory) |
-| privilegesJSSObjects | string[] | JSS Object permissions granted to the account |
-| privilegesJSSActions | string[] | JSS Action permissions granted |
-| privilegesJSSOSettings | string[] | JSS Settings permissions granted |
-| Groups | integer | Group assignment indicator |
+| tier | integer | Security tier classification (0 for administrators) |
+| local_account | boolean | Whether this is a local Jamf account (not directory) |
+| privileges_jss_objects | string[] | JSS Object permissions granted to the account |
+| privileges_jss_actions | string[] | JSS Action permissions granted |
+| privileges_jss_settings | string[] | JSS Settings permissions granted |
+| groups | integer | Group assignment indicator |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_disabledapiclient.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_disabledapiclient.mdx
@@ -52,12 +52,12 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 
 | Property Name | Data Type | Description |
 |---|---|---|
-| displayName | string | Display name of the API client |
+| display_name | string | Display name of the API client |
 | name | string | Name of the API client |
 | enabled | boolean | Whether the API client is enabled (always false) |
-| authorizationScopes | string[] | API roles assigned to this client |
+| authorization_scopes | string[] | API roles assigned to this client |
 | privileges | string[] | Resolved list of all privileges from assigned roles |
-| Tier | integer | Security tier classification |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_group.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_group.mdx
@@ -55,15 +55,15 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | Property Name | Data Type | Description |
 |---|---|---|
 | displayname | string | Display name of the group |
-| privilegeSet | string | Privilege set assigned (Administrator, Custom, etc.) |
+| privilege_set | string | Privilege set assigned (Administrator, Custom, etc.) |
 | objectid | string | Unique identifier for the Group |
 | name | string | Name of the group |
-| siteID | integer | ID of the site the group is assigned to |
-| accessLevel | string | Access level (Full Access, Site Access) |
-| Tier | integer | Security tier classification (0 for administrator groups) |
-| privilegesJSSObjects | string[] | JSS Object permissions granted to the group |
-| privilegesJSSActions | string[] | JSS Action permissions granted |
-| privilegesJSSOSettings | string[] | JSS Settings permissions granted |
+| site_id | integer | ID of the site the group is assigned to |
+| access_level | string | Access level (Full Access, Site Access) |
+| tier | integer | Security tier classification (0 for administrator groups) |
+| privileges_jss_objects | string[] | JSS Object permissions granted to the group |
+| privileges_jss_actions | string[] | JSS Action permissions granted |
+| privileges_jss_settings | string[] | JSS Settings permissions granted |
 | members | string | Serialized list of group members |
 
 ## Relationship Diagram

--- a/docs/opengraph/extensions/jamf/nodes/jamf_site.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_site.mdx
@@ -38,8 +38,8 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | name | string | Name of the site |
 | objectid | string | Unique identifier for the Site |
 | displayname | string | Display name of the site |
-| siteID | integer | Jamf site ID |
-| Tier | integer | Security tier classification |
+| site_id | integer | Jamf site ID |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_ssointegration.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_ssointegration.mdx
@@ -35,16 +35,16 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 
 | Property Name | Data Type | Description |
 |---|---|---|
-| ssoEnabled | boolean | Whether SSO is enabled |
-| idpUrl | string | Identity Provider URL |
-| idpProviderType | string | Type of identity provider |
-| entityId | string | SAML entity ID |
-| groupAttributeName | string | Attribute name for group mapping |
-| groupRdnKey | string | RDN key for group lookups |
-| siteID | string | Site ID (always "-1" for global) |
-| Tier | integer | Security tier classification (0) |
+| sso_enabled | boolean | Whether SSO is enabled |
+| idp_url | string | Identity Provider URL |
+| idp_provider_type | string | Type of identity provider |
+| entity_id | string | SAML entity ID |
+| group_attribute_name | string | Attribute name for group mapping |
+| group_rdn_key | string | RDN key for group lookups |
+| site_id | string | Site ID (always "-1" for global) |
+| tier | integer | Security tier classification (0) |
 | name | string | Name of the SSO integration |
-| enrollmentSsoConfig | string | Enrollment SSO configuration |
+| enrollment_sso_config | string | Enrollment SSO configuration |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/nodes/jamf_tenant.mdx
+++ b/docs/opengraph/extensions/jamf/nodes/jamf_tenant.mdx
@@ -53,7 +53,7 @@ The tables below list edges defined by the Jamf extension only. Additional edges
 | type | string | Hosting type (cloud-hosted or on-premesis) |
 | objectid | string | Unique identifier matching the tenant name |
 | displayname | string | Display name of the Tenant |
-| Tier | integer | Security tier classification |
+| tier | integer | Security tier classification |
 
 ## Relationship Diagram
 

--- a/docs/opengraph/extensions/jamf/queries.mdx
+++ b/docs/opengraph/extensions/jamf/queries.mdx
@@ -152,7 +152,7 @@ Expand the graph by one edge showing nodes with edges to Tier 1 nodes with edges
 
 ```cypher
 MATCH p=(a) - [] -> (s)-[r]->(t)
-WHERE s.Tier = 1 AND t.Tier = 0
+WHERE s.tier = 1 AND t.tier = 0
 AND type(r) <> 'jamf_Contains'
 RETURN p
 LIMIT 1000
@@ -220,7 +220,7 @@ Retrieve attack paths between Tier 1 nodes and Tier 0 nodes that are fully trave
 
 ```cypher
 MATCH p=(s)-[r*1..5]->(t)
-WHERE s.Tier = 1 AND t.Tier = 0
+WHERE s.tier = 1 AND t.tier = 0
 AND s.primarykind <> 'jamf_Tenant'
 AND s.primarykind <> 'jamf_Site'
 AND r.traversable = True
@@ -236,7 +236,7 @@ Retrieve direct edges between Tier 1 nodes and Tier 0 nodes
 
 ```cypher
 MATCH p=(s)-[]->(t)
-WHERE s.Tier = 1 AND t.Tier = 0
+WHERE s.tier = 1 AND t.tier = 0
 RETURN p
 LIMIT 1000
 ```
@@ -249,7 +249,7 @@ Filter out jamf_Contains edges from Tiered node query
 
 ```cypher
 MATCH p=(s)-[r]->(t)
-WHERE s.Tier = 1 AND t.Tier = 0
+WHERE s.tier = 1 AND t.tier = 0
 AND type(r) <> 'jamf_Contains'
 RETURN p
 LIMIT 1000

--- a/docs/opengraph/extensions/okta/nodes/okta_agent.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_agent.mdx
@@ -37,28 +37,28 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `agent.id` | `string` | Unique agent identifier. |
 | `name` | `agent.name` | `string` | Agent name shown in Okta Admin Console. |
-| `displayName` | `agent.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the agent exists. |
-| `poolName` | `agentPool.name` | `string` | Name of the parent [Okta_AgentPool](/opengraph/extensions/okta/nodes/okta_agentpool). For AD pools this typically corresponds to the synced AD domain. |
-| `operationalStatus` | `agent.operationalStatus` | `string` | Runtime health/operational state reported by Okta. |
-| `updateStatus` | `agent.updateStatus` | `string` | Agent software update state. |
+| `display_name` | `agent.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the agent exists. |
+| `pool_name` | `agentPool.name` | `string` | Name of the parent [Okta_AgentPool](/opengraph/extensions/okta/nodes/okta_agentpool). For AD pools this typically corresponds to the synced AD domain. |
+| `operational_status` | `agent.operationalStatus` | `string` | Runtime health/operational state reported by Okta. |
+| `update_status` | `agent.updateStatus` | `string` | Agent software update state. |
 | `type` | `agent.type` | `string` | Agent type (for example AD, LDAP, IWA, or RADIUS). |
 | `version` | `agent.version` | `string` | Agent software version. |
-| `poolId` | `agent.poolId` | `string` | Identifier of the parent Okta agent pool. |
-| `lastConnection` | `FromUnixTime(agent.lastConnection)` | `datetime` | Timestamp of the last successful agent connection to Okta. |
+| `pool_id` | `agent.poolId` | `string` | Identifier of the parent Okta agent pool. |
+| `last_connection` | `FromUnixTime(agent.lastConnection)` | `datetime` | Timestamp of the last successful agent connection to Okta. |
 
 ## Sample Property Values
 
 ```yaml
 id: a53xfufl4rqWcHhQo697
 name: LON-SRV01
-displayName: LON-SRV01
-poolId: 0oaxg9rhdd7ncGCXv697
-oktaDomain: contoso.okta.com
-poolName: contoso.local
-operationalStatus: DISRUPTED
-updateStatus: Cancelled
+display_name: LON-SRV01
+pool_id: 0oaxg9rhdd7ncGCXv697
+okta_domain: contoso.okta.com
+pool_name: contoso.local
+operational_status: DISRUPTED
+update_status: Cancelled
 type: AD
 version: 3.22.0
-lastConnection: 2026-01-15T02:29:40+00:00
+last_connection: 2026-01-15T02:29:40+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_agentpool.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_agentpool.mdx
@@ -50,9 +50,9 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `agentPool.id + "_pool"` | `string` | Unique agent pool identifier. |
 | `name` | `agentPool.name` | `string` | Name of the Okta agent pool. |
-| `displayName` | `agentPool.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the agent pool exists. |
-| `operationalStatus` | `agentPool.operationalStatus` | `string` | Current health/operational state of the agent pool. |
+| `display_name` | `agentPool.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the agent pool exists. |
+| `operational_status` | `agentPool.operationalStatus` | `string` | Current health/operational state of the agent pool. |
 | `type` | `agentPool.type` | `string` | Agent pool type (for example AD, LDAP, IWA, RADIUS). |
 
 <Info>
@@ -64,8 +64,8 @@ The `_pool` suffix is therefore added to the `id` property of `Okta_AgentPool` n
 ```yaml
 id: 0oaxg9rhdd7ncGCXv697_pool
 name: contoso.local
-displayName: contoso.local
-oktaDomain: contoso.okta.com
-operationalStatus: DISRUPTED
+display_name: contoso.local
+okta_domain: contoso.okta.com
+operational_status: DISRUPTED
 type: AD
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_apiserviceintegration.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_apiserviceintegration.mdx
@@ -49,21 +49,21 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `service.id` | `string` | Unique API service integration identifier. |
 | `name` | `service.name` | `string` | Name of the API service integration in Okta. |
-| `displayName` | `service.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the integration exists. |
-| `appType` | `service.type` | `string` | Integration/application type identifier. |
-| `oauthScopes` | `service.grantedScopes` | `string[]` | OAuth 2.0 scopes granted to the integration. |
-| `createdAt` | `service.createdAt` | `datetime` | Timestamp when the integration was created. |
+| `display_name` | `service.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the integration exists. |
+| `app_type` | `service.type` | `string` | Integration/application type identifier. |
+| `oauth_scopes` | `service.grantedScopes` | `string[]` | OAuth 2.0 scopes granted to the integration. |
+| `created_at` | `service.createdAt` | `datetime` | Timestamp when the integration was created. |
 
 ## Sample Property Values
 
 ```yaml
 id: 0oaz7jy5f2oXnvtmN697
 name: Falcon Shield
-displayName: Falcon Shield
-oktaDomain: contoso.okta.com
-appType: falconshieldapiservice
-oauthScopes:
+display_name: Falcon Shield
+okta_domain: contoso.okta.com
+app_type: falconshieldapiservice
+oauth_scopes:
   - okta.users.read
   - okta.oauthIntegrations.read
   - okta.threatInsights.read
@@ -79,7 +79,7 @@ oauthScopes:
   - okta.policies.read
   - okta.networkZones.read
   - okta.features.read
-createdAt: 2026-01-15T12:25:42.000Z
+created_at: 2026-01-15T12:25:42.000Z
 ```
 
 ## Integration OAuth 2.0 Scopes

--- a/docs/opengraph/extensions/okta/nodes/okta_apitoken.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_apitoken.mdx
@@ -37,28 +37,28 @@ No inbound edges are defined by the Okta extension for this node.
 | ---- | ------ | ---- | ----------- |
 | `id` | `apiToken.id` | `string` | Unique API token identifier. |
 | `name` | `apiToken.name` | `string` | Friendly name of the API token. |
-| `displayName` | `apiToken.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the token exists. |
-| `userId` | `apiToken.userId` | `string` | ID of the Okta user that owns the token. |
-| `clientName` | `apiToken.clientName` | `string` | Client/application name associated with the token. |
+| `display_name` | `apiToken.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the token exists. |
+| `user_id` | `apiToken.userId` | `string` | ID of the Okta user that owns the token. |
+| `client_name` | `apiToken.clientName` | `string` | Client/application name associated with the token. |
 | `created` | `apiToken.created` | `datetime` | Token creation timestamp. |
-| `lastUpdated` | `apiToken.lastUpdated` | `datetime` | Last update timestamp of token metadata. |
-| `expiresAt` | `apiToken.expiresAt` | `datetime` | Token expiration timestamp. |
-| `networkConnection` | `apiToken.network.connection` | `string` | Network connection restriction for token usage. |
-| `tokenWindow` | `ToTimeSpan(apiToken.tokenWindow)` | `duration` | Inactivity window converted to `TimeSpan` when present. |
+| `last_updated` | `apiToken.lastUpdated` | `datetime` | Last update timestamp of token metadata. |
+| `expires_at` | `apiToken.expiresAt` | `datetime` | Token expiration timestamp. |
+| `network_connection` | `apiToken.network.connection` | `string` | Network connection restriction for token usage. |
+| `token_window` | `ToTimeSpan(apiToken.tokenWindow)` | `duration` | Inactivity window converted to `TimeSpan` when present. |
 
 ## Sample Property Values
 
 ```yaml
 id: 00T36fk75smeJybKx697
 name: Postman
-displayName: Postman
-oktaDomain: contoso.okta.com
-userId: 00uw0o8iizq37KgKP697
-clientName: Okta API
+display_name: Postman
+okta_domain: contoso.okta.com
+user_id: 00uw0o8iizq37KgKP697
+client_name: Okta API
 created: 2025-10-03T10:08:09+00:00
-lastUpdated: 2026-01-31T20:22:42+00:00
-expiresAt: 2026-03-02T20:22:42+00:00
-networkConnection: ANYWHERE
-tokenWindow: 30.00:00:00
+last_updated: 2026-01-31T20:22:42+00:00
+expires_at: 2026-03-02T20:22:42+00:00
+network_connection: ANYWHERE
+token_window: 30.00:00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_application.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_application.mdx
@@ -70,16 +70,16 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `application.id` | `string` | Unique application identifier. |
 | `name` | `application.label` | `string` | Name/label of the Okta application. |
-| `displayName` | `application.label` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the application exists. |
-| `hasRoleAssignments` | Calculated | `bool` | Indicates whether the application is assigned any administrative roles. |
+| `display_name` | `application.label` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the application exists. |
+| `has_role_assignments` | Calculated | `bool` | Indicates whether the application is assigned any administrative roles. |
 | `created` | `application.created` | `datetime` | Application creation timestamp. |
-| `lastUpdated` | `application.lastUpdated` | `datetime` | Last update timestamp of the app definition. |
+| `last_updated` | `application.lastUpdated` | `datetime` | Last update timestamp of the app definition. |
 | `status` | `application.status` | `string` | Current lifecycle status of the application instance. |
-| `signOnMode` | `application.signOnMode` | `string` | Sign-on protocol mode (for example `OPENID_CONNECT`, `SAML_2_0`, `AUTO_LOGIN`). |
+| `sign_on_mode` | `application.signOnMode` | `string` | Sign-on protocol mode (for example `OPENID_CONNECT`, `SAML_2_0`, `AUTO_LOGIN`). |
 | `features` | `application.features` | `string[]` | Enabled app capabilities such as SCIM provisioning and password push. |
-| `appType` | `application.name` | `string` | App type identifier (for example `office365`, `snowflake`, `githubcloud`). |
-| `userNameMapping` | `application.credentials.userNameTemplate.template` | `string` | Username mapping template used for provisioning/federation. |
+| `app_type` | `application.name` | `string` | App type identifier (for example `office365`, `snowflake`, `githubcloud`). |
+| `user_name_mapping` | `application.credentials.userNameTemplate.template` | `string` | Username mapping template used for provisioning/federation. |
 
 Individual application types may have additional properties specific to the integration or protocol:
 
@@ -87,14 +87,14 @@ Individual application types may have additional properties specific to the inte
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `githubOrg` | `application.settings.app.githubOrg` | `string` | GitHub organization mapped to the integration. |
+| `github_org` | `application.settings.app.githubOrg` | `string` | GitHub organization mapped to the integration. |
 
 ### Google Workspace
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
 | `domain` | `application.settings.app.domain` | `string` | Google Workspace domain associated with the integration. |
-| `afwOnly` | `application.settings.app.afwOnly` | `bool` | App-specific flag indicating constrained integration behavior. |
+| `afw_only` | `application.settings.app.afwOnly` | `bool` | App-specific flag indicating constrained integration behavior. |
 
 ### Jamf Pro SAML
 
@@ -106,65 +106,65 @@ Individual application types may have additional properties specific to the inte
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `namingContext` | `application.settings.app.namingContext` | `string` | Naming context configured for AD-backed app integration. |
-| `filterGroupsByOU` | `application.settings.app.filterGroupsByOU` | `bool` | Whether group filtering by OU is enabled. |
-| `domainSid` | Derived from synced AD user/group SID values (not directly in app object) | `string` | Domain SID associated with AD-backed integration. |
-| `windowsTransportEnabled` | `application.settings.app.windowsTransportEnabled` | `bool` | Indicates if Windows transport is enabled. |
+| `naming_context` | `application.settings.app.namingContext` | `string` | Naming context configured for AD-backed app integration. |
+| `filter_groups_by_ou` | `application.settings.app.filterGroupsByOU` | `bool` | Whether group filtering by OU is enabled. |
+| `domain_sid` | Derived from synced AD user/group SID values (not directly in app object) | `string` | Domain SID associated with AD-backed integration. |
+| `windows_transport_enabled` | `application.settings.app.windowsTransportEnabled` | `bool` | Indicates if Windows transport is enabled. |
 
 ### Generic SAML Application
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
 | `url` | `application.settings.signOn.ssoAcsUrl` (SAML 2.0) / `application.settings.signOn.ssoAcsUrlOverride` (SAML 1.1) | `string` | Primary sign-on URL exposed for SAML applications. |
-| `entityID` | `application.settings.signOn.destination` / `application.settings.signOn.audience` | `string` | SAML Entity ID for SAML integrations. |
-| `acsURL` | `application.settings.signOn.ssoAcsUrl` | `string` | Assertion Consumer Service (ACS) URL for SAML integrations. |
-| `wsFedConfigureType` | `application.settings.app.wsFedConfigureType` | `string` | WS-Federation configuration mode. |
+| `entity_id` | `application.settings.signOn.destination` / `application.settings.signOn.audience` | `string` | SAML Entity ID for SAML integrations. |
+| `acs_url` | `application.settings.signOn.ssoAcsUrl` | `string` | Assertion Consumer Service (ACS) URL for SAML integrations. |
+| `ws_fed_configure_type` | `application.settings.app.wsFedConfigureType` | `string` | WS-Federation configuration mode. |
 
 ### Generic OIDC Service Application
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `clientType` | `application.settings.oauthClient.applicationType` | `string` | OIDC client type (for example `web`, `native`, `browser`, `service`). |
-| `grantTypes` | `application.settings.oauthClient.grantTypes[]` | `string[]` | OAuth 2.0 grant types allowed for OIDC apps. |
-| `redirectURI` | `application.settings.oauthClient.redirectUris[]` | `string` | OIDC redirect URI configured for the integration. |
-| `initiateLoginURI` | `application.settings.oauthClient.initiateLoginUri` | `string` | Okta-initiated login URI for supported OIDC apps. |
-| `url` | Derived from OIDC sign-in URL preference (`initiateLoginUri` first, otherwise first `redirectUris[]`) | `string` | Primary sign-in URL for OIDC applications. |
-| `oauthScopes` | Derived from app grants in `PopulateOAuthScopes` / grant collection logic | `string[]` | OAuth scopes granted to the application in Okta. |
+| `client_type` | `application.settings.oauthClient.applicationType` | `string` | OIDC client type (for example `web`, `native`, `browser`, `service`). |
+| `grant_types` | `application.settings.oauthClient.grantTypes[]` | `string[]` | OAuth 2.0 grant types allowed for OIDC apps. |
+| `redirect_uri` | `application.settings.oauthClient.redirectUris[]` | `string` | OIDC redirect URI configured for the integration. |
+| `initiate_login_uri` | `application.settings.oauthClient.initiateLoginUri` | `string` | Okta-initiated login URI for supported OIDC apps. |
+| `url` | Derived from OIDC sign-in URL preference (`initiate_login_uri` first, otherwise first `redirect_uri`) | `string` | Primary sign-in URL for OIDC applications. |
+| `oauth_scopes` | Derived from app grants in `PopulateOAuthScopes` / grant collection logic | `string[]` | OAuth scopes granted to the application in Okta. |
 | `domain` | `application.settings.app.domain` | `string` | Directory or service domain associated with the app integration. |
 | `domains` | `application.settings.app.domains` | `string[]` | Domain list associated with the app integration when provided. |
-| `serviceDomain` | `application.settings.app.serviceDomain` | `string` | Service/API domain used by workflow or API-connected apps. |
-| `subDomain` | `application.settings.app.subDomain` | `string` | Subdomain value used by app-specific integrations. |
-| `regionType` | `application.settings.app.regionType` | `string` | Region suffix/type used by the app integration. |
+| `service_domain` | `application.settings.app.serviceDomain` | `string` | Service/API domain used by workflow or API-connected apps. |
+| `sub_domain` | `application.settings.app.subDomain` | `string` | Subdomain value used by app-specific integrations. |
+| `region_type` | `application.settings.app.regionType` | `string` | Region suffix/type used by the app integration. |
 
 ### Microsoft Entra ID External Authentication
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `microsoftDiscoveryEndpoint` | `application.settings.app.microsoftDiscoveryEndpoint` | `string` | OIDC discovery endpoint used by Microsoft integrations. |
-| `microsoftAppId` | `application.settings.app.microsoftAppId` | `string` | Microsoft application/client ID configured in the integration. |
-| `microsoftTenantId` | `application.settings.app.microsoftTenantId` | `string` | Microsoft Entra tenant GUID associated with the app integration. |
-| `requireAdminConsent` | `application.settings.app.requireAdminConsent` | `bool` | Indicates if Microsoft admin consent is required. |
+| `microsoft_discovery_endpoint` | `application.settings.app.microsoftDiscoveryEndpoint` | `string` | OIDC discovery endpoint used by Microsoft integrations. |
+| `microsoft_app_id` | `application.settings.app.microsoftAppId` | `string` | Microsoft application/client ID configured in the integration. |
+| `microsoft_tenant_id` | `application.settings.app.microsoftTenantId` | `string` | Microsoft Entra tenant GUID associated with the app integration. |
+| `require_admin_consent` | `application.settings.app.requireAdminConsent` | `bool` | Indicates if Microsoft admin consent is required. |
 
 ### Microsoft Office 365
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `msftTenant` | `application.settings.app.msftTenant` | `string` | Microsoft tenant short name/domain used by the Office 365 integration. |
-| `microsoftTenantId` | Calculated from `msftTenant` | `string` | Microsoft Entra tenant GUID resolved from the Office 365 onmicrosoft tenant. |
+| `msft_tenant` | `application.settings.app.msftTenant` | `string` | Microsoft tenant short name/domain used by the Office 365 integration. |
+| `microsoft_tenant_id` | Calculated from `msft_tenant` | `string` | Microsoft Entra tenant GUID resolved from the Office 365 onmicrosoft tenant. |
 
 ### Generic SWA / Browser Plugin Application
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `loginURL` | `application.settings.app.loginUrl` | `string` | App login URL used by SWA/browser plugin configurations. |
+| `login_url` | `application.settings.app.loginUrl` | `string` | App login URL used by SWA/browser plugin configurations. |
 | `url` | `application.settings.signOn.loginUrl` (AutoLogin) / `application.settings.app.url` (BrowserPlugin/BasicAuth/Bookmark/SPS) | `string` | Primary login URL exposed for SWA and related app types. |
-| `appFilter` | `application.settings.app.appFilter` | `string` | App-side filter expression value. |
-| `groupFilter` | `application.settings.app.groupFilter` | `string` | Group filter pattern used for provisioning/mapping. |
-| `useGroupMapping` | `application.settings.app.useGroupMapping` | `bool` | Whether group mapping is enabled for integration. |
-| `joinAllRoles` | `application.settings.app.joinAllRoles` | `bool` | Whether all discovered roles are joined/collected. |
-| `roleValuePattern` | `application.settings.app.roleValuePattern` | `string` | Role mapping pattern template for AWS role federation. |
-| `awsEnvironmentType` | `application.settings.app.awsEnvironmentType` | `string` | AWS environment identifier for AWS app integrations. |
-| `sessionDuration` | `application.settings.app.sessionDuration` | `integer` | Session duration setting (seconds) for supported app integrations. |
+| `app_filter` | `application.settings.app.appFilter` | `string` | App-side filter expression value. |
+| `group_filter` | `application.settings.app.groupFilter` | `string` | Group filter pattern used for provisioning/mapping. |
+| `use_group_mapping` | `application.settings.app.useGroupMapping` | `bool` | Whether group mapping is enabled for integration. |
+| `join_all_roles` | `application.settings.app.joinAllRoles` | `bool` | Whether all discovered roles are joined/collected. |
+| `role_value_pattern` | `application.settings.app.roleValuePattern` | `string` | Role mapping pattern template for AWS role federation. |
+| `aws_environment_type` | `application.settings.app.awsEnvironmentType` | `string` | AWS environment identifier for AWS app integrations. |
+| `session_duration` | `application.settings.app.sessionDuration` | `integer` | Session duration setting (seconds) for supported app integrations. |
 
 ## Sample Property Values
 
@@ -173,54 +173,54 @@ Individual application types may have additional properties specific to the inte
 ```yaml
 id: 0oawyp12cjglrkfId697
 name: Github Contoso
-appType: githubcloud
-displayName: Github Contoso
+app_type: githubcloud
+display_name: Github Contoso
 features: []
-githubOrg: Contoso
-hasRoleAssignments: false
-oktaDomain: contoso.okta.com
-signOnMode: SAML_2_0
+github_org: Contoso
+has_role_assignments: false
+okta_domain: contoso.okta.com
+sign_on_mode: SAML_2_0
 status: ACTIVE
-userNameMapping: ${source.login}
+user_name_mapping: ${source.login}
 created: 2025-10-31T06:08:00+00:00
-lastUpdated: 2025-10-31T06:08:01+00:00
+last_updated: 2025-10-31T06:08:01+00:00
 ```
 
 ### Google Workspace
 
 ```yaml
 id: 0oax4r57x0V5NHL2W697
-afwOnly: false
-appType: google
-displayName: Google Workspace
+afw_only: false
+app_type: google
+display_name: Google Workspace
 domain: contoso.com
 features: []
-hasRoleAssignments: false
+has_role_assignments: false
 name: Google Workspace
-oktaDomain: contoso.okta.com
-signOnMode: SAML_2_0
+okta_domain: contoso.okta.com
+sign_on_mode: SAML_2_0
 status: ACTIVE
-userNameMapping: ${source.login}
+user_name_mapping: ${source.login}
 created: 2025-11-05T09:06:48+00:00
-lastUpdated: 2025-11-05T09:07:21+00:00
+last_updated: 2025-11-05T09:07:21+00:00
 ```
 
 ### Jamf Pro SAML
 
 ```yaml
 id: 0oax4r3ud0J2WjlNh697
-appType: jamfsoftwareserver
-displayName: Jamf Pro SAML
+app_type: jamfsoftwareserver
+display_name: Jamf Pro SAML
 domain: contoso.jamfcloud.com
 features: []
-hasRoleAssignments: false
+has_role_assignments: false
 name: Jamf Pro SAML
-oktaDomain: contoso.okta.com
-signOnMode: SAML_2_0
+okta_domain: contoso.okta.com
+sign_on_mode: SAML_2_0
 status: ACTIVE
-userNameMapping: ${source.login}
+user_name_mapping: ${source.login}
 created: 2025-11-05T09:10:52+00:00
-lastUpdated: 2026-01-19T14:33:39+00:00
+last_updated: 2026-01-19T14:33:39+00:00
 ```
 
 ### OktaHound
@@ -228,14 +228,14 @@ lastUpdated: 2026-01-19T14:33:39+00:00
 ```yaml
 id: 0oaw0pujq5WtBiMYD697
 name: OktaHound
-appType: oidc_client
-clientType: service
-displayName: OktaHound
+app_type: oidc_client
+client_type: service
+display_name: OktaHound
 features: []
-grantTypes:
+grant_types:
   - client_credentials
-hasRoleAssignments: true
-oauthScopes:
+has_role_assignments: true
+oauth_scopes:
   - okta.trustedOrigins.read
   - okta.policies.read
   - okta.linkedObjects.read
@@ -279,12 +279,12 @@ oauthScopes:
   - okta.features.read
   - okta.sessions.read
   - okta.userTypes.read
-oktaDomain: integrator-5415459.okta.com
-signOnMode: OPENID_CONNECT
+okta_domain: integrator-5415459.okta.com
+sign_on_mode: OPENID_CONNECT
 status: ACTIVE
-userNameMapping: ${source.login}
+user_name_mapping: ${source.login}
 created: 2025-10-02T10:11:20+00:00
-lastUpdated: 2025-10-02T10:26:27+00:00
+last_updated: 2025-10-02T10:26:27+00:00
 ```
 
 ### Active Directory Integration
@@ -292,22 +292,22 @@ lastUpdated: 2025-10-02T10:26:27+00:00
 ```yaml
 id: 0oaxg9rhdd7ncGCXv697
 name: contoso.local
-appType: active_directory
-displayName: contoso.local
-domainSid: S-1-5-21-71365889-924527929-2677699343
+app_type: active_directory
+display_name: contoso.local
+domain_sid: S-1-5-21-71365889-924527929-2677699343
 features:
   - IMPORT_PROFILE_UPDATES
   - PROFILE_MASTERING
   - OUTBOUND_DEL_AUTH
   - IMPORT_USER_SCHEMA
   - IMPORT_NEW_USERS
-filterGroupsByOU: false
-hasRoleAssignments: false
-namingContext: contoso.local
-oktaDomain: contoso.okta.com
+filter_groups_by_ou: false
+has_role_assignments: false
+naming_context: contoso.local
+okta_domain: contoso.okta.com
 status: ACTIVE
 created: 2025-11-14T12:50:42+00:00
-lastUpdated: 2026-01-31T15:12:24+00:00
+last_updated: 2026-01-31T15:12:24+00:00
 ```
 
 ## User Name Mapping
@@ -418,7 +418,7 @@ When integrating Okta with GitHub Enterprise Cloud, each GitHub organization con
 ### Jamf Pro
 
 When integrating Okta with Jamf Pro using SAML 2.0, each Jamf Pro instance connected to Okta is represented as a separate `Okta_Application` node in BloodHound.
-The differentiator is the `domainFQDN` property:
+The differentiator is the `domain_fqdn` property:
 
 ![Jamf Pro SAML application in BloodHound](/images/extensions/okta/bloodhound-jamf-saml-properties.png)
 
@@ -428,7 +428,7 @@ It is also possible to integrate Jamf Pro with Okta using Secure Web Authenticat
 
 ## Google Workspace
 
-Similarly to the Jamf Pro SAML applications, each Google Workspace (formerly G Suite) instance connected to Okta using SAML 2.0 is represented as a separate `Okta_Application` node in BloodHound and is identified by the `domainFQDN` property:
+Similarly to the Jamf Pro SAML applications, each Google Workspace (formerly G Suite) instance connected to Okta using SAML 2.0 is represented as a separate `Okta_Application` node in BloodHound and is identified by the `domain_fqdn` property:
 
 ![Google Workspace SAML application in BloodHound](/images/extensions/okta/bloodhound-google-saml-properties.png)
 

--- a/docs/opengraph/extensions/okta/nodes/okta_authorizationserver.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_authorizationserver.mdx
@@ -39,28 +39,28 @@ No outbound edges are defined by the Okta extension for this node.
 | ---- | ------ | ---- | ----------- |
 | `id` | `server.id` | `string` | Unique authorization server identifier. |
 | `name` | `server.name` | `string` | Authorization server name. |
-| `displayName` | `server.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the authorization server exists. |
+| `display_name` | `server.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the authorization server exists. |
 | `description` | `server.description` | `string` | Human-readable server description. |
 | `status` | `server.status` | `string` | Current lifecycle status. |
 | `issuer` | `server.issuer` | `string` | Token issuer URL. |
-| `issuerMode` | `server.issuerMode` | `string` | Issuer mode selected in Okta. |
+| `issuer_mode` | `server.issuerMode` | `string` | Issuer mode selected in Okta. |
 | `audiences` | `server.audiences` | `string[]` | Allowed audience values for issued tokens. |
 | `created` | `server.created` | `datetime` | Authorization server creation timestamp. |
-| `lastUpdated` | `server.lastUpdated` | `datetime` | Last update timestamp for the server configuration. |
+| `last_updated` | `server.lastUpdated` | `datetime` | Last update timestamp for the server configuration. |
 
 ## Sample Property Values
 
 ```yaml
 id: ausz6ipkn4u0hDzyf697
 name: app creation
-displayName: app creation
-oktaDomain: contoso.okta.com
+display_name: app creation
+okta_domain: contoso.okta.com
 status: INACTIVE
 issuer: https://contoso.okta.com/oauth2/ausz6ipkn4u0hDzyf697
-issuerMode: DYNAMIC
+issuer_mode: DYNAMIC
 audiences:
   - test
 created: 2026-01-14T15:41:28+00:00
-lastUpdated: 2026-01-14T16:09:30+00:00
+last_updated: 2026-01-14T16:09:30+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_clientsecret.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_clientsecret.mdx
@@ -45,22 +45,22 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `secret.id` | `string` | Unique client secret identifier. |
 | `name` | `secret.secretHash` | `string` | Hash of the secret value used as name/display label. |
-| `displayName` | `secret.secretHash` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the client secret exists. |
+| `display_name` | `secret.secretHash` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the client secret exists. |
 | `status` | `secret.status` | `string` | Current lifecycle status of the secret. |
 | `created` | `secret.created` | `datetime` | Secret creation timestamp. |
-| `lastUpdated` | `secret.lastUpdated` | `datetime` | Last update timestamp for the secret metadata. |
+| `last_updated` | `secret.lastUpdated` | `datetime` | Last update timestamp for the secret metadata. |
 
 ## Sample Property Values
 
 ```yaml
 id: ocsxqwizfyqsf0aVG697
 name: T1e6fl4jGqvPkgd94NKx5g
-displayName: T1e6fl4jGqvPkgd94NKx5g
-oktaDomain: contoso.okta.com
+display_name: T1e6fl4jGqvPkgd94NKx5g
+okta_domain: contoso.okta.com
 status: ACTIVE
 created: 2025-11-24T12:24:08.000Z
-lastUpdated: 2025-11-24T12:24:08.000Z
+last_updated: 2025-11-24T12:24:08.000Z
 ```
 
 <Info>

--- a/docs/opengraph/extensions/okta/nodes/okta_customrole.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_customrole.mdx
@@ -38,21 +38,21 @@ No outbound edges are defined by the Okta extension for this node.
 | ---- | ------ | ---- | ----------- |
 | `id` | `role.id` | `string` | Unique custom role identifier. |
 | `name` | `role.label` | `string` | Name of the custom role. |
-| `displayName` | `role.label` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the custom role exists. |
+| `display_name` | `role.label` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the custom role exists. |
 | `permissions` | `role.permissions` | `string[]` | Effective permission labels associated with the custom role. |
 | `created` | `role.created` | `datetime` | Custom role creation timestamp. |
-| `lastUpdated` | `role.lastUpdated` | `datetime` | Last update timestamp of the role definition. |
+| `last_updated` | `role.lastUpdated` | `datetime` | Last update timestamp of the role definition. |
 
 ## Sample Property Values
 
 ```yaml
 id: cr0wwdjuk0w96MpFr697
 name: IAM Readers
-displayName: IAM Readers
-oktaDomain: contoso.okta.com
+display_name: IAM Readers
+okta_domain: contoso.okta.com
 created: 2025-10-29T12:45:55+00:00
-lastUpdated: 2025-10-30T13:35:36+00:00
+last_updated: 2025-10-30T13:35:36+00:00
 permissions:
   - okta.iam.read
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_device.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_device.mdx
@@ -37,25 +37,25 @@ The tables below list edges defined by the Okta extension only. Additional edges
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `id` | `device.uuid + "@" + oktaDomain` or `device.id` | `string` | Unique device identifier (derived from hardware ID + domain). |
+| `id` | `device.uuid + "@" + okta_domain` or `device.id` | `string` | Unique device identifier (derived from hardware ID + domain). |
 | `name` | `device.resourceDisplayName` | `string` | Device display name from Okta. |
-| `displayName` | `device.resourceDisplayName` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the device exists. |
-| `oktaId` | `device.id` | `string` | Original Okta device identifier (stored for reference). |
+| `display_name` | `device.resourceDisplayName` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the device exists. |
+| `okta_id` | `device.id` | `string` | Original Okta device identifier (stored for reference). |
 | `created` | `device.created` | `datetime` | Device record creation timestamp. |
-| `lastUpdated` | `device.lastUpdated` | `datetime` | Last update timestamp. |
+| `last_updated` | `device.lastUpdated` | `datetime` | Last update timestamp. |
 | `status` | `device.status` | `string` | Device lifecycle/status value. |
-| `resourceType` | `device.resourceType` | `string` | Okta device resource type. |
+| `resource_type` | `device.resourceType` | `string` | Okta device resource type. |
 | `platform` | `device.profile.platform` | `string` | Device platform/OS family. |
 | `manufacturer` | `device.profile.manufacturer` | `string` | Hardware vendor/manufacturer. |
 | `model` | `device.profile.model` | `string` | Device model name. |
-| `osVersion` | `device.profile.osVersion` | `string` | Operating system version. |
+| `os_version` | `device.profile.osVersion` | `string` | Operating system version. |
 | `registered` | `device.profile.registered` | `bool` | Whether the device is registered in Okta. |
-| `secureHardwarePresent` | `device.profile.secureHardwarePresent` | `bool` | Indicates secure hardware support (for example Secure Enclave/TPM). |
-| `jailBreak` | `device.profile.integrityJailbreak` | `bool` | Device jailbreak/root integrity signal. |
+| `secure_hardware_present` | `device.profile.secureHardwarePresent` | `bool` | Indicates secure hardware support (for example Secure Enclave/TPM). |
+| `jail_break` | `device.profile.integrityJailbreak` | `bool` | Device jailbreak/root integrity signal. |
 | `udid` | `device.profile.udid` | `string` | Apple UDID for iOS devices. |
-| `objectSid` | `device.profile.sid` | `string` | SID attribute for Windows/AD-linked devices. |
-| `serialNumber` | `device.profile.serialNumber` | `string` | Device serial number, when provided and non-empty. |
+| `object_sid` | `device.profile.sid` | `string` | SID attribute for Windows/AD-linked devices. |
+| `serial_number` | `device.profile.serialNumber` | `string` | Device serial number, when provided and non-empty. |
 
 ## Sample Property Values
 
@@ -64,23 +64,23 @@ Windows device:
 ```yaml
 id: 4C4C4544-0057-4C10-8057-C8C04F573934@contoso.okta.com
 name: PC01
-displayName: PC01
-oktaDomain: contoso.okta.com
-oktaId: guoxrzqh8jBxYxEeJ697
+display_name: PC01
+okta_domain: contoso.okta.com
+okta_id: guoxrzqh8jBxYxEeJ697
 created: 2025-11-25T11:01:53+00:00
-lastUpdated: 2026-02-17T08:55:45+00:00
+last_updated: 2026-02-17T08:55:45+00:00
 status: ACTIVE
-resourceType: UDDevice
+resource_type: UDDevice
 platform: WINDOWS
 manufacturer: Dell Inc.
 model: XPS 14 9440
-osVersion: 10.0.26200.7623
+os_version: 10.0.26200.7623
 registered: true
-secureHardwarePresent: true
-jailBreak: false
+secure_hardware_present: true
+jail_break: false
 udid: 4C4C4544-0057-4C10-8057-C8C04F573934
-objectSid: S-1-5-21-1084505731-826279434-3585917670
-serialNumber: HWLWW94
+object_sid: S-1-5-21-1084505731-826279434-3585917670
+serial_number: HWLWW94
 ```
 
 iOS device:
@@ -88,18 +88,18 @@ iOS device:
 ```yaml
 id: guowq18eyhZaDlkkA697
 name: John's iPhone
-displayName: John's iPhone
-oktaDomain: contoso.okta.com
-oktaId: guowq18eyhZaDlkkA697
+display_name: John's iPhone
+okta_domain: contoso.okta.com
+okta_id: guowq18eyhZaDlkkA697
 status: ACTIVE
-resourceType: UDDevice
+resource_type: UDDevice
 platform: IOS
 manufacturer: APPLE
 model: iPhone17,1
-osVersion: 18.6.2
+os_version: 18.6.2
 registered: true
-secureHardwarePresent: true
-jailBreak: false
+secure_hardware_present: true
+jail_break: false
 created: 2025-10-23T17:16:46+00:00
-lastUpdated: 2025-10-23T17:16:47+00:00
+last_updated: 2025-10-23T17:16:47+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_group.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_group.mdx
@@ -63,27 +63,27 @@ Standard Okta group properties:
 | ---- | ------ | ---- | ----------- |
 | `id` | `group.id` | `string` | Unique group identifier. |
 | `name` | `group.profile.name` | `string` | Group name in Okta (or synchronized source). |
-| `displayName` | `group.profile.name` | `string` | Display label used in BloodHound. |
+| `display_name` | `group.profile.name` | `string` | Display label used in BloodHound. |
 | `description` | `group.profile.description` | `string` | Group description text. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the group exists. |
-| `hasRoleAssignments` | Calculated | `bool` | Indicates whether the group is assigned any administrative roles. |
-| `oktaGroupType` | `group.type` | `string` | Group type (for example `OKTA_GROUP`, `APP_GROUP`, `BUILT_IN`). |
-| `objectClass` | `group.objectClass[0]` | `string` | Source object class (for example AD security principal). |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the group exists. |
+| `has_role_assignments` | Calculated | `bool` | Indicates whether the group is assigned any administrative roles. |
+| `okta_group_type` | `group.type` | `string` | Group type (for example `OKTA_GROUP`, `APP_GROUP`, `BUILT_IN`). |
+| `object_class` | `group.objectClass[0]` | `string` | Source object class (for example AD security principal). |
 | `created` | `group.created` | `datetime` | Group creation timestamp. |
-| `lastUpdated` | `group.lastUpdated` | `datetime` | Last update timestamp. |
-| `lastMembershipUpdated` | `group.lastMembershipUpdated` | `datetime` | Last membership change timestamp. |
+| `last_updated` | `group.lastUpdated` | `datetime` | Last update timestamp. |
+| `last_membership_updated` | `group.lastMembershipUpdated` | `datetime` | Last membership change timestamp. |
 
 Additional properties of groups synchronized from Active Directory:
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `objectSid` | `group.profile.objectSid` | `string` | Security Identifier (SID) for the AD group. |
-| `distinguishedName` | `group.profile.dn` | `string` | Active Directory distinguished name. |
-| `samAccountName` | `group.profile.samAccountName` | `string` | Security Account Manager (SAM) account name. |
-| `domainQualifiedName` | `group.profile.windowsDomainQualifiedName` | `string` | Domain-qualified name of the AD group. |
-| `groupScope` | `group.profile.groupScope` | `string` | AD group scope (for example global, domainLocal, universal). |
-| `groupType` | `group.profile.groupType` | `string` | AD group type, i.e., security or distribution. |
-| `objectGuid` | `Base64ToGuid(group.profile.externalId)` | `string` | AD object GUID. |
+| `object_sid` | `group.profile.objectSid` | `string` | Security Identifier (SID) for the AD group. |
+| `distinguished_name` | `group.profile.dn` | `string` | Active Directory distinguished name. |
+| `sam_account_name` | `group.profile.samAccountName` | `string` | Security Account Manager (SAM) account name. |
+| `domain_qualified_name` | `group.profile.windowsDomainQualifiedName` | `string` | Domain-qualified name of the AD group. |
+| `group_scope` | `group.profile.groupScope` | `string` | AD group scope (for example global, domainLocal, universal). |
+| `group_type` | `group.profile.groupType` | `string` | AD group type, i.e., security or distribution. |
+| `object_guid` | `Base64ToGuid(group.profile.externalId)` | `string` | AD object GUID. |
 
 ## Sample Property Values
 
@@ -92,15 +92,15 @@ Example of a group created directly in Okta:
 ```yaml
 id: 00gxg12p4kFOkyXLb697
 name: Engineering
-displayName: Engineering
+display_name: Engineering
 description: Engineering department group
-oktaDomain: contoso.okta.com
-hasRoleAssignments: false
-oktaGroupType: OKTA_GROUP
-objectClass: okta:user_group
+okta_domain: contoso.okta.com
+has_role_assignments: false
+okta_group_type: OKTA_GROUP
+object_class: okta:user_group
 created: 2025-11-14T08:00:25+00:00
-lastUpdated: 2025-11-14T08:00:25+00:00
-lastMembershipUpdated: 2025-11-14T08:00:25+00:00
+last_updated: 2025-11-14T08:00:25+00:00
+last_membership_updated: 2025-11-14T08:00:25+00:00
 ```
 
 Example of a group synchronized from Active Directory:
@@ -108,22 +108,22 @@ Example of a group synchronized from Active Directory:
 ```yaml
 id: 00gxga7s3yDJ71OzW697
 name: Sales
-displayName: Sales
+display_name: Sales
 description: Sales department group
-oktaDomain: contoso.okta.com
-hasRoleAssignments: false
-oktaGroupType: APP_GROUP
-objectClass: okta:windows_security_principal
-objectSid: S-1-5-21-71365889-924527929-2677699343-2536
-distinguishedName: CN=Sales,CN=Groups,DC=contoso,DC=local
-samAccountName: Sales
-domainQualifiedName: CONTOSO\Sales
-groupScope: Global
-groupType: Security
-objectGuid: 4ab65ef0-ab82-4017-b5ee-1c20facd4d6a
+okta_domain: contoso.okta.com
+has_role_assignments: false
+okta_group_type: APP_GROUP
+object_class: okta:windows_security_principal
+object_sid: S-1-5-21-71365889-924527929-2677699343-2536
+distinguished_name: CN=Sales,CN=Groups,DC=contoso,DC=local
+sam_account_name: Sales
+domain_qualified_name: CONTOSO\Sales
+group_scope: Global
+group_type: Security
+object_guid: 4ab65ef0-ab82-4017-b5ee-1c20facd4d6a
 created: 2025-11-14T12:58:13+00:00
-lastUpdated: 2025-11-14T13:05:44+00:00
-lastMembershipUpdated: 2025-11-14T12:58:13+00:00
+last_updated: 2025-11-14T13:05:44+00:00
+last_membership_updated: 2025-11-14T12:58:13+00:00
 ```
 
 ## Synchronization with External Directories

--- a/docs/opengraph/extensions/okta/nodes/okta_identityprovider.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_identityprovider.mdx
@@ -47,14 +47,14 @@ These properties are common for all identity provider types:
 | ---- | ------ | ---- | ----------- |
 | `id` | `idp.id` | `string` | Unique identity provider identifier. |
 | `name` | `idp.name` | `string` | Identity provider name. |
-| `displayName` | `idp.name` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the identity provider exists. |
-| `issuerMode` | `idp.issuerMode` | `string` | Issuer mode for the identity provider. |
+| `display_name` | `idp.name` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the identity provider exists. |
+| `issuer_mode` | `idp.issuerMode` | `string` | Issuer mode for the identity provider. |
 | `type` | `idp.type` | `string` | Identity provider category/type. |
 | `enabled` | `idp.status == "ACTIVE"` | `bool` | Whether the IdP is active/enabled. |
-| `autoUserProvisioning` | `idp.policy.provisioning.action == "AUTO"` | `bool` | Whether automatic user provisioning is enabled. |
-| `governedGroupIds` | `idp.policy.provisioning.groups` | `string[]` | Group IDs governed by this IdP provisioning policy. |
-| `protocolType` | `idp.protocol.*.type[0]` | `string` | Protocol configured for authentication through this IdP. |
+| `auto_user_provisioning` | `idp.policy.provisioning.action == "AUTO"` | `bool` | Whether automatic user provisioning is enabled. |
+| `governed_group_ids` | `idp.policy.provisioning.groups` | `string[]` | Group IDs governed by this IdP provisioning policy. |
+| `protocol_type` | `idp.protocol.*.type[0]` | `string` | Protocol configured for authentication through this IdP. |
 | `url` | `idp.protocol.*.endpoints.*.url[0]` | `string` | Primary authorization/SSO endpoint URL for the IdP. |
 | `created` | `idp.created` | `datetime` | IdP creation timestamp. |
 
@@ -62,21 +62,21 @@ Additional properties are provider-specific:
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `entraTenantId` | `TenantIdFromSamlEndpoint(url)` | `string` | Associated Entra tenant ID when identifiable. |
+| `entra_tenant_id` | `TenantIdFromSamlEndpoint(url)` | `string` | Associated Entra tenant ID when identifiable. |
 
 ## Sample Property Values
 
 ```yaml
 id: 0oazpi53t1cRNcPL4697
 name: Microsoft Entra ID
-displayName: Microsoft Entra ID
-oktaDomain: contoso.okta.com
+display_name: Microsoft Entra ID
+okta_domain: contoso.okta.com
 created: 2026-01-31T15:21:37+00:00
-issuerMode: DYNAMIC
+issuer_mode: DYNAMIC
 type: MICROSOFT
 enabled: false
-autoUserProvisioning: true
-governedGroupIds: []
-protocolType: OIDC
+auto_user_provisioning: true
+governed_group_ids: []
+protocol_type: OIDC
 url: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_jwk.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_jwk.mdx
@@ -33,26 +33,26 @@ No inbound edges are defined by the Okta extension for this node.
 | ---- | ------ | ---- | ----------- |
 | `id` | `jwk.id` | `string` | Unique JSON Web Key identifier. |
 | `name` | `jwk.kid` (fallback `jwk.id`) | `string` | Key identifier used as node name. |
-| `displayName` | `jwk.kid` (fallback `jwk.id`) | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the key exists. |
+| `display_name` | `jwk.kid` (fallback `jwk.id`) | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the key exists. |
 | `status` | `jwk.status` | `string` | Current lifecycle status of the key. |
 | `kid` | `jwk.kid` | `string` | JSON Web Key identifier (`kid`). |
 | `kty` | `jwk.kty` | `string` | Key type (`RSA`, `EC`, ...). |
 | `use` | `jwk.use` | `string` | Intended key usage (`sig`, `enc`). |
 | `created` | `jwk.created` | `datetime` | Key creation timestamp. |
-| `lastUpdated` | `jwk.lastUpdated` | `datetime` | Last update timestamp. |
+| `last_updated` | `jwk.lastUpdated` | `datetime` | Last update timestamp. |
 
 ## Sample Property Values
 
 ```yaml
 id: pksw0py294dQ80EdI697
 name: ncxmNARybDrxlemwkrvyphCYQ2VwMG9cxV95jgVziZ4
-displayName: ncxmNARybDrxlemwkrvyphCYQ2VwMG9cxV95jgVziZ4
-oktaDomain: contoso.okta.com
+display_name: ncxmNARybDrxlemwkrvyphCYQ2VwMG9cxV95jgVziZ4
+okta_domain: contoso.okta.com
 status: ACTIVE
 kid: ncxmNARybDrxlemwkrvyphCYQ2VwMG9cxV95jgVziZ4
 kty: RSA
 use: sig
 created: 2025-10-02T10:14:44Z
-lastUpdated: 2025-10-02T10:26:27Z
+last_updated: 2025-10-02T10:26:27Z
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_organization.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_organization.mdx
@@ -35,23 +35,23 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
 | `id` | `settings.id` | `string` | Unique organization identifier. |
-| `name` | `oktaDomain` | `string` | Okta organization domain name. |
-| `displayName` | `settings.companyName` | `string` | Organization/company display name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain name. |
+| `name` | `okta_domain` | `string` | Okta organization domain name. |
+| `display_name` | `settings.companyName` | `string` | Organization/company display name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain name. |
 | `subdomain` | `settings.subdomain` | `string` | Okta subdomain value. |
 | `status` | `settings.status` | `string` | Organization lifecycle status. |
 | `created` | `settings.created` | `datetime` | Organization creation timestamp. |
-| `lastUpdated` | `settings.lastUpdated` | `datetime` | Last organization metadata update timestamp. |
+| `last_updated` | `settings.lastUpdated` | `datetime` | Last organization metadata update timestamp. |
 
 ## Sample Property Values
 
 ```yaml
 id: 00ow0o8if0CNwsKmk697
 name: contoso.okta.com
-displayName: Contoso
-oktaDomain: contoso.okta.com
+display_name: Contoso
+okta_domain: contoso.okta.com
 subdomain: contoso
 status: ACTIVE
 created: 2025-10-02T09:21:31+00:00
-lastUpdated: 2025-12-09T23:04:15+00:00
+last_updated: 2025-12-09T23:04:15+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_policy.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_policy.mdx
@@ -36,8 +36,8 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `policy.id` | `string` | Unique policy identifier. |
 | `name` | `policy.name` | `string` | Policy name. |
-| `displayName` | `policy.name` | `string` | Display-friendly policy name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the policy exists. |
+| `display_name` | `policy.name` | `string` | Display-friendly policy name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the policy exists. |
 | `description` | `policy.description` | `string` | Policy description text. |
 | `type` | `policy.type` | `string` | Policy type identifier (for example `OKTA_SIGN_ON`, `ACCESS_POLICY`, `PROFILE_ENROLLMENT`). |
 | `priority` | `policy.priority` | `integer` | Policy evaluation order priority. |
@@ -49,8 +49,8 @@ The tables below list edges defined by the Okta extension only. Additional edges
 ```yaml
 id: rstw0o8il8ktUxo3t697
 name: Okta Account Management Policy
-displayName: Okta Account Management Policy
-oktaDomain: contoso.okta.com
+display_name: Okta Account Management Policy
+okta_domain: contoso.okta.com
 description: This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.
 type: ACCESS_POLICY
 priority: 1

--- a/docs/opengraph/extensions/okta/nodes/okta_realm.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_realm.mdx
@@ -39,26 +39,26 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `realm.id` | `string` | Unique realm identifier. |
 | `name` | `realm.profile.name` | `string` | Realm name. |
-| `displayName` | `realm.profile.name` | `string` | Display-friendly realm name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the realm exists. |
+| `display_name` | `realm.profile.name` | `string` | Display-friendly realm name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the realm exists. |
 | `type` | `realm.profile.realmType` | `string` | Realm type classification, such as `PARTNER` or `DEFAULT`. |
-| `isDefault` | `realm.isDefault` | `bool` | Whether this is the default realm. |
+| `is_default` | `realm.isDefault` | `bool` | Whether this is the default realm. |
 | `domains` | `realm.profile.domains` | `string[]` | List of domains allowed in the realm. |
 | `created` | `realm.created` | `datetime` | Realm creation timestamp. |
-| `lastUpdated` | `realm.lastUpdated` | `datetime` | Last realm update timestamp. |
+| `last_updated` | `realm.lastUpdated` | `datetime` | Last realm update timestamp. |
 
 ## Sample Property Values
 
 ```yaml
 id: guor3k19x7pVQ6Abc0g7
 name: Car Co
-displayName: Car Co
-oktaDomain: contoso.okta.com
+display_name: Car Co
+okta_domain: contoso.okta.com
 type: PARTNER
-isDefault: false
+is_default: false
 domains:
   - atko.com
   - user.com
 created: 2025-06-01T08:00:00.0000000+00:00
-lastUpdated: 2026-02-20T07:45:12.0000000+00:00
+last_updated: 2026-02-20T07:45:12.0000000+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_resourceset.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_resourceset.mdx
@@ -58,13 +58,13 @@ The tables below list edges defined by the Okta extension only. Additional edges
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `id` | `resourceSet.id + "@" + oktaDomain` or `resourceSet.id` | `string` | Unique resource set identifier (domain-qualified). |
+| `id` | `resourceSet.id + "@" + okta_domain` or `resourceSet.id` | `string` | Unique resource set identifier (domain-qualified). |
 | `name` | `resourceSet.label` | `string` | Resource set name. |
-| `displayName` | `resourceSet.label` | `string` | Display-friendly resource set name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the resource set exists. |
+| `display_name` | `resourceSet.label` | `string` | Display-friendly resource set name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the resource set exists. |
 | `description` | `resourceSet.description` | `string` | Resource set description text. |
 | `created` | `resourceSet.created` | `datetime` | Resource set creation timestamp. |
-| `lastUpdated` | `resourceSet.lastUpdated` | `datetime` | Last resource set update timestamp. |
+| `last_updated` | `resourceSet.lastUpdated` | `datetime` | Last resource set update timestamp. |
 
 <Info>
 The built-in resource set `Workflows Resource Set` has the `WORKFLOWS_IAM_POLICY` identifier in all Okta organizations.
@@ -76,9 +76,9 @@ To make it unique, the collector adds the organization domain name as a suffix t
 ```yaml
 id: WORKFLOWS_IAM_POLICY@contoso.okta.com
 name: Workflows Resource Set
-displayName: Workflows Resource Set
-oktaDomain: contoso.okta.com
+display_name: Workflows Resource Set
+okta_domain: contoso.okta.com
 description: A resource set managed by Workflows Administrator
 created: 2025-10-22T13:29:26+00:00
-lastUpdated: 2025-10-22T13:29:26+00:00
+last_updated: 2025-10-22T13:29:26+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_role.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_role.mdx
@@ -54,10 +54,10 @@ No outbound edges are defined by the Okta extension for this node.
 
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
-| `id` | `role.id + "@" + oktaDomain` | `string` | Unique role identifier (domain-qualified). |
+| `id` | `role.id + "@" + okta_domain` | `string` | Unique role identifier (domain-qualified). |
 | `name` | `role.label` | `string` | Role name. |
-| `displayName` | `role.label` | `string` | Display-friendly role name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the role exists. |
+| `display_name` | `role.label` | `string` | Display-friendly role name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the role exists. |
 | `description` | `role.description` | `string` | Role description text when available. |
 | `permissions` | Hardcoded mapping | `string[]` | Effective permission labels associated with the role. |
 
@@ -66,8 +66,8 @@ No outbound edges are defined by the Okta extension for this node.
 ```yaml
 id: APP_ADMIN@contoso.okta.com
 name: Application Administrator
-displayName: Application Administrator
-oktaDomain: contoso.okta.com
+display_name: Application Administrator
+okta_domain: contoso.okta.com
 permissions:
     - okta.apps.manage
     - okta.apps.read

--- a/docs/opengraph/extensions/okta/nodes/okta_roleassignment.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_roleassignment.mdx
@@ -34,24 +34,24 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `roleAssignment.id + "_" + assignee.id` | `string` | Unique role-assignment identifier derived from role assignment and assignee IDs. |
 | `name` | `roleAssignment.label` | `string` | Role name associated with this assignment. |
-| `displayName` | `roleAssignment.label` | `string` | Display label used in BloodHound. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the role assignment exists. |
-| `assignmentType` | `roleAssignment.assignmentType` | `string` | Assignment scope/type (for example user or group assignment). |
+| `display_name` | `roleAssignment.label` | `string` | Display label used in BloodHound. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the role assignment exists. |
+| `assignment_type` | `roleAssignment.assignmentType` | `string` | Assignment scope/type (for example user or group assignment). |
 | `type` | `roleAssignment.type` | `string` | Assigned role identifier (for example `WORKFLOWS_ADMIN`, `APP_ADMIN`). |
 | `status` | `roleAssignment.status` | `string` | Role assignment lifecycle status. |
 | `created` | `roleAssignment.created` | `datetime` | Role assignment creation timestamp. |
-| `lastUpdated` | `roleAssignment.lastUpdated` | `datetime` | Last role assignment update timestamp. |
+| `last_updated` | `roleAssignment.lastUpdated` | `datetime` | Last role assignment update timestamp. |
 
 ## Sample Property Values
 
 ```yaml
 id: irbwnwe8vjjXl4FbX697_00uw2sodowQc75SUm697
 name: Workflows Administrator
-displayName: Workflows Administrator
-oktaDomain: contoso.okta.com
-assignmentType: USER
+display_name: Workflows Administrator
+okta_domain: contoso.okta.com
+assignment_type: USER
 type: WORKFLOWS_ADMIN
 status: ACTIVE
 created: 2025-10-22T13:29:26+00:00
-lastUpdated: 2025-10-22T13:29:26+00:00
+last_updated: 2025-10-22T13:29:26+00:00
 ```

--- a/docs/opengraph/extensions/okta/nodes/okta_user.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_user.mdx
@@ -75,56 +75,56 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | ---- | ------ | ---- | ----------- |
 | `id` | `user.id` | `string` | Unique user identifier. |
 | `name` | `user.profile.login` | `string` | Okta username/login. |
-| `displayName` | `user.profile.displayName` | `string` | User display name. |
-| `oktaDomain` | Collector context (non-API) | `string` | Okta organization domain where the user exists. |
+| `display_name` | `user.profile.displayName` | `string` | User display name. |
+| `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the user exists. |
 | `login` | `user.profile.login` | `string` | User login/UPN value. |
 | `email` | `user.profile.email` | `string` | Primary email address. |
-| `firstName` | `user.profile.firstName` | `string` | User first/given name. |
-| `lastName` | `user.profile.lastName` | `string` | User last/family name. |
+| `first_name` | `user.profile.firstName` | `string` | User first/given name. |
+| `last_name` | `user.profile.lastName` | `string` | User last/family name. |
 | `title` | `user.profile.title` | `string` | Job title from user profile when present. |
 | `department` | `user.profile.department` | `string` | Department value from user profile when present. |
 | `city` | `user.profile.city` | `string` | City/location value from user profile when present. |
 | `state` | `user.profile.state` | `string` | State/region value from user profile when present. |
-| `countryCode` | `user.profile.countryCode` | `string` | ISO-like country code from user profile when present. |
+| `country_code` | `user.profile.countryCode` | `string` | ISO-like country code from user profile when present. |
 | `status` | `user.status` | `string` | User lifecycle status. |
 | `enabled` | `IsEnabled(user.status)` | `bool` | Boolean status projection used by BloodHound. |
-| `hasRoleAssignments` | Calculated | `bool` | Indicates whether the user is assigned any administrative roles. |
-| `credentialProviderName` | `user.credentials.provider.name` | `string` | Authentication provider name for this user. |
-| `credentialProviderType` | `user.credentials.provider.type` | `string` | Authentication provider type for this user. |
-| `managerId` | `user.profile.managerId` | `string` | Manager identifier from user profile synchronization. |
+| `has_role_assignments` | Calculated | `bool` | Indicates whether the user is assigned any administrative roles. |
+| `credential_provider_name` | `user.credentials.provider.name` | `string` | Authentication provider name for this user. |
+| `credential_provider_type` | `user.credentials.provider.type` | `string` | Authentication provider type for this user. |
+| `manager_id` | `user.profile.managerId` | `string` | Manager identifier from user profile synchronization. |
 | `activated` | `user.activated` | `datetime` | Timestamp when the user account was activated. |
 | `created` | `user.created` | `datetime` | User creation timestamp. |
-| `passwordChanged` | `user.passwordChanged` | `datetime` | Timestamp when the password was last changed. |
-| `lastLogin` | `user.lastLogin` | `datetime` | Timestamp of the most recent successful login. |
-| `lastUpdated` | `user.lastUpdated` | `datetime` | Last profile/update timestamp. |
+| `password_changed` | `user.passwordChanged` | `datetime` | Timestamp when the password was last changed. |
+| `last_login` | `user.lastLogin` | `datetime` | Timestamp of the most recent successful login. |
+| `last_updated` | `user.lastUpdated` | `datetime` | Last profile/update timestamp. |
 
 ## Sample Property Values
 
 ```yaml
 id: 00uw2sodn4ZPJJQyx697
 name: john.doe@contoso.com
-displayName: John Doe
-oktaDomain: contoso.okta.com
+display_name: John Doe
+okta_domain: contoso.okta.com
 login: john.doe@contoso.com
 email: john.doe@contoso.com
-firstName: John
-lastName: Doe
+first_name: John
+last_name: Doe
 title: Senior Identity Engineer
 department: Security Engineering
 city: Seattle
 state: WA
-countryCode: US
+country_code: US
 status: ACTIVE
 enabled: true
-hasRoleAssignments: false
-credentialProviderName: OKTA
-credentialProviderType: OKTA
-managerId: joe.smith@contoso.com
+has_role_assignments: false
+credential_provider_name: OKTA
+credential_provider_type: OKTA
+manager_id: joe.smith@contoso.com
 created: 2025-10-03T18:45:57+00:00
 activated: 2025-10-03T19:02:11+00:00
-passwordChanged: 2026-01-12T14:27:03+00:00
-lastLogin: 2026-02-20T09:41:55+00:00
-lastUpdated: 2025-10-29T11:09:47+00:00
+password_changed: 2026-01-12T14:27:03+00:00
+last_login: 2026-02-20T09:41:55+00:00
+last_updated: 2025-10-29T11:09:47+00:00
 ```
 
 ## User Status
@@ -156,7 +156,7 @@ Okta supports various authentication factors for multi-factor authentication (MF
 such as SMS, email, push notifications, and hardware tokens.
 In case of mobile and desktop applications, these authentication factors are associated with the [Device](/opengraph/extensions/okta/nodes/okta_device) entities.
 Other authentication factors, such as YubiKeys and Google Authenticator, are not represented as separate nodes in BloodHound,
-but the number of enrolled factors is stored in the `authenticationFactors` attribute of the `Okta_User` nodes.
+but the number of enrolled factors is stored in the `authentication_factors` attribute of the `Okta_User` nodes.
 
 ## Synchronization with External Directories
 

--- a/docs/opengraph/extensions/okta/queries.mdx
+++ b/docs/opengraph/extensions/okta/queries.mdx
@@ -29,7 +29,7 @@ Identifies principals with access to the Okta Admin Console.
 
 ```cypher
 MATCH path = (:Okta_Organization)-[:Okta_Contains]->(:Okta)-[:Okta_AppAssignment]->(console:Okta_Application)
-WHERE console.appType = "saasure"
+WHERE console.app_type = "saasure"
 RETURN path
 LIMIT 1000
 ```
@@ -297,7 +297,7 @@ Users who do not have multi-factor authentication enabled and directly hold priv
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.authenticationFactors = 0
+WHERE user.authentication_factors = 0
 RETURN path
 LIMIT 1000
 ```
@@ -310,7 +310,7 @@ Users who do not have multi-factor authentication enabled and hold privileged ro
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_MemberOf]->(:Okta_Group)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.authenticationFactors = 0
+WHERE user.authentication_factors = 0
 RETURN path
 LIMIT 1000
 ```
@@ -323,7 +323,7 @@ Finds users whose last password change was more than a year ago and directly hol
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.passwordChanged IS NOT NULL AND datetime(user.passwordChanged) <= datetime() - duration("P365D")
+WHERE user.password_changed IS NOT NULL AND datetime(user.password_changed) <= datetime() - duration("P365D")
 RETURN path
 LIMIT 1000
 ```
@@ -336,7 +336,7 @@ Finds users whose last password change was more than a year ago and hold privile
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_MemberOf]->(:Okta_Group)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.passwordChanged IS NOT NULL AND datetime(user.passwordChanged) <= datetime() - duration("P365D")
+WHERE user.password_changed IS NOT NULL AND datetime(user.password_changed) <= datetime() - duration("P365D")
 RETURN path
 LIMIT 1000
 ```
@@ -499,7 +499,7 @@ Finds user accounts that have not logged in for at least 180 days and directly h
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.lastLogin IS NULL OR datetime(user.lastLogin) <= datetime() - duration("P180D")
+WHERE user.last_login IS NULL OR datetime(user.last_login) <= datetime() - duration("P180D")
 RETURN path
 LIMIT 1000
 ```
@@ -512,7 +512,7 @@ Finds user accounts that have not logged in for at least 180 days and hold privi
 
 ```cypher
 MATCH path = (user:Okta_User)-[:Okta_MemberOf]->(:Okta_Group)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.lastLogin IS NULL OR datetime(user.lastLogin) <= datetime() - duration("P180D")
+WHERE user.last_login IS NULL OR datetime(user.last_login) <= datetime() - duration("P180D")
 RETURN path
 LIMIT 1000
 ```


### PR DESCRIPTION
The first iteration of the OG collectors for Okta and Jamf created properties in camelCase. OpenHound use snake_case. This PR will align with OpenHound. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized Jamf and Okta documentation to use `snake_case` property names across node tables and sample values.
  * Updated related query examples to match the new property naming, including `tier`, `site_id`, `okta_domain`, and other renamed fields.
  * Improved consistency across identity, user, group, device, role, and integration pages so examples now align with documented schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->