### PR TITLE
Fix okta properties

### DIFF
--- a/docs/opengraph/extensions/okta/nodes/okta_application.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_application.mdx
@@ -69,7 +69,7 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | Name | Source | Type | Description |
 | ---- | ------ | ---- | ----------- |
 | `id` | `application.id` | `string` | Unique application identifier. |
-| `name` | `application.label` | `string` | Name/label of the Okta application. |
+| `name` | `application.name` | `string` | App type identifier (for example `office365`, `snowflake`, `githubcloud`). |
 | `display_name` | `application.label` | `string` | Display label used in BloodHound. |
 | `okta_domain` | Collector context (non-API) | `string` | Okta organization domain where the application exists. |
 | `has_role_assignments` | Calculated | `bool` | Indicates whether the application is assigned any administrative roles. |
@@ -78,7 +78,6 @@ The tables below list edges defined by the Okta extension only. Additional edges
 | `status` | `application.status` | `string` | Current lifecycle status of the application instance. |
 | `sign_on_mode` | `application.signOnMode` | `string` | Sign-on protocol mode (for example `OPENID_CONNECT`, `SAML_2_0`, `AUTO_LOGIN`). |
 | `features` | `application.features` | `string[]` | Enabled app capabilities such as SCIM provisioning and password push. |
-| `app_type` | `application.name` | `string` | App type identifier (for example `office365`, `snowflake`, `githubcloud`). |
 | `user_name_mapping` | `application.credentials.userNameTemplate.template` | `string` | Username mapping template used for provisioning/federation. |
 
 Individual application types may have additional properties specific to the integration or protocol:
@@ -172,8 +171,7 @@ Individual application types may have additional properties specific to the inte
 
 ```yaml
 id: 0oawyp12cjglrkfId697
-name: Github Contoso
-app_type: githubcloud
+name: githubcloud
 display_name: Github Contoso
 features: []
 github_org: Contoso
@@ -190,13 +188,12 @@ last_updated: 2025-10-31T06:08:01+00:00
 
 ```yaml
 id: 0oax4r57x0V5NHL2W697
+name: google
 afw_only: false
-app_type: google
 display_name: Google Workspace
 domain: contoso.com
 features: []
 has_role_assignments: false
-name: Google Workspace
 okta_domain: contoso.okta.com
 sign_on_mode: SAML_2_0
 status: ACTIVE
@@ -209,7 +206,7 @@ last_updated: 2025-11-05T09:07:21+00:00
 
 ```yaml
 id: 0oax4r3ud0J2WjlNh697
-app_type: jamfsoftwareserver
+name: jamfsoftwareserver
 display_name: Jamf Pro SAML
 domain: contoso.jamfcloud.com
 features: []
@@ -227,8 +224,7 @@ last_updated: 2026-01-19T14:33:39+00:00
 
 ```yaml
 id: 0oaw0pujq5WtBiMYD697
-name: OktaHound
-app_type: oidc_client
+name: oidc_client
 client_type: service
 display_name: OktaHound
 features: []
@@ -291,8 +287,7 @@ last_updated: 2025-10-02T10:26:27+00:00
 
 ```yaml
 id: 0oaxg9rhdd7ncGCXv697
-name: contoso.local
-app_type: active_directory
+name: active_directory
 display_name: contoso.local
 domain_sid: S-1-5-21-71365889-924527929-2677699343
 features:

--- a/docs/opengraph/extensions/okta/nodes/okta_user.mdx
+++ b/docs/opengraph/extensions/okta/nodes/okta_user.mdx
@@ -150,13 +150,6 @@ To simplify analysis in BloodHound, the collector maps the **Status** attribute 
 This mapping is a simplification and may not cover all edge cases.
 Always refer to the actual **Status** attribute for precise user state information.
 </Warning>
-## Authentication Factors
-
-Okta supports various authentication factors for multi-factor authentication (MFA),
-such as SMS, email, push notifications, and hardware tokens.
-In case of mobile and desktop applications, these authentication factors are associated with the [Device](/opengraph/extensions/okta/nodes/okta_device) entities.
-Other authentication factors, such as YubiKeys and Google Authenticator, are not represented as separate nodes in BloodHound,
-but the number of enrolled factors is stored in the `authentication_factors` attribute of the `Okta_User` nodes.
 
 ## Synchronization with External Directories
 

--- a/docs/opengraph/extensions/okta/queries.mdx
+++ b/docs/opengraph/extensions/okta/queries.mdx
@@ -29,7 +29,7 @@ Identifies principals with access to the Okta Admin Console.
 
 ```cypher
 MATCH path = (:Okta_Organization)-[:Okta_Contains]->(:Okta)-[:Okta_AppAssignment]->(console:Okta_Application)
-WHERE console.app_type = "saasure"
+WHERE console.name = "saasure"
 RETURN path
 LIMIT 1000
 ```

--- a/docs/opengraph/extensions/okta/queries.mdx
+++ b/docs/opengraph/extensions/okta/queries.mdx
@@ -291,31 +291,6 @@ LIMIT 1000
 
 This query can be imported into BloodHound from the [privileged-principals-hybrid-indirect.json](https://github.com/SpecterOps/openhound-okta/tree/main/extension/saved_searches/privileged-principals-hybrid-indirect.json) file.
 
-## Privileged Users without MFA (Direct)
-
-Users who do not have multi-factor authentication enabled and directly hold privileged role assignments.
-
-```cypher
-MATCH path = (user:Okta_User)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.authentication_factors = 0
-RETURN path
-LIMIT 1000
-```
-
-This query can be imported into BloodHound from the [privileged-users-no-mfa-direct.json](https://github.com/SpecterOps/openhound-okta/tree/main/extension/saved_searches/privileged-users-no-mfa-direct.json) file.
-
-## Privileged Users without MFA (Indirect)
-
-Users who do not have multi-factor authentication enabled and hold privileged role assignments through group membership.
-
-```cypher
-MATCH path = (user:Okta_User)-[:Okta_MemberOf]->(:Okta_Group)-[:Okta_HasRoleAssignment]->(:Okta_RoleAssignment)-[:Okta_ScopedTo]->(:Okta)
-WHERE user.authentication_factors = 0
-RETURN path
-LIMIT 1000
-```
-
-This query can be imported into BloodHound from the [privileged-users-no-mfa-indirect.json](https://github.com/SpecterOps/openhound-okta/tree/main/extension/saved_searches/privileged-users-no-mfa-indirect.json) file.
 
 ## Privileged Users with Old Passwords (Direct)
 


### PR DESCRIPTION
Fix 1:

OktaHound created a user property named `authentication_factors`, but this property was not ported to OpenHound due to performance concerns.

We are therefore removing this property from the docs.

Fix 2:

Remove the non-existing `app_type` property for app nodes, and fix the `name` property which hold the intended value. 