### PR TITLE
BP-2735: Release notes (2026-07-07)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -894,14 +894,15 @@
                 "group": "Release Notes",
                 "pages": [
                   "resources/release-notes/summary",
+                  "resources/release-notes/2026-07-07",
                   "resources/release-notes/2026-06-17",
-                  "resources/release-notes/2026-05-28",
                   {
                     "group": "Archive",
                     "pages": [
                       {
                         "group": "2026",
                         "pages": [
+                          "resources/release-notes/2026-05-28",
                           "resources/release-notes/2026-05-06",
                           "resources/release-notes/2026-04-13",
                           "resources/release-notes/2026-03-23",

--- a/docs/manage-bloodhound/auth/users-and-roles.mdx
+++ b/docs/manage-bloodhound/auth/users-and-roles.mdx
@@ -69,5 +69,5 @@ For OpenGraph extensions, BloodHound separates read and write permissions. Users
 | Run collector client on-demand scan \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
 | Add, modify, and remove a collector client \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
 | Regenerate collector client credentials \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
-| File Ingest | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | <Icon icon="square-check" iconType="solid" color="#22c55e"/> |
+| File Ingest | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | <Icon icon="square-check" iconType="solid" color="#22c55e"/> |
 

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -167,8 +167,3 @@ sidebarTitle: "2026-07-07"
   - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior.
   - {/*BED-8692*/} Resolved an issue that could cause Okta and GitHub collections to fail in Kubernetes-based deployments.
 </Update>
-
-{/* TODO(doc-follow-up):
-- Review docs/analyze-data/privilege-zones/rules.mdx for the rule-builder validation and state-preservation changes in this release, and confirm whether Variable Analysis Mode needs separate public documentation.
-- Review docs/collect-data/enterprise-collection/monitor.mdx, docs/collect-data/enterprise-collection/create-collector.mdx, and docs/openhound/configuration.mdx for OpenHound version visibility, long-running job heartbeat behavior, updated troubleshooting guidance, and configuration examples (e.g., logs).
-*/}

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -48,6 +48,19 @@ sidebarTitle: "2026-07-07"
   Auditors can now access these administration views in a read-only state while actions, such as uploading files or creating providers, remain restricted to [roles](/manage-bloodhound/auth/users-and-roles) with write access.
 </Update>
 
+<Update label="BloodHound" description="Enhancement" tags={["Administration"]}>
+  {/*BED-8189*/}
+  ## Updated Default Admin Email Address
+
+  Use a more appropriate default admin email address in BloodHound Community configuration and example files.
+
+  BloodHound Community now uses `admin@example.com` instead of `spam@example.com` for the [`default_admin.email_address`](/manage-bloodhound/bh-config#default_admin-email_address) configuration property and related examples.
+
+  <Warning>
+    Existing workflows that still rely on the previous email address for initial login may need to be updated.
+  </Warning>
+</Update>
+
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-8777, BED-8747, BED-8746, BED-8744, BED-8693*/}
   ## More Resilient OpenHound Operations
@@ -114,27 +127,37 @@ sidebarTitle: "2026-07-07"
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>
-  ## Analysis and API
+  ## Analysis
 
-  - {/*BED-8136*/} Resolved an issue where [`GET /api/v2/datapipe/status`](/reference/datapipe/get-datapipe-status) did not reliably update `last_analysis_run_at` and did not expose the scheduled-analysis timestamps needed to track analysis cadence.
-  - {/*BED-5572*/} Resolved an issue where multi-forest environments that shared ADCS infrastructure could produce false-positive attack paths.
-  - {/*BED-4867*/} Resolved an issue where Azure descendant `related_entity_type` requests could respond too slowly in large tenants.
+  {/*BED-5572*/} Resolved an issue where multi-forest environments that consolidated ADCS into one forest could produce false-positive ADCS ESC attack path edges when a **Computer** node belonged to a different forest than the **Enterprise CA**.
+
+  ## API
+
+  - {/*BED-8136*/} Resolved an issue where the [`GET /api/v2/datapipe/status`](/reference/datapipe/get-datapipe-status) endpoint did not reliably update `last_analysis_run_at` and did not expose the scheduled-analysis timestamps needed to track analysis cadence.
+  - {/*BED-4867*/} Resolved an issue where the [`related_entity_type`](/reference/azure-entities/get-azure-entity#parameter-related-entity-type) parameter on the **Get Azure entity** endpoint could respond too slowly for descendant objects of large **AZTenant** nodes and degrade the user experience in the UI.
+
+  ## Explore
+
+  - {/*BED-7040*/} Resolved an issue where saved query imports could fail for JSON files that used UTF-8 BOM encoding, including files packaged in ZIP archives.
   - {/*BED-7883*/} Resolved an issue where Cypher equality comparisons could fail for values that contained special characters.
 
-  ## Explore, Posture, and Privilege Zones
+  ## OpenGraph
 
-  - {/*BED-8114*/} Resolved an issue where the **Attack Paths** and **Posture** pages could show inconsistent finding counts.
-  - {/*BED-8642*/} Resolved an issue where pathfinding involving OpenGraph data could fail unexpectedly.
+  - {/*BED-8656*/} Resolved an issue where dragging a file onto the **Quick Upload** dialog on the **OpenGraph Management** page could open the wrong dialog.
+  - {/*BED-8642*/} Resolved an issue where nodes with colons in their names could disappear from the **Search** and **Pathfinding** fields.
+  - {/*BED-8570*/} Resolved an issue where the OpenGraph extension deletion dialog accepted only one character at a time, preventing confirmation.
   - {/*BED-8310*/} Resolved an issue where the Privilege Zone object details panel failed to load OpenGraph node data for rule-matched objects.
+
+  ## UI
+
+  - {/*BED-8754*/} Resolved focus-state inconsistencies on dropdown menus that could make active controls harder to distinguish.
   - {/*BED-8390*/} Resolved an issue where parts of the **Posture** page used browser localization settings inconsistently.
 
-  ## Administration, OpenGraph, and UI
+  ## Findings
 
-  - {/*BED-8656*/} Resolved an issue where dragging a file into **Quick Upload** on the **OpenGraph Management** page could open the wrong upload dialog.
-  - {/*BED-8570*/} Resolved an issue where the OpenGraph extension deletion dialog only accepted one character at a time when confirming an extension name.
-  - {/*BED-7040*/} Resolved an issue where saved-query uploads did not use the same ingest file safety checks as other upload workflows.
-  - {/*BED-8189*/} Resolved an issue in BloodHound Community where the default `admin` email address used an example value that was misleading in production-like setups.
-  - {/*BED-8754*/} Resolved focus-state inconsistencies that could make active controls harder to distinguish during keyboard navigation.
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+  {/*BED-8114*/} Resolved an issue where individual attack paths and their finding counts could appear on the **Posture** page but not on the **Attack Paths** page.
 </Update>
 
 <Update label="OpenHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -73,14 +73,14 @@ sidebarTitle: "2026-07-07"
   - Continues collection more often when single-object errors occur
   - Handles deferred pipeline failures more consistently
   - Reports its version to BloodHound for visibility on the **Manage Clients** page
-  - Uses human-readable plain-text logs by default for file and stdout output, while keeping structured JSON as an opt-in format
+  - Uses human-readable plain-text [log format](/openhound/configuration#log-format) by default for file and stdout output, while keeping structured JSON as an opt-in format
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Zone Builder"]}>
   {/*BED-8303, BED-7739, BED-8520*/}
   ## Privilege Zone Rule Authoring Improvements
 
-  Build and validate Privilege Zone rules with less rework when you switch rule types or refine Cypher-based rules.
+  Build and validate Privilege Zone [rules](/analyze-data/privilege-zones/rules) with less rework when you switch rule types or refine Cypher-based rules.
 
   BloodHound now:
 
@@ -121,7 +121,7 @@ sidebarTitle: "2026-07-07"
 
   See Privilege Zone updates reflected in your graph faster.
 
-  When you enable **Variable Analysis Mode** on the **Early Access** page, BloodHound Enterprise can skip post-processing after Privilege Zone changes and re-run only the analysis stages needed to update tagged objects and findings.
+  When you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Early Access** page, BloodHound Enterprise can skip post-processing after Privilege Zone changes and re-run only the analysis stages needed to update tagged objects and findings.
   
   This reduces the time it takes for updated zone definitions and related findings to appear in the graph.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -58,6 +58,15 @@ sidebarTitle: "2026-07-07"
   BloodHound now preserves rule state when you switch between Cypher and Object ID rules, prompts you to rerun Cypher when the query changes, and prevents saving Cypher rules that have not produced valid results.
 </Update>
 
+<Update label="BloodHound" description="Enhancement" tags={["Privilege Zones"]}>
+  {/*BED-8276, BED-8781*/}
+  ## Variable Analysis Mode
+
+  Review unrealized Privilege Zone analysis changes with Variable Analysis Mode and manage the associated feature flag more directly in supported environments.
+
+  This release adds Variable Analysis Mode support for Privilege Zone analysis workflows and makes the related feature-flag setting user-updatable.
+</Update>
+
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
   {/*BED-7222, BED-7215, BED-7212, BED-8290*/}
   ## Accessibility Improvements

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -13,20 +13,6 @@ sidebarTitle: "2026-07-07"
   Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
 </Tip>
 
-<Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
-  {/*BED-6155*/}
-  ## ADCS ESC14 Scenario A Attack Paths
-
-  Analyze ADCS ESC14 Scenario A attack paths directly in BloodHound so you can identify explicit certificate-mapping abuse paths that rely on `altSecurityIdentities`.
-
-  In [ESC14 Scenario A](https://posts.specterops.io/adcs-esc14-abuse-technique-333a004dc2b9), an attacker who can modify a target principal's `altSecurityIdentities` attribute, or who has equivalent control through the `Public-Information` property set, can add an explicit certificate mapping that points to a certificate they control and then authenticate as the target.
-
-  This release adds graph coverage for the following edges, helping you surface certificate-based impersonation and privilege escalation paths that were previously harder to model and investigate:
-
-  - [`WriteAltSecurityIdentities`](/resources/edges/write-alt-security-identities)
-  - [`WritePublicInformation`](/resources/edges/write-public-information)
-</Update>
-
 <Update label="BloodHound" description="New Feature" tags={["API"]}>
   {/*BED-8608, BED-8609*/}
   ## Graph ID Lookup APIs

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -43,7 +43,7 @@ sidebarTitle: "2026-07-07"
   {/*BED-8518, BED-8519, BED-8588*/}
   ## Auditor Role Access Improvements
 
-  Allow auditors to review **File Ingest** activity and **SSO Configuration** details without granting edit permissions.
+  Allow auditors to review **File Ingest** activity and **SSO Configuration** details.
 
   Auditors can now access these administration views in a read-only state while actions, such as uploading files or creating providers, remain restricted to [roles](/manage-bloodhound/auth/users-and-roles) with write access.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -108,9 +108,7 @@ sidebarTitle: "2026-07-07"
 
   <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
-  Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
-
-  This release raises the [`graph_query_memory_limit`](/manage-bloodhound/bh-config#graph_query_memory_limit) setting for user-generated Cypher queries from 2GB to 4GB in hosted enterprise environments.
+  Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than were previously supported.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Zone Builder"]}>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "2026-07-07"
 |     |     |     |     |     |
 | --- | --- | --- | --- | --- |
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
-| 2026-07-07 | v9.4.0 | v0.2.10 | No release | No release |
+| 2026-07-07 | v9.4.0 | v0.2.11 | No release | No release |
 
 <Tip>
   Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
@@ -166,4 +166,5 @@ sidebarTitle: "2026-07-07"
   - {/*BED-8689*/} Resolved issues that made large GitHub collections more likely to stall or fail when GitHub API rate limits were exhausted.
   - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior.
   - {/*BED-8692*/} Resolved an issue that could cause Okta and GitHub collections to fail in Kubernetes-based deployments.
+  - {/*BED-8855*/} Resolved an issue where OpenHound did not respect the default setting that disables telemetry data.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -73,6 +73,8 @@ sidebarTitle: "2026-07-07"
   {/*BED-8276, BED-8781*/}
   ## Variable Analysis Mode
 
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
   Review unrealized Privilege Zone analysis changes with Variable Analysis Mode and manage the associated feature flag more directly in supported environments.
 
   This release adds Variable Analysis Mode support for Privilege Zone analysis workflows and makes the related feature-flag setting user-updatable.

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -166,5 +166,5 @@ sidebarTitle: "2026-07-07"
   - {/*BED-8689*/} Resolved issues that made large GitHub collections more likely to stall or fail when GitHub API rate limits were exhausted.
   - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior.
   - {/*BED-8692*/} Resolved an issue that could cause Okta and GitHub collections to fail in Kubernetes-based deployments.
-  - {/*BED-8855*/} Resolved an issue where OpenHound did not respect the default setting that disables telemetry data.
+  - {/*BED-8855*/} Resolved an issue where OpenHound did not respect the default setting that disables anonymous telemetry data.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -13,22 +13,39 @@ sidebarTitle: "2026-07-07"
   Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
 </Tip>
 
-<Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
+<Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
   {/*BED-6155*/}
-  ## ADCS ESC14 Scenario A Coverage
+  ## ADCS ESC14 Scenario A Attack Paths
 
-  Analyze ADCS ESC14 Scenario A attack paths directly in BloodHound so you can identify certificate-mapping abuse paths that rely on `altSecurityIdentities`.
+  Analyze ADCS ESC14 Scenario A attack paths directly in BloodHound so you can identify explicit certificate-mapping abuse paths that rely on `altSecurityIdentities`.
 
-  This release adds graph coverage for [`WriteAltSecurityIdentities`](/resources/edges/write-alt-security-identities) and [`WritePublicInformation`](/resources/edges/write-public-information), helping you surface certificate-based privilege escalation paths that were previously harder to model and investigate.
+  In [ESC14 Scenario A](https://posts.specterops.io/adcs-esc14-abuse-technique-333a004dc2b9), an attacker who can modify a target principal's `altSecurityIdentities` attribute, or who has equivalent control through the `Public-Information` property set, can add an explicit certificate mapping that points to a certificate they control and then authenticate as the target.
+
+  This release adds graph coverage for the following edges, helping you surface certificate-based impersonation and privilege escalation paths that were previously harder to model and investigate:
+
+  - [`WriteAltSecurityIdentities`](/resources/edges/write-alt-security-identities)
+  - [`WritePublicInformation`](/resources/edges/write-public-information)
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["API"]}>
+  {/*BED-8608, BED-8609*/}
+  ## Graph ID Lookup APIs
+
+  Retrieve details for specific OpenGraph nodes and relationships by their graph-assigned integer IDs.
+
+  BloodHound now exposes the following experimental OpenGraph API endpoints:
+
+  - [`GET /api/v2/nodes/{node_id}`](/reference/opengraph-experimental/get-node-by-graph-node-id)
+  - [`GET /api/v2/relationships/{relationship_id}`](/reference/opengraph-experimental/get-relationship-by-graph-relationship-id)
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Administration"]}>
   {/*BED-8518, BED-8519, BED-8588*/}
-  ## Auditor Access for File Ingest and SSO Configuration
+  ## Auditor Role Access Improvements
 
-  Let auditors review **File Ingest** activity and **SSO Configuration** details without granting edit permissions.
+  Allow auditors to review **File Ingest** activity and **SSO Configuration** details without granting edit permissions.
 
-  Auditors can now access these administration views in a read-only state while actions such as uploading files or creating providers remain restricted to roles with write access.
+  Auditors can now access these administration views in a read-only state while actions, such as uploading files or creating providers, remain restricted to [roles](/manage-bloodhound/auth/users-and-roles) with write access.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
@@ -37,47 +54,30 @@ sidebarTitle: "2026-07-07"
 
   Keep long-running OpenHound jobs alive, identify deployed client versions more easily, and troubleshoot failures with clearer logs.
 
-  OpenHound now continues checking in during active collections to reduce unintended job timeouts, reports its installed version back to BloodHound for better client visibility, improves log readability, handles deferred pipeline failures more consistently, and continues collection more often when single-object errors occur.
+  OpenHound now:
+
+  - Continues checking in during active collections to reduce unintended job timeouts
+  - Continues collection more often when single-object errors occur
+  - Handles deferred pipeline failures more consistently
+  - Reports its version to BloodHound for visibility on the **Manage Clients** page
+  - Uses human-readable plain-text logs by default for file and stdout output, while keeping structured JSON as an opt-in format
 </Update>
 
-<Update label="BloodHound" description="Enhancement" tags={["API"]}>
-  {/*BED-8608, BED-8609*/}
-  ## Graph ID Lookup APIs
-
-  Retrieve specific nodes and relationships by their graph-assigned integer IDs when you need to automate graph lookups outside the UI.
-
-  BloodHound now exposes [`GET /api/v2/nodes/{node_id}`](/reference/opengraph-experimental/get-node-by-graph-node-id) and [`GET /api/v2/relationships/{relationship_id}`](/reference/opengraph-experimental/get-relationship-by-graph-relationship-id) to simplify targeted integrations and investigation workflows.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Cypher"]}>
-  {/*BI-1814*/}
-  ## Higher Memory Limits for User-Generated Cypher Queries
-
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
-
-  Run more complex user-generated Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
-
-  This release raises the [`graph_query_memory_limit`](/manage-bloodhound/bh-config#graph_query_memory_limit) setting used for user-generated Cypher queries from `2` to `4`, increasing the memory available to those workflows in hosted enterprise environments.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Privilege Zones"]}>
+<Update label="BloodHound" description="Enhancement" tags={["Zone Builder"]}>
   {/*BED-8303, BED-7739, BED-8520*/}
   ## Privilege Zone Rule Authoring Improvements
 
   Build and validate Privilege Zone rules with less rework when you switch rule types or refine Cypher-based rules.
 
-  BloodHound now preserves rule state when you switch between Cypher and Object ID rules, prompts you to rerun Cypher when the query changes, and prevents saving Cypher rules that have not produced valid results.
-</Update>
+  BloodHound now:
 
-<Update label="BloodHound" description="Enhancement" tags={["Privilege Zones"]}>
-  {/*BED-8276, BED-8781*/}
-  ## Variable Analysis Mode
+  - Preserves rule state when you switch between Cypher and Object ID rule types
+  - Prompts you to rerun Cypher when the query changes
+  - Warns you with a confirmation dialog before saving a Cypher-based rule that returns no results
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
-
-  Review unrealized Privilege Zone analysis changes with Variable Analysis Mode and manage the associated feature flag more directly in supported environments.
-
-  This release adds Variable Analysis Mode support for Privilege Zone analysis workflows and makes the related feature-flag setting user-updatable.
+    <Note>
+      This helps when you expect a rule to return results after future data collection or changes in your environment.
+    </Note>
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
@@ -87,6 +87,30 @@ sidebarTitle: "2026-07-07"
   Navigate BloodHound with clearer focus states, more consistent semantic structure, and better screen-reader labeling across key workflows.
 
   This release improves accessible names and labels in administration forms, strengthens visible keyboard focus behavior, and refines headings and page structure to better support assistive technologies.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Cypher"]}>
+  {/*BI-1814*/}
+  ## Higher Memory Limits for Cypher Queries
+
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+  Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
+
+  This release raises the [`graph_query_memory_limit`](/manage-bloodhound/bh-config#graph_query_memory_limit) setting for user-generated Cypher queries from 2GB to 4GB in hosted enterprise environments.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Zone Builder"]}>
+  {/*BED-8276, BED-8781*/}
+  ## Variable Analysis Mode
+
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+  See Privilege Zone updates reflected in your graph faster.
+
+  When you enable **Variable Analysis Mode** on the **Early Access** page, BloodHound Enterprise can skip post-processing after Privilege Zone changes and re-run only the analysis stages needed to update the graph.
+  
+  This reduces the time it takes for updated zone definitions and related findings to appear in the graph.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>
@@ -127,8 +151,6 @@ sidebarTitle: "2026-07-07"
 </Update>
 
 {/* TODO(doc-follow-up):
-- Update docs/manage-bloodhound/auth/users-and-roles.mdx if Auditor access to File Ingest and SSO Configuration is now part of the supported permission matrix.
-- Review docs/manage-bloodhound/bh-config.mdx if the documented `graph_query_memory_limit` example or rollout guidance should change after the enterprise fleet configuration update ships.
 - Review docs/analyze-data/privilege-zones/rules.mdx for the rule-builder validation and state-preservation changes in this release, and confirm whether Variable Analysis Mode needs separate public documentation.
-- Review docs/collect-data/enterprise-collection/monitor.mdx, docs/collect-data/enterprise-collection/create-collector.mdx, and docs/openhound/configuration.mdx for OpenHound version visibility, long-running job heartbeat behavior, and updated troubleshooting guidance.
+- Review docs/collect-data/enterprise-collection/monitor.mdx, docs/collect-data/enterprise-collection/create-collector.mdx, and docs/openhound/configuration.mdx for OpenHound version visibility, long-running job heartbeat behavior, updated troubleshooting guidance, and configuration examples (e.g., logs).
 */}

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -1,0 +1,111 @@
+---
+title: 2026-07-07 Release Notes
+description: Learn about new features, enhancements, and fixed issues in BloodHound.
+sidebarTitle: "2026-07-07"
+---
+
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-07-07 | v9.4.0 | v0.2.10 | No release | No release |
+
+<Tip>
+  Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
+</Tip>
+
+<Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
+  {/*BED-6155*/}
+  ## ADCS ESC14 Scenario A Coverage
+
+  Analyze ADCS ESC14 Scenario A attack paths directly in BloodHound so you can identify certificate-mapping abuse paths that rely on `altSecurityIdentities`.
+
+  This release adds graph coverage for [`WriteAltSecurityIdentities`](/resources/edges/write-alt-security-identities) and [`WritePublicInformation`](/resources/edges/write-public-information), helping you surface certificate-based privilege escalation paths that were previously harder to model and investigate.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Administration"]}>
+  {/*BED-8518, BED-8519, BED-8588*/}
+  ## Auditor Access for File Ingest and SSO Configuration
+
+  Let auditors review **File Ingest** activity and **SSO Configuration** details without granting edit permissions.
+
+  Auditors can now access these administration views in a read-only state while actions such as uploading files or creating providers remain restricted to roles with write access.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8777, BED-8747, BED-8746, BED-8744, BED-8693*/}
+  ## More Resilient OpenHound Operations
+
+  Keep long-running OpenHound jobs alive, identify deployed client versions more easily, and troubleshoot failures with clearer logs.
+
+  OpenHound now continues checking in during active collections to reduce unintended job timeouts, reports its installed version back to BloodHound for better client visibility, improves log readability, handles deferred pipeline failures more consistently, and continues collection more often when single-object errors occur.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["API"]}>
+  {/*BED-8608, BED-8609*/}
+  ## Graph ID Lookup APIs
+
+  Retrieve specific nodes and relationships by their graph-assigned integer IDs when you need to automate graph lookups outside the UI.
+
+  BloodHound now exposes [`GET /api/v2/nodes/{node_id}`](/reference/opengraph-experimental/get-node-by-graph-node-id) and [`GET /api/v2/relationships/{relationship_id}`](/reference/opengraph-experimental/get-relationship-by-graph-relationship-id) to simplify targeted integrations and investigation workflows.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Privilege Zones"]}>
+  {/*BED-8303, BED-7739, BED-8520*/}
+  ## Privilege Zone Rule Authoring Improvements
+
+  Build and validate Privilege Zone rules with less rework when you switch rule types or refine Cypher-based rules.
+
+  BloodHound now preserves rule state when you switch between Cypher and Object ID rules, prompts you to rerun Cypher when the query changes, and prevents saving Cypher rules that have not produced valid results.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
+  {/*BED-7222, BED-7215, BED-7212, BED-8290*/}
+  ## Accessibility Improvements
+
+  Navigate BloodHound with clearer focus states, more consistent semantic structure, and better screen-reader labeling across key workflows.
+
+  This release improves accessible names and labels in administration forms, strengthens visible keyboard focus behavior, and refines headings and page structure to better support assistive technologies.
+</Update>
+
+<Update label="BloodHound" tags={["Fixed Issues"]}>
+  ## Analysis and API
+
+  - {/*BED-8136*/} Resolved an issue where [`GET /api/v2/datapipe/status`](/reference/datapipe/get-datapipe-status) did not reliably update `last_analysis_run_at` and did not expose the scheduled-analysis timestamps needed to track analysis cadence.
+  - {/*BED-5572*/} Resolved an issue where multi-forest environments that shared ADCS infrastructure could produce false-positive attack paths.
+  - {/*BED-4867*/} Resolved an issue where Azure descendant `related_entity_type` requests could respond too slowly in large tenants.
+  - {/*BED-7883*/} Resolved an issue where Cypher equality comparisons could fail for values that contained special characters.
+
+  ## Explore, Posture, and Privilege Zones
+
+  - {/*BED-8114*/} Resolved an issue where the **Attack Paths** and **Posture** pages could show inconsistent finding counts.
+  - {/*BED-8642*/} Resolved an issue where pathfinding involving OpenGraph data could fail unexpectedly.
+  - {/*BED-8310*/} Resolved an issue where the Privilege Zone object details panel failed to load OpenGraph node data for rule-matched objects.
+  - {/*BED-8390*/} Resolved an issue where parts of the **Posture** page used browser localization settings inconsistently.
+
+  ## Administration, OpenGraph, and UI
+
+  - {/*BED-8656*/} Resolved an issue where dragging a file into **Quick Upload** on the **OpenGraph Management** page could open the wrong upload dialog.
+  - {/*BED-8570*/} Resolved an issue where the OpenGraph extension deletion dialog only accepted one character at a time when confirming an extension name.
+  - {/*BED-7040*/} Resolved an issue where saved-query uploads did not use the same ingest file safety checks as other upload workflows.
+  - {/*BED-8189*/} Resolved an issue in BloodHound Community where the default `admin` email address used an example value that was misleading in production-like setups.
+  - {/*BED-8754*/} Resolved focus-state inconsistencies that could make active controls harder to distinguish during keyboard navigation.
+</Update>
+
+<Update label="OpenHound" tags={["Fixed Issues"]}>
+  ## GitHub Collection Reliability
+
+  - {/*BED-8783*/} Resolved an issue where a stub `GH_Organization` node could overwrite a fully collected organization and incorrectly mark it as not collected.
+  - {/*BED-8687*/} Resolved an issue that could cause GitHub collections to fail during normalization in early 0.2.x releases.
+  - {/*BED-8689*/} Resolved issues that made large GitHub collections more likely to stall or fail when GitHub API rate limits were exhausted.
+
+  ## Jamf and Okta Collection Reliability
+
+  - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior across 0.2.x releases.
+  - {/*BED-8692*/} Resolved an issue that could cause Okta and GitHub collections to fail in Kubernetes-based deployments.
+</Update>
+
+{/* TODO(doc-follow-up):
+- Update docs/manage-bloodhound/auth/users-and-roles.mdx if Auditor access to File Ingest and SSO Configuration is now part of the supported permission matrix.
+- Review docs/analyze-data/privilege-zones/rules.mdx for the rule-builder validation and state-preservation changes in this release, and confirm whether Variable Analysis Mode needs separate public documentation.
+- Review docs/collect-data/enterprise-collection/monitor.mdx, docs/collect-data/enterprise-collection/create-collector.mdx, and docs/openhound/configuration.mdx for OpenHound version visibility, long-running job heartbeat behavior, and updated troubleshooting guidance.
+*/}

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -161,15 +161,10 @@ sidebarTitle: "2026-07-07"
 </Update>
 
 <Update label="OpenHound" tags={["Fixed Issues"]}>
-  ## GitHub Collection Reliability
-
   - {/*BED-8783*/} Resolved an issue where a stub `GH_Organization` node could overwrite a fully collected organization and incorrectly mark it as not collected.
-  - {/*BED-8687*/} Resolved an issue that could cause GitHub collections to fail during normalization in early 0.2.x releases.
+  - {/*BED-8687*/} Resolved an issue that could cause GitHub collections to fail during normalization.
   - {/*BED-8689*/} Resolved issues that made large GitHub collections more likely to stall or fail when GitHub API rate limits were exhausted.
-
-  ## Jamf and Okta Collection Reliability
-
-  - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior across 0.2.x releases.
+  - {/*BED-8768, BED-8729, BED-8688*/} Resolved multiple Jamf collector failures involving preprocessing, database lookups, and ingest behavior.
   - {/*BED-8692*/} Resolved an issue that could cause Okta and GitHub collections to fail in Kubernetes-based deployments.
 </Update>
 

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -121,7 +121,7 @@ sidebarTitle: "2026-07-07"
 
   See Privilege Zone updates reflected in your graph faster.
 
-  When you enable **Variable Analysis Mode** on the **Early Access** page, BloodHound Enterprise can skip post-processing after Privilege Zone changes and re-run only the analysis stages needed to update the graph.
+  When you enable **Variable Analysis Mode** on the **Early Access** page, BloodHound Enterprise can skip post-processing after Privilege Zone changes and re-run only the analysis stages needed to update tagged objects and findings.
   
   This reduces the time it takes for updated zone definitions and related findings to appear in the graph.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -49,6 +49,17 @@ sidebarTitle: "2026-07-07"
   BloodHound now exposes [`GET /api/v2/nodes/{node_id}`](/reference/opengraph-experimental/get-node-by-graph-node-id) and [`GET /api/v2/relationships/{relationship_id}`](/reference/opengraph-experimental/get-relationship-by-graph-relationship-id) to simplify targeted integrations and investigation workflows.
 </Update>
 
+<Update label="BloodHound" description="Enhancement" tags={["Cypher"]}>
+  {/*BI-1814*/}
+  ## Higher Memory Limits for User-Generated Cypher Queries
+
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+  Run more complex user-generated Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
+
+  This release raises the [`graph_query_memory_limit`](/manage-bloodhound/bh-config#graph_query_memory_limit) setting used for user-generated Cypher queries from `2` to `4`, increasing the memory available to those workflows in hosted enterprise environments.
+</Update>
+
 <Update label="BloodHound" description="Enhancement" tags={["Privilege Zones"]}>
   {/*BED-8303, BED-7739, BED-8520*/}
   ## Privilege Zone Rule Authoring Improvements
@@ -115,6 +126,7 @@ sidebarTitle: "2026-07-07"
 
 {/* TODO(doc-follow-up):
 - Update docs/manage-bloodhound/auth/users-and-roles.mdx if Auditor access to File Ingest and SSO Configuration is now part of the supported permission matrix.
+- Review docs/manage-bloodhound/bh-config.mdx if the documented `graph_query_memory_limit` example or rollout guidance should change after the enterprise fleet configuration update ships.
 - Review docs/analyze-data/privilege-zones/rules.mdx for the rule-builder validation and state-preservation changes in this release, and confirm whether Variable Analysis Mode needs separate public documentation.
 - Review docs/collect-data/enterprise-collection/monitor.mdx, docs/collect-data/enterprise-collection/create-collector.mdx, and docs/openhound/configuration.mdx for OpenHound version visibility, long-running job heartbeat behavior, and updated troubleshooting guidance.
 */}

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -27,16 +27,14 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-07-07 | v9.4.0 | v0.2.11 | No release | No release |
 
-This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
+This release opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
-- **New edges**: Model ADCS ESC14 Scenario A attack paths with new certificate-mapping edge coverage.
 - **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than were previously supported.
 
 ### <Icon icon="sparkles" /> New Features
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Data Collection | [ADCS ESC14 Scenario A Attack Paths](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-attack-paths) | Analyze certificate-mapping attack paths that rely on a principal's `altSecurityIdentities` attribute. |
 | API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
 
 ### <Icon icon="check-circle" /> Enhancements
@@ -53,7 +51,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 
 ### <Icon icon="wrench" /> Fixed Issues
 
-See the [release notes](/resources/release-notes/2026-07-07#bloodhound-9) for a full list of fixed issues in this release.
+See the [release notes](/resources/release-notes/2026-07-07#bloodhound-8) for a full list of fixed issues in this release.
 
 ## 2026-06-17
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -30,7 +30,7 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
 - **New edges**: Model ADCS ESC14 Scenario A attack paths with new certificate-mapping edge coverage.
-- **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
+- **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previously supported.
 
 ### <Icon icon="sparkles" /> New Features
 
@@ -43,7 +43,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Administration | [Auditor Role Access Improvements](/resources/release-notes/2026-07-07#auditor-role-access-improvements) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
+| Administration | [Auditor Role Access Improvements](/resources/release-notes/2026-07-07#auditor-role-access-improvements) | Auditors may now review **File Ingest** activity and **SSO Configuration** details. |
 | Administration | [Updated Default Admin Email Address](/resources/release-notes/2026-07-07#updated-default-admin-email-address) | BloodHound Community now uses `admin@example.com` instead of `spam@example.com` in configuration and example files. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
 | Cypher (Enterprise) | [Higher Memory Limits for Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-cypher-queries) | BloodHound Enterprise now uses a higher memory limit for Cypher queries. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -30,7 +30,7 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
 - **New edges**: Model ADCS ESC14 Scenario A attack paths with new certificate-mapping edge coverage.
-- **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previously supported.
+- **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than were previously supported.
 
 ### <Icon icon="sparkles" /> New Features
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -31,6 +31,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 
 - **Attack path coverage**: Model ADCS ESC14 Scenario A paths with new certificate-mapping edge coverage.
 - **Administration**: Let auditors inspect **File Ingest** and **SSO Configuration** without receiving edit access.
+- **Cypher**: Raise the memory available to user-generated Cypher queries in BloodHound Enterprise so more complex queries and larger **Entity Panel** sections can return successfully.
 - **OpenHound**: Keep long-running jobs alive, surface deployed versions in BloodHound, and troubleshoot failures with clearer logs.
 
 ### <Icon icon="sparkles" /> New Features
@@ -46,6 +47,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 | Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
 | API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
+| Cypher (Enterprise) | [Higher Memory Limits for User-Generated Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-user-generated-cypher-queries) | Increase the `graph_query_memory_limit` used for user-generated Cypher queries so more complex queries and larger **Entity Panel** sections can return. |
 | Privilege Zones | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and require valid Cypher results before saving. |
 | Privilege Zones | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Review unrealized Privilege Zone analysis changes and manage the related feature flag more directly. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-07-07#accessibility-improvements) | Navigate key workflows with clearer focus states, semantic structure, and screen-reader labels. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -29,6 +29,7 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 
 This release opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
+- **OpenHound**: Keep long-running jobs alive, identify deployed client versions more easily, and troubleshoot failures with clearer logs.
 - **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than were previously supported.
 
 ### <Icon icon="sparkles" /> New Features

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -44,6 +44,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 | Component | Update | Summary |
 | --- | --- | --- |
 | Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
+| Administration | [Updated Default Admin Email Address](/resources/release-notes/2026-07-07#updated-default-admin-email-address) | BloodHound Community now uses `admin@example.com` instead of `spam@example.com` in configuration and example files. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
 | Cypher (Enterprise) | [Higher Memory Limits for Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-cypher-queries) | BloodHound Enterprise now uses a higher memory limit for Cypher queries. |
 | Zone Builder | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and warn before saving Cypher-based rules that return no results. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -53,7 +53,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 
 ### <Icon icon="wrench" /> Fixed Issues
 
-See the [release notes](/resources/release-notes/2026-07-07#bloodhound-6) for a full list of fixed issues in this release.
+See the [release notes](/resources/release-notes/2026-07-07#bloodhound-9) for a full list of fixed issues in this release.
 
 ## 2026-06-17
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -29,21 +29,21 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 
 This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
-- **New edges**: Model ADCS ESC14 Scenario A paths with new certificate-mapping edge coverage.
+- **New edges**: Model ADCS ESC14 Scenario A attack paths with new certificate-mapping edge coverage.
 - **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
 
 ### <Icon icon="sparkles" /> New Features
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Data Collection | [ADCS ESC14 Scenario A Coverage](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-attack-paths) | Analyze certificate-mapping attack paths that rely on a principal's `altSecurityIdentities` attribute. |
+| Data Collection | [ADCS ESC14 Scenario A Attack Paths](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-attack-paths) | Analyze certificate-mapping attack paths that rely on a principal's `altSecurityIdentities` attribute. |
 | API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
 
 ### <Icon icon="check-circle" /> Enhancements
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
+| Administration | [Auditor Role Access Improvements](/resources/release-notes/2026-07-07#auditor-role-access-improvements) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
 | Administration | [Updated Default Admin Email Address](/resources/release-notes/2026-07-07#updated-default-admin-email-address) | BloodHound Community now uses `admin@example.com` instead of `spam@example.com` in configuration and example files. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
 | Cypher (Enterprise) | [Higher Memory Limits for Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-cypher-queries) | BloodHound Enterprise now uses a higher memory limit for Cypher queries. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -38,7 +38,8 @@ This release expands ADCS attack path coverage, opens more administration workfl
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Attack Paths | [ADCS ESC14 Scenario A Coverage](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-coverage) | Analyze certificate-mapping attack paths that rely on `altSecurityIdentities`. |
+| Data Collection | [ADCS ESC14 Scenario A Coverage](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-attack-paths) | Analyze certificate-mapping attack paths that rely on a principal's `altSecurityIdentities` attribute. |
+| API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
 
 ### <Icon icon="check-circle" /> Enhancements
 
@@ -46,10 +47,9 @@ This release expands ADCS attack path coverage, opens more administration workfl
 | --- | --- | --- |
 | Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
-| API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
 | Cypher (Enterprise) | [Higher Memory Limits for User-Generated Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-user-generated-cypher-queries) | Increase the `graph_query_memory_limit` used for user-generated Cypher queries so more complex queries and larger **Entity Panel** sections can return. |
-| Privilege Zones | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and require valid Cypher results before saving. |
-| Privilege Zones | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Review unrealized Privilege Zone analysis changes and manage the related feature flag more directly. |
+| Zone Builder | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and warn before saving Cypher rules that currently return no results. |
+| Zone Builder | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Reduce the time it takes for Privilege Zone changes to appear in the graph and in related findings. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-07-07#accessibility-improvements) | Navigate key workflows with clearer focus states, semantic structure, and screen-reader labels. |
 
 ### <Icon icon="wrench" /> Fixed Issues

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -29,10 +29,8 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 
 This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 
-- **Attack path coverage**: Model ADCS ESC14 Scenario A paths with new certificate-mapping edge coverage.
-- **Administration**: Let auditors inspect **File Ingest** and **SSO Configuration** without receiving edit access.
-- **Cypher**: Raise the memory available to user-generated Cypher queries in BloodHound Enterprise so more complex queries and larger **Entity Panel** sections can return successfully.
-- **OpenHound**: Keep long-running jobs alive, surface deployed versions in BloodHound, and troubleshoot failures with clearer logs.
+- **New edges**: Model ADCS ESC14 Scenario A paths with new certificate-mapping edge coverage.
+- **Cypher**: Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than the previous default allowed.
 
 ### <Icon icon="sparkles" /> New Features
 
@@ -47,9 +45,9 @@ This release expands ADCS attack path coverage, opens more administration workfl
 | --- | --- | --- |
 | Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
-| Cypher (Enterprise) | [Higher Memory Limits for User-Generated Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-user-generated-cypher-queries) | Increase the `graph_query_memory_limit` used for user-generated Cypher queries so more complex queries and larger **Entity Panel** sections can return. |
-| Zone Builder | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and warn before saving Cypher rules that currently return no results. |
-| Zone Builder | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Reduce the time it takes for Privilege Zone changes to appear in the graph and in related findings. |
+| Cypher (Enterprise) | [Higher Memory Limits for Cypher Queries](/resources/release-notes/2026-07-07#higher-memory-limits-for-cypher-queries) | BloodHound Enterprise now uses a higher memory limit for Cypher queries. |
+| Zone Builder | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and warn before saving Cypher-based rules that return no results. |
+| Zone Builder | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Skip post-processing after Privilege Zone changes so updated zone definitions and related findings appear faster in the graph. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-07-07#accessibility-improvements) | Navigate key workflows with clearer focus states, semantic structure, and screen-reader labels. |
 
 ### <Icon icon="wrench" /> Fixed Issues

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -20,6 +20,39 @@ SpecterOps is heading to Black Hat USA 2026 with training courses, technical bri
 
 We're excited to share that SO-CON talks are now available [online](https://ghst.ly/SOCON26YT). We've also published the presentation slide decks in a public [GitHub repository](https://github.com/SpecterOps/presentations/tree/main/SO-CON%202026).
 
+## 2026-07-07
+
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-07-07 | v9.4.0 | v0.2.10 | No release | No release |
+
+This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
+
+- **Attack path coverage**: Model ADCS ESC14 Scenario A paths with new certificate-mapping edge coverage.
+- **Administration**: Let auditors inspect **File Ingest** and **SSO Configuration** without receiving edit access.
+- **OpenHound**: Keep long-running jobs alive, surface deployed versions in BloodHound, and troubleshoot failures with clearer logs.
+
+### <Icon icon="sparkles" /> New Features
+
+| Component | Update | Summary |
+| --- | --- | --- |
+| Attack Paths | [ADCS ESC14 Scenario A Coverage](/resources/release-notes/2026-07-07#adcs-esc14-scenario-a-coverage) | Analyze certificate-mapping attack paths that rely on `altSecurityIdentities`. |
+
+### <Icon icon="check-circle" /> Enhancements
+
+| Component | Update | Summary |
+| --- | --- | --- |
+| Administration | [Auditor Access for File Ingest and SSO Configuration](/resources/release-notes/2026-07-07#auditor-access-for-file-ingest-and-sso-configuration) | Let auditors review **File Ingest** activity and **SSO Configuration** details without edit permissions. |
+| Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
+| API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
+| Privilege Zones | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and require valid Cypher results before saving. |
+| Accessibility | [Accessibility Improvements](/resources/release-notes/2026-07-07#accessibility-improvements) | Navigate key workflows with clearer focus states, semantic structure, and screen-reader labels. |
+
+### <Icon icon="wrench" /> Fixed Issues
+
+See the [release notes](/resources/release-notes/2026-07-07#bloodhound-6) for a full list of fixed issues in this release.
+
 ## 2026-06-17
 
 |     |     |     |     |     |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -25,7 +25,7 @@ We're excited to share that SO-CON talks are now available [online](https://ghst
 |     |     |     |     |     |
 | --- | --- | --- | --- | --- |
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
-| 2026-07-07 | v9.4.0 | v0.2.10 | No release | No release |
+| 2026-07-07 | v9.4.0 | v0.2.11 | No release | No release |
 
 This release expands ADCS attack path coverage, opens more administration workflows to auditors in read-only mode, and improves OpenHound collection resilience. Key highlights include:
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -47,6 +47,7 @@ This release expands ADCS attack path coverage, opens more administration workfl
 | Data Collection | [More Resilient OpenHound Operations](/resources/release-notes/2026-07-07#more-resilient-openhound-operations) | Keep OpenHound jobs alive longer, surface installed versions in BloodHound, and improve logging and failure handling. |
 | API | [Graph ID Lookup APIs](/resources/release-notes/2026-07-07#graph-id-lookup-apis) | Retrieve nodes and relationships by graph-assigned integer IDs for targeted automation and investigation. |
 | Privilege Zones | [Privilege Zone Rule Authoring Improvements](/resources/release-notes/2026-07-07#privilege-zone-rule-authoring-improvements) | Preserve rule state across rule types and require valid Cypher results before saving. |
+| Privilege Zones | [Variable Analysis Mode](/resources/release-notes/2026-07-07#variable-analysis-mode) | Review unrealized Privilege Zone analysis changes and manage the related feature flag more directly. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-07-07#accessibility-improvements) | Navigate key workflows with clearer focus states, semantic structure, and screen-reader labels. |
 
 ### <Icon icon="wrench" /> Fixed Issues


### PR DESCRIPTION
## Purpose

This pull request (PR) adds release notes for the v9.4.0 BloodHound release cycle to the release integration branch, which includes:

- BloodHound v9.4.0
- OpenHound v0.2.11 (also includes issues from undocumented iterations since v0.2.1)

No release for:

- SharpHound
- AzureHound

There are several related PRs for supporting documentation that also need to be reviewed and merged separately to ensure alignment with release notes:

- #337 
- #336 
- #335 
- #332 
- ~#325~
- #303 

## Staging

- [summary](https://specterops-bp-2735-release-notes.mintlify.app/resources/release-notes/summary#2026-07-07)
- [release notes](https://specterops-bp-2735-release-notes.mintlify.app/resources/release-notes/2026-07-07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new release notes entry highlighting ADCS ESC14 Scenario A graph coverage and experimental graph ID lookup APIs.
  * Documented new Enterprise analysis options, including a variable analysis mode for faster re-runs after privilege zone changes.

* **Enhancements**
  * Noted improved read-only access for auditors and updated default admin email guidance.
  * Expanded Zone Builder authoring guidance and increased default query memory limits.

* **Bug Fixes**
  * Added multiple fixed issues across analysis, API, explore, OpenGraph, UI, findings, and collector stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->