### PR TITLE
Add guidance for variable analysis mode

### DIFF
--- a/docs/analyze-data/findings/analysis.mdx
+++ b/docs/analyze-data/findings/analysis.mdx
@@ -53,7 +53,7 @@ BloodHound does not rely only on directly collected relationships. During **post
 
 When updating Privilege Zones, you likely want to see updated object membership and related findings as quickly as possible. You can speed up this process by enabling **Variable Analysis Mode** on the **Administration** > **Early Access Features** page.
 
-Variable analysis mode effectively skips the pre-processing stages of analysis. BloodHound still updates normal analysis completion tracking after these runs, including timestamps and related status information.
+Variable analysis mode effectively skips the post-processing stages of analysis. BloodHound still updates normal analysis completion tracking after these runs, including timestamps and related status information.
 
 <Note>
   This option applies to Privilege Zone-triggered analysis only. Other actions that trigger analysis still run the full pipeline.

--- a/docs/analyze-data/findings/analysis.mdx
+++ b/docs/analyze-data/findings/analysis.mdx
@@ -53,7 +53,7 @@ BloodHound does not rely only on directly collected relationships. During **post
 
 When updating Privilege Zones, you likely want to see updated object membership and related findings as quickly as possible. You can speed up this process by enabling **Variable Analysis Mode** on the **Administration** > **Early Access Features** page.
 
-Variable analysis mode effectively skips the post-processing stages of analysis. BloodHound still updates normal analysis completion tracking after these runs, including timestamps and related status information.
+Variable analysis mode skips the post-processing stages of analysis. BloodHound still updates normal analysis completion tracking after these runs, including timestamps and related status information.
 
 <Note>
   This option applies to Privilege Zone-triggered analysis only. Other actions that trigger analysis still run the full pipeline.

--- a/docs/analyze-data/findings/analysis.mdx
+++ b/docs/analyze-data/findings/analysis.mdx
@@ -10,6 +10,21 @@ import defCompositeEdge from '/snippets/terms/composite-edge.mdx';
 
 BloodHound Enterprise's analysis process includes several key steps that work together to surface findings and prioritize risk.
 
+## Analysis stages
+
+By default, BloodHound runs the full analysis pipeline in the following order:
+
+1. Active Directory post-processing
+1. Azure post-processing
+1. Tagging
+1. Analysis
+
+BloodHound uses the full analysis pipeline for all standard and scheduled analysis runs. BloodHound Enterprise customers can enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) to skip post-processing for some analysis runs to speed up the process (for example, when updating Privilege Zones).
+
+<Note>
+  Scheduled analysis is a SpecterOps-managed feature.
+</Note>
+
 ## Choke point analysis
 
 BloodHound Enterprise generates one <Tooltip tip="An aggregate view of the graph for a selected environment and privilege zone. It simplifies large volumes of nodes and edges into a compact visualization optimized for readability." cta="Learn more" href="/analyze-data/findings/attack-paths">choke point view</Tooltip> view per environment, such as an Active Directory domain or Azure tenant. The choke point view organizes findings by category and shows the number of exposed principals in each, helping you quickly understand where risk concentrates.
@@ -33,6 +48,16 @@ BloodHound does not rely only on directly collected relationships. During **post
 <defCompositeEdge />
 
 <PostProcessedEdges />
+
+## Variable Analysis Mode
+
+When updating Privilege Zones, you likely want to see updated object membership and related findings as quickly as possible. You can speed up this process by enabling **Variable Analysis Mode** on the **Administration** > **Early Access Features** page.
+
+Variable analysis mode effectively skips the pre-processing stages of analysis. BloodHound still updates normal analysis completion tracking after these runs, including timestamps and related status information.
+
+<Note>
+  This option applies to Privilege Zone-triggered analysis only. Other actions that trigger analysis still run the full pipeline.
+</Note>
 
 ## Remediation
 

--- a/docs/analyze-data/privilege-zones/overview.mdx
+++ b/docs/analyze-data/privilege-zones/overview.mdx
@@ -40,6 +40,16 @@ Before working with Privilege Zones, it's important to understand how BloodHound
 
 Most changes to Privilege Zones affect object membership and require analysis to run before you can validate the results. Understanding when you can expect to see results helps you maintain your configuration and validate remediation efforts.
 
+For Cypher-based rules, validation happens in two stages. First, rerun the query in the rule editor after you change it so BloodHound can validate the updated rule definition. After you save the rule, BloodHound runs analysis before updated zone or label membership appears elsewhere in the product.
+
+<Callout color="#8E92EB">
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at **Tagging** instead of re-running post-processing.
+
+_Scheduled analysis (a SpecterOps-managed feature) always runs a full analysis._
+</Callout>
+
 ## Workflow
 
 The following steps represent the general workflow for making changes and validating the results:
@@ -63,7 +73,11 @@ The following steps represent the general workflow for making changes and valida
   <Step title="Wait for analysis to complete">
     Check your [tenant status](/collect-data/enterprise-collection/monitor#tenant-status) to monitor analysis progress. During analysis, BloodHound re-evaluates object membership against the updated configuration.
 
-    <Note>Analysis may take several minutes to complete depending on the size of your environment. Until analysis finishes, the Zone Builder **Details View** and related metrics will not reflect your latest changes.</Note>
+    <Note>
+      Analysis may take several minutes to complete depending on the size of your environment. BloodHound Enterprise customers can enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) to potentially speed up analysis for Privilege Zone changes.
+
+      Until analysis finishes, the Zone Builder **Details View** and related metrics will not reflect your latest changes.
+    </Note>
   </Step>
 
   <Step title="Validate the results">

--- a/docs/analyze-data/privilege-zones/overview.mdx
+++ b/docs/analyze-data/privilege-zones/overview.mdx
@@ -43,11 +43,11 @@ Most changes to Privilege Zones affect object membership and require analysis to
 For Cypher-based rules, validation happens in two stages. First, rerun the query in the rule editor after you change it so BloodHound can validate the updated rule definition. After you save the rule, BloodHound runs analysis before updated zone or label membership appears elsewhere in the product.
 
 <Callout color="#8E92EB">
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
-If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at **Tagging** instead of re-running post-processing.
+  If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at **Tagging** instead of re-running post-processing.
 
-_Scheduled analysis (a SpecterOps-managed feature) always runs a full analysis._
+  _Scheduled analysis (a SpecterOps-managed feature) always runs a full analysis._
 </Callout>
 
 ## Workflow

--- a/docs/analyze-data/privilege-zones/overview.mdx
+++ b/docs/analyze-data/privilege-zones/overview.mdx
@@ -45,7 +45,7 @@ For Cypher-based rules, validation happens in two stages. First, rerun the query
 <Callout color="#8E92EB">
   <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
-  If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at **Tagging** instead of re-running post-processing.
+  If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at the **Tagging** stage instead of running the full analysis pipeline.
 
   _Scheduled analysis (a SpecterOps-managed feature) always runs a full analysis._
 </Callout>

--- a/docs/collect-data/enterprise-collection/monitor.mdx
+++ b/docs/collect-data/enterprise-collection/monitor.mdx
@@ -25,8 +25,6 @@ Tenant status (also known as [datapipe status](/reference/datapipe/get-datapipe-
 | **Purging** | Data is actively being deleted from the database (for example, you used the **Database Management** page to delete data). |
 
 <Callout color="#8E92EB">
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
-
 If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, analysis triggered by Privilege Zone changes still appears as **Analyzing** in tenant status.
 
 The tenant status does not distinguish between a full analysis run and a variable analysis run that starts at **Tagging**.

--- a/docs/collect-data/enterprise-collection/monitor.mdx
+++ b/docs/collect-data/enterprise-collection/monitor.mdx
@@ -24,6 +24,16 @@ Tenant status (also known as [datapipe status](/reference/datapipe/get-datapipe-
 | **Pruning** | Analysis is almost complete; stale objects, edges, and disconnected nodes are being removed based on [data reconciliation](/collect-data/enterprise-collection/data-retention) settings. |
 | **Purging** | Data is actively being deleted from the database (for example, you used the **Database Management** page to delete data). |
 
+<Callout color="#8E92EB">
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+
+If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, analysis triggered by Privilege Zone changes still appears as **Analyzing** in tenant status.
+
+The tenant status does not distinguish between a full analysis run and a variable analysis run that starts at **Tagging**.
+
+_Scheduled analysis (a SpecterOps-managed feature) always runs a full analysis._
+</Callout>
+
 ## Job Status
 
 The following statuses apply to both the **Finished Jobs Log** and **File Ingest** pages.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance on analysis stages and when updates may run faster with Variable Analysis Mode.
  * Explained how Privilege Zone validation works and when results become visible after analysis completes.
  * Clarified tenant status behavior during analysis, including how scheduled analysis is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Staging

https://specterops-variable-analysis-mode-clean.mintlify.site/analyze-data/findings/analysis