### PR TITLE
Add rule enhancements

### DIFF
--- a/docs/analyze-data/privilege-zones/labels.mdx
+++ b/docs/analyze-data/privilege-zones/labels.mdx
@@ -46,7 +46,7 @@ The **Owned** label represents objects that have been compromised in your enviro
 
 ### Create a label
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 You can create custom labels to categorize objects based on any criteria relevant to your environment, such as business function, sensitivity level, or compliance requirements.
 
@@ -140,7 +140,7 @@ To edit a label, follow these steps:
 
 ### Delete a label
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 You cannot delete the default **Owned** label, but you can edit its description and rules.
 

--- a/docs/analyze-data/privilege-zones/overview.mdx
+++ b/docs/analyze-data/privilege-zones/overview.mdx
@@ -17,7 +17,7 @@ The **Zone Builder** page provides tools for configuring and managing your Privi
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Zone**          | A group of objects that represents a hierarchy of control across identity providers and services, based on access level. An object can belong to only one zone at a time (the highest-priority zone that matches). |
 | **Label**         | A flexible way to categorize objects for searching and filtering. An object can belong to multiple labels simultaneously.                                                                                          |
-| **Certification** | <Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge> An optional review step that pauses automatic inclusion of newly matched objects in a zone until you certify them.               |
+| **Certification** | An optional review step in BloodHound Enterprise only that pauses automatic inclusion of newly matched objects in a zone until you certify them.               |
 | **History**       | An audit log of changes made to zones, labels, and related rules.                                                                                                                                                  |
 
 Zones organize objects into a strict hierarchy. BloodHound analyzes how object privileges are assigned and where they can be escalated across your environment.
@@ -39,6 +39,8 @@ Before working with Privilege Zones, it's important to understand how BloodHound
 * **Objects can have multiple labels**: Unlike zones, an object can match multiple label rules simultaneously
 
 Most changes to Privilege Zones affect object membership and require analysis to run before you can validate the results. Understanding when you can expect to see results helps you maintain your configuration and validate remediation efforts.
+
+For Cypher-based rules, validation happens in two stages. First, rerun the query in the rule editor after you change it so BloodHound can validate the updated rule definition. After you save the rule, BloodHound runs analysis before updated zone or label membership appears elsewhere in the product.
 
 ## Workflow
 

--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -13,7 +13,9 @@ Rules are instructions that associate objects with zones and labels based on obj
 
 **Label** rules provide a flexible method of tagging objects in an environment. Objects can have multiple labels and you can use those labels to search and filter using Cypher in the **Explore** page.
 
-<Note>If your rules don't show expected objects, see [Troubleshoot missing objects](#troubleshoot-missing-objects).</Note>
+<Note>
+  If your rules don't show expected objects, see [Troubleshoot missing objects](#troubleshoot-missing-objects).
+</Note>
 
 ### Types
 
@@ -29,7 +31,9 @@ Rules automatically include related objects based on the type of object that you
 
 This "expansion" saves you time by tagging entire groups or organizational units at once. The following sections describe how different object types expand during the tagging process.
 
-<Tip>You can interrupt automatic inclusion of additional objects into Privilege Zones by requiring manual certification of the additional objects. See [Certification](/analyze-data/privilege-zones/certification) to learn more.</Tip>
+<Tip>
+  You can interrupt automatic inclusion of additional objects into Privilege Zones by requiring manual certification of the additional objects. See [Certification](/analyze-data/privilege-zones/certification) to learn more.
+</Tip>
 
 ### Group-like expansion
 
@@ -44,7 +48,9 @@ Objects that behave like groups in Active Directory include all contained member
 Objects that provide structural organization include all contained objects within the zone/label. These include the following type (edge) relationships:
 
 * Domain ([`Contains`](/resources/edges/contains))
-  <Note>For non-default rules only.</Note>
+  <Note>
+    For non-default rules only.
+  </Note>
 * OU ([`Contains`](/resources/edges/contains))
 * AZSubscription ([`AZContains`](/resources/edges/az-contains))
 * AZManagementGroup ([`AZContains`](/resources/edges/az-contains))
@@ -66,7 +72,9 @@ Unless you're defining a rule as part of the zone or label creation process, be 
 
 <Steps>
   <Step title="Open the Zone Builder page">
-    <Tip>If you're defining a rule as part of the [zone or label](/analyze-data/privilege-zones/zones) creation process, skip to **Configure rule details** below.</Tip>
+    <Tip>
+      If you're defining a rule as part of the [zone or label](/analyze-data/privilege-zones/zones) creation process, skip to **Configure rule details** below.
+    </Tip>
 
     1. In the left menu, click **Privilege Zones**.
 
@@ -80,18 +88,22 @@ Unless you're defining a rule as part of the zone or label creation process, be 
 
     1. Enter all relevant information for the rule:
 
-        <Warning>Review [rule expansion](/analyze-data/privilege-zones/rules#rule-expansion) for more information about rule behavior.</Warning>
+        <Warning>
+          Review [rule expansion](/analyze-data/privilege-zones/rules#rule-expansion) for more information about rule behavior.
+        </Warning>
 
         | Field                   | Required? | Description                                                                                                             |
         | ----------------------- | :-------: | ----------------------------------------------------------------------------------------------------------------------- |
         | Name                    |    Yes    | A unique name for the rule (e.g., PCI Assets)                                                                           |
         | Description             |     No    | A brief description of the rule's purpose and scope (e.g., PCI assets)                                                  |
-        | Automatic Certification |     No    | <Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge> An option to choose how BloodHound [certifies](/analyze-data/privilege-zones/certification) new objects (available for zones only) |
+        | Automatic Certification |     No    | An option in Enterprise Edition to choose how new objects are [certified](/analyze-data/privilege-zones/certification) (available for zones only) |
         | Rule Type               |    Yes    | The type of rule to use (e.g., Object ID or Cypher)                                                                     |
 
     **Automatic Certification options**
 
-    <Note>See [Certification](/analyze-data/privilege-zones/certification) to learn more.</Note>
+    <Note>
+      See [Certification](/analyze-data/privilege-zones/certification) to learn more.
+    </Note>
 
     * **Direct Objects**: Only the objects directly matched by the rule are certified automatically (excludes objects added through [expansion](#rule-expansion), such as OUs and GPOs). These objects are shown separately in the **Sample Results** panel.
     * **All Objects**: Every object (including those tied to direct objects through expansion) is certified automatically
@@ -105,6 +117,8 @@ Unless you're defining a rule as part of the zone or label creation process, be 
       </Frame>
 
       **Rule type configuration details**
+
+      When you switch between **Object ID** and **Cypher** while working on rules, BloodHound preserves the current state for each rule type until you save the rule or leave the page. If you navigate away before saving, BloodHound clears that temporary state.
 
       <Tabs>
         <Tab title="Object ID">
@@ -127,6 +141,8 @@ Unless you're defining a rule as part of the zone or label creation process, be 
 
           1. Click **Run** below the Cypher query box. You must run the query before you can create the rule.
 
+             If you change the query after running it, click **Run** again before you save the rule.
+
              <SampleResultsNote />
 
              <Frame>
@@ -136,7 +152,11 @@ Unless you're defining a rule as part of the zone or label creation process, be 
                />
              </Frame>
 
-             <Tip>*(Optional)* Click **View in Explore** to pivot to the **Explore** page and see results in the graph view.</Tip>
+             If the query returns no results, BloodHound asks you to confirm before saving the rule. This is useful when you expect a future data collection or environment change to produce matching objects.
+
+             <Tip>
+               *(Optional)* Click **View in Explore** to pivot to the **Explore** page and see results in the graph view.
+             </Tip>
         </Tab>
       </Tabs>
 
@@ -158,7 +178,9 @@ Unless you're defining a rule as part of the zone or label creation process, be 
 
 To edit or delete a rule, follow these steps:
 
-<Note>Only users with the appropriate [permissions](/manage-bloodhound/auth/users-and-roles) can make changes. You cannot delete [default rules](/analyze-data/privilege-zones/default-rules).</Note>
+<Note>
+  Only users with the appropriate [permissions](/manage-bloodhound/auth/users-and-roles) can make changes. You cannot delete [default rules](/analyze-data/privilege-zones/default-rules).
+</Note>
 
 <Steps>
   <Step title="Locate a rule">
@@ -197,13 +219,19 @@ To edit or delete a rule, follow these steps:
       <Tab title="Edit a rule" icon="edit">
         To edit a rule:
 
-        <Note>Only users with the appropriate [permissions](/manage-bloodhound/auth/users-and-roles) can make changes. You cannot disable some [default rules](/analyze-data/privilege-zones/default-rules).</Note>
+        <Note>
+          Only users with the appropriate [permissions](/manage-bloodhound/auth/users-and-roles) can make changes. You cannot disable some [default rules](/analyze-data/privilege-zones/default-rules).
+        </Note>
 
         1. Make any necessary changes to the rule configuration.
 
            For example, you can modify the rule's name, description, rule type, and certification settings (available for zones only).
 
            You can also disable or enable a rule by toggling the **Enabled** switch.
+
+           If you switch between **Object ID** and **Cypher** while editing the rule, BloodHound preserves the current state for each rule type until you save or leave the page.
+
+           If you edit a Cypher query, click **Run** again before you click **Save Edits**. If the rerun query returns no results, BloodHound asks you to confirm the save. If you do not rerun the updated query, BloodHound prompts you to run it before saving.
 
            <img
              src="/images/privzones/edit-rule.png"
@@ -247,9 +275,23 @@ For example, if an object is tagged by both a Tier Zero rule and a Tier One rule
 
 **Solution**: Review your **Zone Order** and check whether objects are being tagged by higher-priority zones. You can verify this by checking the higher-priority zones for the missing objects.
 
+### Unsaved rule type changes disappeared
+
+BloodHound preserves temporary **Object ID** and **Cypher** rule state only while you remain on the current rule page. If you leave the page before saving, BloodHound clears that temporary state.
+
+**Solution**: Save the rule before navigating away if you want to keep your current changes.
+
+### Cypher changes do not save
+
+If you change a Cypher query after running it, BloodHound requires you to click **Run** again before you can save the rule. This ensures BloodHound validates the updated query and refreshes the sample results for the current rule definition.
+
+If the query returns no results, BloodHound asks you to confirm the save. If you do not rerun the updated query, BloodHound prompts you to run it first.
+
+**Solution**: Rerun the updated query, review the direct and expanded sample results, and then save the rule.
+
 ### Object deleted from graph
 
-<Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 Objects are automatically deleted from the graph if they haven't been observed within the configured retention period. BloodHound stores a timestamp on every object that updates whenever a collection includes that object or references to it. This ensures your data remains fresh and accurate over time.
 

--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -257,9 +257,9 @@ To edit or delete a rule, follow these steps:
   </Step>
 </Steps>
 
-## Troubleshoot missing objects
+## Troubleshoot rules
 
-If a rule doesn't show expected objects or appears empty, consider the following common causes:
+If a rule doesn't tag the objects you expect, or you run into issues creating or saving a rule, use the following sections to identify the cause and resolve the issue.
 
 ### Domain filter mismatch
 
@@ -269,7 +269,7 @@ The **Domain** selector filters which objects are visible in the zone or label v
 
 ### Zone precedence conflicts
 
-When an object matches rules in multiple zones, only the highest-priority zone in your [**Zone Order**](/analyze-data/privilege-zones/zones) tags that object. Lower-priority zones won't tag the object, even if their rules match. This is why the **Sample Results** panel during [rule creation](#define-a-rule) may show objects that don't appear in your lower-priority zones—they're being tagged by a higher-priority zone instead.
+When an object matches rules in multiple zones, only the highest-priority zone in your [**Zone Order**](/analyze-data/privilege-zones/zones) tags that object. Lower-priority zones won't tag the object, even if their rules match. This is why the **Sample Results** panel during [rule creation](/analyze-data/privilege-zones/rules#define-a-rule) may show objects that don't appear in your lower-priority zones—they're being tagged by a higher-priority zone instead.
 
 For example, if an object is tagged by both a Tier Zero rule and a Tier One rule, it will only appear in the Tier Zero zone. The **Sample Results** panel would show the object as a result of your Tier One rule, but the object would only appear in the higher-priority Tier Zero zone, not in Tier One.
 

--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -14,7 +14,7 @@ Rules are instructions that associate objects with zones and labels based on obj
 **Label** rules provide a flexible method of tagging objects in an environment. Objects can have multiple labels and you can use those labels to search and filter using Cypher in the **Explore** page.
 
 <Note>
-  If your rules don't show expected objects, see [Troubleshoot missing objects](#troubleshoot-missing-objects).
+  If your rules don't show expected objects, see [Troubleshoot missing objects](/analyze-data/privilege-zones/rules#troubleshoot-missing-objects).
 </Note>
 
 ### Types
@@ -105,7 +105,7 @@ Unless you're defining a rule as part of the zone or label creation process, be 
       See [Certification](/analyze-data/privilege-zones/certification) to learn more.
     </Note>
 
-    * **Direct Objects**: Only the objects directly matched by the rule are certified automatically (excludes objects added through [expansion](#rule-expansion), such as OUs and GPOs). These objects are shown separately in the **Sample Results** panel.
+    * **Direct Objects**: Only the objects directly matched by the rule are certified automatically (excludes objects added through [expansion](/analyze-data/privilege-zones/rules#rule-expansion), such as OUs and GPOs). These objects are shown separately in the **Sample Results** panel.
     * **All Objects**: Every object (including those tied to direct objects through expansion) is certified automatically
     * **Off**: All certification is manual
 

--- a/docs/analyze-data/privilege-zones/zones.mdx
+++ b/docs/analyze-data/privilege-zones/zones.mdx
@@ -45,7 +45,7 @@ BloodHound uses zones to measure risk and detect violations. Each zone has a spe
 
 ### Create a zone
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 Creating a zone involves configuring the zone details and defining a rule.
 
@@ -147,7 +147,7 @@ To edit a zone, follow these steps:
 
 ### Delete a zone
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise Edition</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 You cannot delete the default **Tier Zero** zone, but you can edit its properties.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Privilege Zones docs to use the new Enterprise logo pill styling in place of the old badge in several places.
  * Added clearer guidance for creating, editing, and troubleshooting rules, including what happens when switching rule types, rerunning Cypher queries, and saving changes.
  * Clarified certification and validation behavior, including when updated zone or label membership becomes visible after analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Staging

https://specterops-pz-rule-enhancements.mintlify.site/analyze-data/privilege-zones/rules