### PR TITLE
chore: hide ADCS ESC14 edges

### DIFF
--- a/docs/resources/edges/generic-all.mdx
+++ b/docs/resources/edges/generic-all.mdx
@@ -4,7 +4,6 @@ description: This is also known as full control. This privilege allows the trust
 ---
 
 import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
-import AltSecurityIdentitiesEsc14 from '/snippets/edges/alt-security-identities-esc14.mdx';
 import GpoAbuseTools from '/snippets/edges/gpo-abuse-tools.mdx';
 
 <ResourceEditionPill />
@@ -21,8 +20,6 @@ You can reset user passwords with full control over user objects. For full abuse
 
 You can write to the `msDS-KeyCredentialLink` attribute on a user. Writing to this property allows an attacker to create "Shadow Credentials" on the object and authenticate as the principal using Kerberos PKINIT. See more information under the [AddKeyCredentialLink](/resources/edges/add-key-credential-link) edge.
 
-<AltSecurityIdentitiesEsc14 edgeName="GenericAll" />
-
 Alternatively, you can write to the `servicePrincipalNames` attribute and perform a targeted kerberoasting attack. See the abuse section under the [WriteSPN](/resources/edges/write-spn) edge for more information.
 
 ### With GenericAll Over a Computer
@@ -30,8 +27,6 @@ Alternatively, you can write to the `servicePrincipalNames` attribute and perfor
 You may read the LAPS password of the computer object. See more information under the [ReadLAPSPassword](/resources/edges/read-laps-password) edge.
 
 You can write to the `msDS-KeyCredentialLink` attribute on a computer. Writing to this property allows an attacker to create "Shadow Credentials" on the object and authenticate as the computer using Kerberos PKINIT. See more information under the [AddKeyCredentialLink](/resources/edges/add-key-credential-link) edge.
-
-<AltSecurityIdentitiesEsc14 edgeName="GenericAll" />
 
 Alternatively, Full control of a computer object can be used to perform a Resource-Based Constrained Delegation attack. See more information under the [AllowedToAct](/resources/edges/allowed-to-act) edge.
 

--- a/docs/resources/edges/generic-write.mdx
+++ b/docs/resources/edges/generic-write.mdx
@@ -4,7 +4,6 @@ description: Generic Write access grants you the ability to write to any non-pro
 ---
 
 import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
-import AltSecurityIdentitiesEsc14 from '/snippets/edges/alt-security-identities-esc14.mdx';
 import GpoAbuseTools from '/snippets/edges/gpo-abuse-tools.mdx';
 
 <ResourceEditionPill />
@@ -15,8 +14,6 @@ import GpoAbuseTools from '/snippets/edges/gpo-abuse-tools.mdx';
 
 With GenericWrite over a user, you can write to the `msDS-KeyCredentialLink` attribute. Writing to this property allows an attacker to create "Shadow Credentials" on the object and authenticate as the principal using Kerberos PKINIT. See more information under the [AddKeyCredentialLink](/resources/edges/add-key-credential-link) edge.
 
-<AltSecurityIdentitiesEsc14 edgeName="GenericWrite" />
-
 Alternatively, you can write to the `servicePrincipalNames` attribute and perform a targeted kerberoasting attack. See the abuse section under the [WriteSPN](/resources/edges/write-spn) edge for more information.
 
 **Groups**
@@ -26,8 +23,6 @@ With GenericWrite over a group, add yourself or another principal you control to
 **Computers**
 
 With GenericWrite over a computer, you can write to the `msDS-KeyCredentialLink` attribute. Writing to this property allows an attacker to create "Shadow Credentials" on the object and authenticate as the principal using Kerberos PKINIT. See more information under the [AddKeyCredentialLink](/resources/edges/add-key-credential-link) edge.
-
-<AltSecurityIdentitiesEsc14 edgeName="GenericWrite" />
 
 Alternatively, you can perform a resource-based constrained delegation attack against the computer. See the [AllowedToAct](/resources/edges/allowed-to-act) edge abuse info for more information about that attack.
 

--- a/docs/resources/edges/traversable-edges.mdx
+++ b/docs/resources/edges/traversable-edges.mdx
@@ -41,9 +41,8 @@ These are the traversable AD edge types in BloodHound:
 | [OwnsLimitedRights](/resources/edges/owns-limited-rights)       | [ReadGMSAPassword](/resources/edges/read-gmsa-password)         | [ReadLAPSPassword](/resources/edges/read-laps-password)            |
 | [SameForestTrust](/resources/edges/same-forest-trust)         | [SpoofSIDHistory](/resources/edges/spoof-sid-history)          | [SQLAdmin](/resources/edges/sql-admin)                   |
 | [SyncedToADUser](/resources/edges/synced-to-ad-user)          | [SyncedToEntraUser](/resources/edges/synced-to-entra-user)        | [SyncLAPSPassword](/resources/edges/sync-laps-password)            |
-| [WriteAccountRestrictions](/resources/edges/write-account-restrictions)| [WriteAltSecurityIdentities](/resources/edges/write-alt-security-identities) | [WriteDacl](/resources/edges/write-dacl)                |
-| [WriteGPLink](/resources/edges/write-gp-link)              | [WriteOwner](/resources/edges/write-owner) | [WriteOwnerLimitedRights](/resources/edges/write-owner-limited-rights) |
-| [WritePublicInformation](/resources/edges/write-public-information) | [WriteSPN](/resources/edges/write-spn) | |
+| [WriteAccountRestrictions](/resources/edges/write-account-restrictions)| [WriteDacl](/resources/edges/write-dacl) | [WriteGPLink](/resources/edges/write-gp-link)                |
+| [WriteOwner](/resources/edges/write-owner)              | [WriteOwnerLimitedRights](/resources/edges/write-owner-limited-rights) | [WriteSPN](/resources/edges/write-spn) |
 
 These are the traversable Azure edge types in BloodHound:
 

--- a/docs/resources/edges/write-alt-security-identities.mdx
+++ b/docs/resources/edges/write-alt-security-identities.mdx
@@ -1,6 +1,7 @@
 ---
 title: WriteAltSecurityIdentities
 description: "The principal can write to the altSecurityIdentities attribute on a user or computer, enabling explicit certificate mappings and ADCS ESC14 Scenario A."
+hidden: true
 ---
 
 import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';

--- a/docs/resources/edges/write-public-information.mdx
+++ b/docs/resources/edges/write-public-information.mdx
@@ -1,6 +1,7 @@
 ---
 title: WritePublicInformation
 description: "The principal can write to the Public-Information property set on a user or computer, including altSecurityIdentities and servicePrincipalName."
+hidden: true
 ---
 
 import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';


### PR DESCRIPTION
## Purpose

This pull request (PR) [hides](https://www.mintlify.com/docs/organize/hidden-pages) the ADCS ESC14 scenario A edges introduced in v9.4.0 (#325 - BED-6155) and removes related snippets from existing edges.

We're doing this because these edges require a SharpHound upgrade, but a SharpHound release is not scheduled to coincide with the v9.4.0 BloodHound release.

>[!NOTE]
>We should revert this commit in the future when the appropriate SharpHound version is available. We removed the v9.4.0  release notes copy in a [separate](https://github.com/SpecterOps/bloodhound-docs/pull/333/commits/2036c586b301265b7d33469e36658ace138674cb) commit, which we can also use later.