### PR TITLE
chore: move axonius integration to third-party section

### DIFF
--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -48,19 +48,6 @@ The sections below describe officially supported integrations, third-party integ
 The following integrations are officially supported by SpecterOps.
 
 <Card
-  title="Axonius"
-  href="https://docs.axonius.com/docs/bloodhound"
->
-  The Axonius integration enables Axonius users to fetch and catalog users and devices from BloodHound Enterprise, providing visibility into identity relationships and potential Attack Paths.
-
-  | | |
-  | --- | --- |
-  | **Supported actions** | Fetch BloodHound Enterprise Attack Path Details:<ul><li>All Tier Zero Assets</li><li>All Computer Admin Users</li><li>All Users with RDP Access</li><li>Assets by Attack Path</li><li>Only Enabled Users</li></ul> |
-  | **Common use cases** | <ul><li>Identify which identities hold administrative or privileged access rights within the environment.</li><li>Discover users who hold administrative or privileged access rights within the environment, and any associated devices where that user has admin rights.</li><li>Identify devices and assets that are within an Attack Path.</li></ul> |
-  | **Integration instructions** | <a href="https://docs.axonius.com/docs/bloodhound">Configure the Axonius adapter for BloodHound</a> |
-</Card>
-
-<Card
   title="Palo Alto XSOAR"
   href="/integrations/cortex-xsoar/configure"
 >
@@ -158,6 +145,19 @@ The following integrations are officially supported by SpecterOps.
 ### Third-party integrations
 
 The following integrations are developed by third-party vendors and are not officially supported by SpecterOps.
+
+<Card
+  title="Axonius"
+  href="https://docs.axonius.com/docs/bloodhound"
+>
+  The Axonius integration enables Axonius users to fetch and catalog users and devices from BloodHound Enterprise, providing visibility into identity relationships and potential Attack Paths.
+
+  | | |
+  | --- | --- |
+  | **Supported actions** | Fetch BloodHound Enterprise Attack Path Details:<ul><li>All Tier Zero Assets</li><li>All Computer Admin Users</li><li>All Users with RDP Access</li><li>Assets by Attack Path</li><li>Only Enabled Users</li></ul> |
+  | **Common use cases** | <ul><li>Identify which identities hold administrative or privileged access rights within the environment.</li><li>Discover users who hold administrative or privileged access rights within the environment, and any associated devices where that user has admin rights.</li><li>Identify devices and assets that are within an Attack Path.</li></ul> |
+  | **Integration instructions** | <a href="https://docs.axonius.com/docs/bloodhound">Configure the Axonius adapter for BloodHound</a> |
+</Card>
 
 <Card
   title="Cisco Duo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the integrations overview to reclassify Axonius from “Supported integrations” to “Third-party integrations.”
  * No other listed integrations were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->