### PR TITLE
BP-2504: Use consistent iconography for traversable edges

### DIFF
--- a/docs/analyze-data/explore/search.mdx
+++ b/docs/analyze-data/explore/search.mdx
@@ -213,7 +213,7 @@ Layout behavior depends on whether you explicitly choose a layout:
     <Tabs>
       <Tab title="Organic">
 
-        <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+        <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
         Uses a force-directed layout algorithm to position objects based on their relationships, creating a natural and intuitive view of the graph.
 
@@ -226,7 +226,7 @@ Layout behavior depends on whether you explicitly choose a layout:
       </Tab>
       <Tab title="Stacked">
 
-        <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+        <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
         The default layout for BloodHound Enterprise.
 

--- a/docs/analyze-data/privilege-zones/labels.mdx
+++ b/docs/analyze-data/privilege-zones/labels.mdx
@@ -46,7 +46,7 @@ The **Owned** label represents objects that have been compromised in your enviro
 
 ### Create a label
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 You can create custom labels to categorize objects based on any criteria relevant to your environment, such as business function, sensitivity level, or compliance requirements.
 
@@ -140,7 +140,7 @@ To edit a label, follow these steps:
 
 ### Delete a label
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 You cannot delete the default **Owned** label, but you can edit its description and rules.
 

--- a/docs/analyze-data/privilege-zones/overview.mdx
+++ b/docs/analyze-data/privilege-zones/overview.mdx
@@ -43,7 +43,7 @@ Most changes to Privilege Zones affect object membership and require analysis to
 For Cypher-based rules, validation happens in two stages. First, rerun the query in the rule editor after you change it so BloodHound can validate the updated rule definition. After you save the rule, BloodHound runs analysis before updated zone or label membership appears elsewhere in the product.
 
 <Callout color="#8E92EB">
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   If you enable [Variable Analysis Mode](/analyze-data/findings/analysis#variable-analysis-mode) on the **Administration** > **Early Access Features** page, BloodHound Enterprise can complete analysis for Privilege Zone changes faster because it starts at the **Tagging** stage instead of running the full analysis pipeline.
 

--- a/docs/analyze-data/privilege-zones/rules.mdx
+++ b/docs/analyze-data/privilege-zones/rules.mdx
@@ -297,7 +297,7 @@ If the query returns no results, BloodHound asks you to confirm the save. If you
 
 ### Object deleted from graph
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 Objects are automatically deleted from the graph if they haven't been observed within the configured retention period. BloodHound stores a timestamp on every object that updates whenever a collection includes that object or references to it. This ensures your data remains fresh and accurate over time.
 

--- a/docs/analyze-data/privilege-zones/zones.mdx
+++ b/docs/analyze-data/privilege-zones/zones.mdx
@@ -45,7 +45,7 @@ BloodHound uses zones to measure risk and detect violations. Each zone has a spe
 
 ### Create a zone
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 Creating a zone involves configuring the zone details and defining a rule.
 
@@ -147,7 +147,7 @@ To edit a zone, follow these steps:
 
 ### Delete a zone
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 You cannot delete the default **Tier Zero** zone, but you can edit its properties.
 

--- a/docs/manage-bloodhound/bh-shortcuts.mdx
+++ b/docs/manage-bloodhound/bh-shortcuts.mdx
@@ -30,7 +30,7 @@ description: "List of the keyboard shortcuts available in BloodHound"
 
 ## Attack Paths page
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 | Command | Action |
 | ------- | ------ |
@@ -41,7 +41,7 @@ description: "List of the keyboard shortcuts available in BloodHound"
 
 ## Posture page
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 | Command | Action |
 | ------- | ------ |

--- a/docs/manage-bloodhound/bh-shortcuts.mdx
+++ b/docs/manage-bloodhound/bh-shortcuts.mdx
@@ -30,7 +30,7 @@ description: "List of the keyboard shortcuts available in BloodHound"
 
 ## Attack Paths page
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 | Command | Action |
 | ------- | ------ |
@@ -41,7 +41,7 @@ description: "List of the keyboard shortcuts available in BloodHound"
 
 ## Posture page
 
-<Badge shape="rounded" size="sm" stroke color="purple">Enterprise</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 | Command | Action |
 | ------- | ------ |

--- a/docs/resources/edges/abuse-tgt-delegation.mdx
+++ b/docs/resources/edges/abuse-tgt-delegation.mdx
@@ -129,7 +129,7 @@ The attack can be detected by correlating Windows security events from the attac
 
 Source: [Domain](/resources/nodes/domain)  
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/adcs-esc1.mdx
+++ b/docs/resources/edges/adcs-esc1.mdx
@@ -58,7 +58,7 @@ certipy auth -pfx administrator.pfx -dc-ip 172.16.12
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/adcs-esc10a.mdx
+++ b/docs/resources/edges/adcs-esc10a.mdx
@@ -151,7 +151,7 @@ Opsec Considerations
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc10b.mdx
+++ b/docs/resources/edges/adcs-esc10b.mdx
@@ -174,7 +174,7 @@ certipy auth -pfx TARGET.pfx -dc-ip IP -ldap-shell
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc13.mdx
+++ b/docs/resources/edges/adcs-esc13.mdx
@@ -56,7 +56,7 @@ When the affected certificate authority issues the certificate to the attacker, 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Group](/resources/nodes/group)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc3.mdx
+++ b/docs/resources/edges/adcs-esc3.mdx
@@ -75,7 +75,7 @@ certipy auth -pfx administrator.pfx -dc-ip 172.16.126.128
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc4.mdx
+++ b/docs/resources/edges/adcs-esc4.mdx
@@ -635,7 +635,7 @@ When the affected certificate authority issues the certificate to the attacker, 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc6a.mdx
+++ b/docs/resources/edges/adcs-esc6a.mdx
@@ -73,7 +73,7 @@ supported by Certipy. See the Windows abuse section for example.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/adcs-esc6b.mdx
+++ b/docs/resources/edges/adcs-esc6b.mdx
@@ -63,7 +63,7 @@ certipy auth -pfx administrator.pfx -dc-ip 172.16.126.128
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc9a.mdx
+++ b/docs/resources/edges/adcs-esc9a.mdx
@@ -125,7 +125,7 @@ Request a ticket granting ticket (TGT) from the domain, specifying the certifica
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/adcs-esc9b.mdx
+++ b/docs/resources/edges/adcs-esc9b.mdx
@@ -160,7 +160,7 @@ certipy auth -pfx TARGET.pfx -dc-ip IP
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/add-allowed-to-act.mdx
+++ b/docs/resources/edges/add-allowed-to-act.mdx
@@ -21,7 +21,7 @@ See the [AllowedToAct](/resources/edges/allowed-to-act) edge section for opsec c
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/add-key-credential-link.mdx
+++ b/docs/resources/edges/add-key-credential-link.mdx
@@ -28,7 +28,7 @@ If PKINIT is not common in the environment, a 4768 (Kerberos authentication tick
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)  
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/add-member.mdx
+++ b/docs/resources/edges/add-member.mdx
@@ -50,7 +50,7 @@ You may be able to completely evade those features by downgrading to PowerShell 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Group](/resources/nodes/group)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 * [https://github.com/PowerShellMafia/PowerSploit/blob/dev/Recon/PowerView.ps1](https://github.com/PowerShellMafia/PowerSploit/blob/dev/Recon/PowerView.ps1)

--- a/docs/resources/edges/add-self.mdx
+++ b/docs/resources/edges/add-self.mdx
@@ -51,7 +51,7 @@ You may be able to completely evade those features by downgrading to PowerShell 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Group](/resources/nodes/group)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/admin-to.mdx
+++ b/docs/resources/edges/admin-to.mdx
@@ -46,7 +46,7 @@ Additionally, an EDR product may detect your attempt to inject into lsass and al
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/all-extended-rights.mdx
+++ b/docs/resources/edges/all-extended-rights.mdx
@@ -51,7 +51,7 @@ This will depend on the actual attack performed. See the particular opsec consid
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Domain](/resources/nodes/domain), [CertTemplate](/resources/nodes/cert-template)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/allowed-to-act.mdx
+++ b/docs/resources/edges/allowed-to-act.mdx
@@ -58,7 +58,7 @@ To execute this attack, the Rubeus C# assembly needs to be executed on some syst
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/allowed-to-delegate.mdx
+++ b/docs/resources/edges/allowed-to-delegate.mdx
@@ -30,7 +30,7 @@ As mentioned in the abuse info, in order to currently abuse this primitive the R
 
 Source: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 * [https://github.com/GhostPack/Rubeus#s4u](https://github.com/GhostPack/Rubeus#s4u)

--- a/docs/resources/edges/can-ps-remote.mdx
+++ b/docs/resources/edges/can-ps-remote.mdx
@@ -63,7 +63,7 @@ Entering a PSSession will generate a logon event on the target computer.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/can-rdp.mdx
+++ b/docs/resources/edges/can-rdp.mdx
@@ -66,7 +66,7 @@ Remote desktop will create Logon and Logoff events with the access type RemoteIn
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/claim-special-identity.mdx
+++ b/docs/resources/edges/claim-special-identity.mdx
@@ -54,7 +54,7 @@ No OPSEC considerations are available for this edge.
 
 Source: [Group](/resources/nodes/group)   
 Destination: [User](/resources/nodes/user), [Group](/resources/nodes/group)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/coerce-and-relay-ntlm-to-adcs.mdx
+++ b/docs/resources/edges/coerce-and-relay-ntlm-to-adcs.mdx
@@ -73,7 +73,7 @@ Authentication using the obtained certificate is another detection opportunity. 
 
 Source: `Authenticated Users`, [Group](/resources/nodes/group)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/coerce-and-relay-ntlm-to-ldap.mdx
+++ b/docs/resources/edges/coerce-and-relay-ntlm-to-ldap.mdx
@@ -74,7 +74,7 @@ This edge indicates that the target computer has the WebClient service running. 
 
 Source: `Authenticated Users`, [Group](/resources/nodes/group)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/coerce-and-relay-ntlm-to-ldaps.mdx
+++ b/docs/resources/edges/coerce-and-relay-ntlm-to-ldaps.mdx
@@ -72,7 +72,7 @@ This edge indicates that the target computer has the WebClient service running. 
 
 Source: `Authenticated Users`, [Group](/resources/nodes/group)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/coerce-and-relay-ntlm-to-smb.mdx
+++ b/docs/resources/edges/coerce-and-relay-ntlm-to-smb.mdx
@@ -59,7 +59,7 @@ This edge indicates that an attacker with "Authenticated Users" access can compr
 
 Source: `Authenticated Users`, [Group](/resources/nodes/group)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/coerce-to-tgt.mdx
+++ b/docs/resources/edges/coerce-to-tgt.mdx
@@ -116,7 +116,7 @@ There is no opsec information for this edge.
 
 Source: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/contains.mdx
+++ b/docs/resources/edges/contains.mdx
@@ -21,7 +21,7 @@ Creation and modification of ACEs will be logged depending on the auditing setup
 
 Source: [Computer](/resources/nodes/computer), [OU](/resources/nodes/ou), [Container](/resources/nodes/container)  
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 * [https://wald0.com/?p=179](https://wald0.com/?p=179)

--- a/docs/resources/edges/cross-forest-trust.mdx
+++ b/docs/resources/edges/cross-forest-trust.mdx
@@ -23,7 +23,7 @@ There is no OPSEC associated with this edge.
 
 Source: [Domain](/resources/nodes/domain)  
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/dc-for.mdx
+++ b/docs/resources/edges/dc-for.mdx
@@ -19,7 +19,7 @@ Domain Controllers are universally among the most sensitive systems in Active Di
 
 Source: [Domain](/resources/nodes/domain)  
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/dc-sync.mdx
+++ b/docs/resources/edges/dc-sync.mdx
@@ -24,7 +24,7 @@ For detailed information on detection of DCSync as well as opsec considerations,
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/dump-smsa-password.mdx
+++ b/docs/resources/edges/dump-smsa-password.mdx
@@ -66,7 +66,7 @@ Access to registry hives can be monitored and alerted via event ID 4656 (A handl
 
 Source: [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user)   
-Traversable: **Yes**   
+Traversable: ✅   
 
 ## References
 

--- a/docs/resources/edges/execute-dcom.mdx
+++ b/docs/resources/edges/execute-dcom.mdx
@@ -44,7 +44,7 @@ Many DCOM servers spawn under the process “svchost.exe -k DcomLaunch” and ty
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 * [https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/](https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/)

--- a/docs/resources/edges/force-change-password.mdx
+++ b/docs/resources/edges/force-change-password.mdx
@@ -49,7 +49,7 @@ Finally, by changing a service account password, you may cause that service to s
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/generic-all.mdx
+++ b/docs/resources/edges/generic-all.mdx
@@ -131,7 +131,7 @@ This will depend on the actual attack performed. See the particular opsec consid
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 * [https://github.com/PowerShellMafia/PowerSploit/blob/dev/Recon/PowerView.ps1](https://github.com/PowerShellMafia/PowerSploit/blob/dev/Recon/PowerView.ps1)

--- a/docs/resources/edges/generic-write.mdx
+++ b/docs/resources/edges/generic-write.mdx
@@ -71,7 +71,7 @@ This will depend on which type of object you are targeting and the attack you pe
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)
 
-Traversable: **Yes**
+Traversable: ✅
 
 ## References
 

--- a/docs/resources/edges/golden-cert.mdx
+++ b/docs/resources/edges/golden-cert.mdx
@@ -67,7 +67,7 @@ Request a TGT for the targeted principal using the certificate against a given D
 
 Source: [Computer](/resources/nodes/computer)  
 Destination: [Domain](/resources/nodes/domain)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/gp-link.mdx
+++ b/docs/resources/edges/gp-link.mdx
@@ -29,7 +29,7 @@ There is no opsec information for this edge.
 
 Source: [GPO](/resources/nodes/gpo)  
 Destination: [Domain](/resources/nodes/domain), [OU](/resources/nodes/ou)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/has-session.mdx
+++ b/docs/resources/edges/has-session.mdx
@@ -37,7 +37,7 @@ An EDR product may detect your attempt to inject into lsass and alert a SOC anal
 
 Source: [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/has-sid-history.mdx
+++ b/docs/resources/edges/has-sid-history.mdx
@@ -23,7 +23,7 @@ No opsec considerations apply to this edge.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
 Destination: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/has-trust-keys.mdx
+++ b/docs/resources/edges/has-trust-keys.mdx
@@ -60,7 +60,7 @@ Authentication via a trust account is unusual and can be detected by Windows sec
 
 Source: [Domain](/resources/nodes/domain)  
 Destination: [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/manage-ca.mdx
+++ b/docs/resources/edges/manage-ca.mdx
@@ -135,7 +135,7 @@ Abusing these capabilities commonly results in certificate issuance; issued cert
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [EnterpriseCA](/resources/nodes/enterprise-ca)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/manage-certificates.mdx
+++ b/docs/resources/edges/manage-certificates.mdx
@@ -51,7 +51,7 @@ Approving requests generates issuance events and stores issued certificates on t
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [EnterpriseCA](/resources/nodes/enterprise-ca)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/member-of.mdx
+++ b/docs/resources/edges/member-of.mdx
@@ -21,7 +21,7 @@ No opsec considerations apply to this edge.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [Group](/resources/nodes/group)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References[](#heading-3)

--- a/docs/resources/edges/owns-limited-rights.mdx
+++ b/docs/resources/edges/owns-limited-rights.mdx
@@ -19,7 +19,7 @@ Please refer to the OPSEC section in the [edge documentation](/resources/edges/o
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/owns.mdx
+++ b/docs/resources/edges/owns.mdx
@@ -26,7 +26,7 @@ This depends on the target object and how to take advantage of this privilege.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/read-gmsa-password.mdx
+++ b/docs/resources/edges/read-gmsa-password.mdx
@@ -48,7 +48,7 @@ When retrieving the GMSA password from Active Directory, you may generate a 4662
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [User](/resources/nodes/user)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/read-laps-password.mdx
+++ b/docs/resources/edges/read-laps-password.mdx
@@ -45,7 +45,7 @@ Reading properties from LDAP is extremely low risk, and can only be found using 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [Computer](/resources/nodes/computer)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/same-forest-trust.mdx
+++ b/docs/resources/edges/same-forest-trust.mdx
@@ -114,7 +114,7 @@ There is no OPSEC associated with this edge.
 
 Source: [Domain](/resources/nodes/domain)   
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/spoof-sid-history.mdx
+++ b/docs/resources/edges/spoof-sid-history.mdx
@@ -73,7 +73,7 @@ There is no OPSEC associated with this edge.
 
 Source: [Domain](/resources/nodes/domain)   
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/sql-admin.mdx
+++ b/docs/resources/edges/sql-admin.mdx
@@ -154,7 +154,7 @@ A summary of the what will show up in the logs, along with the TSQL queries for 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [Computer](/resources/nodes/computer)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/sync-laps-password.mdx
+++ b/docs/resources/edges/sync-laps-password.mdx
@@ -24,7 +24,7 @@ Executing the attack will generate a 4662 (An operation was performed on an obje
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [Domain](/resources/nodes/domain)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 
 ## References

--- a/docs/resources/edges/synced-to-ad-user.mdx
+++ b/docs/resources/edges/synced-to-ad-user.mdx
@@ -22,7 +22,7 @@ The attacker may create artifacts of abusing this relationship in both on-prem A
 
 Source: [AZUser](/resources/nodes/az-user)   
 Destination: [User](/resources/nodes/user)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/synced-to-entra-user.mdx
+++ b/docs/resources/edges/synced-to-entra-user.mdx
@@ -21,7 +21,7 @@ The attacker may create artifacts of abusing this relationship in both on-prem A
 
 Source: [User](/resources/nodes/user)   
 Destination: [AZUser](/resources/nodes/az-user)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-account-restrictions.mdx
+++ b/docs/resources/edges/write-account-restrictions.mdx
@@ -26,7 +26,7 @@ See the [AllowedToAct](/resources/edges/allowed-to-act) edge section for opsec c
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)   
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-alt-security-identities.mdx
+++ b/docs/resources/edges/write-alt-security-identities.mdx
@@ -139,7 +139,7 @@ When the affected certificate authority issues the certificate to the attacker, 
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)<br />
 Destination: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)<br />
-Traversable: **Yes**
+Traversable: ✅
 
 ## References
 

--- a/docs/resources/edges/write-dacl.mdx
+++ b/docs/resources/edges/write-dacl.mdx
@@ -71,7 +71,7 @@ Additional opsec considerations depend on the target object and how to take adva
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-gp-link.mdx
+++ b/docs/resources/edges/write-gp-link.mdx
@@ -34,7 +34,7 @@ There is no opsec information for this edge.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [GPO](/resources/nodes/gpo)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-owner-limited-rights.mdx
+++ b/docs/resources/edges/write-owner-limited-rights.mdx
@@ -19,7 +19,7 @@ Please refer to the OPSEC section in the [edge documentation](/resources/edges/o
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-owner.mdx
+++ b/docs/resources/edges/write-owner.mdx
@@ -41,7 +41,7 @@ This depends on the target object and how to take advantage of this privilege.
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/edges/write-public-information.mdx
+++ b/docs/resources/edges/write-public-information.mdx
@@ -27,7 +27,7 @@ For targeted Kerberoasting, see the [WriteSPN](/resources/edges/write-spn) opsec
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)<br />
 Destination: [User](/resources/nodes/user), [Computer](/resources/nodes/computer)<br />
-Traversable: **Yes**
+Traversable: ✅
 
 ## References
 

--- a/docs/resources/edges/write-spn.mdx
+++ b/docs/resources/edges/write-spn.mdx
@@ -41,7 +41,7 @@ Modifying the `servicePrincipalName` attribute will not, by default, generate an
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
 Destination: [User](/resources/nodes/user)  
-Traversable: **Yes**  
+Traversable: ✅  
 
 ## References
 

--- a/docs/resources/release-notes/2026-01-22.mdx
+++ b/docs/resources/release-notes/2026-01-22.mdx
@@ -129,7 +129,7 @@ sidebarTitle: "2026-01-22"
 
   #### Zones
 
-  <Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge>
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
   The zone dropdown menu in the [Details View](/analyze-data/privilege-zones/zones#details-view) now uses consistent iconography to improve visual recognition and navigation.
 
@@ -272,7 +272,7 @@ sidebarTitle: "2026-01-22"
 
   ## Attack Path Analysis
 
-  <Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge>
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
   {/*BED-5719*/} Resolved an issue causing inconsistent attack path visibility. Previously, the preset *date* range options on the **Posture** page used different *times of day* than the **Custom Range** option. A new [time picker](#bloodhound-8) is now available for custom date ranges to resolve this inconsistency.
 
@@ -292,11 +292,13 @@ sidebarTitle: "2026-01-22"
 
   * {/*BED-6874*/} Resolved an issue where the **Total Count** (renamed to **Total Objects** this release) on the zone and label **Details View** displayed inaccurate object totals when filtering between domains.
 
-  * {/*BED-6458*/} <Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge> Resolved an issue where the **Tier Zero Exposure** value in the domain filter on the **Attack Paths** and **Posture** pages displayed the same percentage across all zones, preventing an accurate assessment of exposure metrics for individual zones.
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
-  * {/*BED-6931*/} <Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge> Resolved an issue on the **Certifications** page where clicking **Certify** or **Revoke** without first selecting an object displayed the **Add Note** modal. The buttons are now deactivated until you select an object.
+  * {/*BED-6458*/} Resolved an issue where the **Tier Zero Exposure** value in the domain filter on the **Attack Paths** and **Posture** pages displayed the same percentage across all zones, preventing an accurate assessment of exposure metrics for individual zones.
 
-  * {/*BED-7150*/}<Badge shape="rounded" size="sm" color="purple">Enterprise Edition</Badge> Resolved an issue where analysis failed on Cypher-based rules. Rules now properly ignore edges and select nodes only.
+  * {/*BED-6931*/} Resolved an issue on the **Certifications** page where clicking **Certify** or **Revoke** without first selecting an object displayed the **Add Note** modal. The buttons are now deactivated until you select an object.
+
+  * {/*BED-7150*/} Resolved an issue where analysis failed on Cypher-based rules. Rules now properly ignore edges and select nodes only.
 </Update>
 
 <Update label="AzureHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-01-22.mdx
+++ b/docs/resources/release-notes/2026-01-22.mdx
@@ -129,7 +129,7 @@ sidebarTitle: "2026-01-22"
 
   #### Zones
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   The zone dropdown menu in the [Details View](/analyze-data/privilege-zones/zones#details-view) now uses consistent iconography to improve visual recognition and navigation.
 
@@ -272,7 +272,7 @@ sidebarTitle: "2026-01-22"
 
   ## Attack Path Analysis
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   {/*BED-5719*/} Resolved an issue causing inconsistent attack path visibility. Previously, the preset *date* range options on the **Posture** page used different *times of day* than the **Custom Range** option. A new [time picker](#bloodhound-8) is now available for custom date ranges to resolve this inconsistency.
 
@@ -292,7 +292,7 @@ sidebarTitle: "2026-01-22"
 
   * {/*BED-6874*/} Resolved an issue where the **Total Count** (renamed to **Total Objects** this release) on the zone and label **Details View** displayed inaccurate object totals when filtering between domains.
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   * {/*BED-6458*/} Resolved an issue where the **Tier Zero Exposure** value in the domain filter on the **Attack Paths** and **Posture** pages displayed the same percentage across all zones, preventing an accurate assessment of exposure metrics for individual zones.
 

--- a/docs/resources/release-notes/2026-02-11.mdx
+++ b/docs/resources/release-notes/2026-02-11.mdx
@@ -76,7 +76,7 @@ sidebarTitle: "2026-02-11"
 
   ## Consistent Certification Terminology
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Use consistent language when managing certifications.
   
@@ -122,7 +122,7 @@ sidebarTitle: "2026-02-11"
 
 ## Attack Path Analysis
 
-<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
 - {/*BED-7149*/} Resolved an issue where the **Posture** page displayed an error after initial file ingestion.
 - {/*BED-6961*/} Resolved an issue where long-running file ingestion jobs prevented analysis from running.

--- a/docs/resources/release-notes/2026-02-11.mdx
+++ b/docs/resources/release-notes/2026-02-11.mdx
@@ -76,7 +76,7 @@ sidebarTitle: "2026-02-11"
 
   ## Consistent Certification Terminology
 
-  <Badge shape="rounded" size="sm" color="purple">Enterprise</Badge>
+  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
   Use consistent language when managing certifications.
   
@@ -122,7 +122,7 @@ sidebarTitle: "2026-02-11"
 
 ## Attack Path Analysis
 
-<Badge shape="rounded" size="sm" color="purple">Enterprise</Badge>
+<img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
 
 - {/*BED-7149*/} Resolved an issue where the **Posture** page displayed an error after initial file ingestion.
 - {/*BED-6961*/} Resolved an issue where long-running file ingestion jobs prevented analysis from running.

--- a/docs/resources/release-notes/2026-05-28.mdx
+++ b/docs/resources/release-notes/2026-05-28.mdx
@@ -124,7 +124,7 @@ sidebarTitle: "2026-05-28"
   ## Exposure Tooltip Improvements
   {/*BED-7803*/}
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   The **Exposed** tooltip on the [Attack Paths](/analyze-data/findings/attack-paths) page now uses platform-agnostic language. Previously, it defined exposure in terms of Active Directory and Entra object types only. As [OpenGraph extensions](/opengraph/overview) expand BloodHound beyond Active Directory and Azure, that definition is no longer accurate.
 
@@ -166,7 +166,7 @@ sidebarTitle: "2026-05-28"
 
   ## Access Control
   
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   - {/*BED-7916*/} Resolved an issue where ETAC-scoped users could see unauthorized environments in filters on the **Attack Paths**, **Explore**, and **Posture** pages.
   - {/*BED-7916*/} Resolved an issue where ETAC-scoped users could not view data from their assigned environments on the **Explore** page.

--- a/docs/resources/release-notes/2026-06-17.mdx
+++ b/docs/resources/release-notes/2026-06-17.mdx
@@ -115,7 +115,7 @@ sidebarTitle: "2026-06-17"
   {/*BED-8277*/}
   ## Pre-Installed SpecterOps Extensions
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   BloodHound Enterprise now includes pre-installed OpenGraph extensions for GitHub, Jamf, and Okta. This streamlines extension management by making these supported extensions available without a separate installation step.
 
@@ -126,7 +126,7 @@ sidebarTitle: "2026-06-17"
   {/*BED-8207*/}
   ## Updated Attack Path Type Names
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   The **Attack Paths** table on the **Posture** page now uses Privilege Zones terminology (where appropriate) instead of older **Tier Zero** naming.
 
@@ -137,7 +137,7 @@ sidebarTitle: "2026-06-17"
   {/*BED-8186*/}
   ## Search Across Certification Statuses
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Search for objects across all [certification statuses](/analyze-data/privilege-zones/certification#by-status) in Zone Builder.
 
@@ -160,7 +160,7 @@ sidebarTitle: "2026-06-17"
 
   ## Posture
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   {/*BED-8392*/} Resolved an issue where enabling **Logarithmic Chart Scale** caused the **Historical Findings** and **Total Attack Paths** charts to go blank.
 </Update>
@@ -170,7 +170,7 @@ sidebarTitle: "2026-06-17"
 </Update>
 
 <Update label="AzureHound" tags={["Fixed Issues"]}>
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   {/*BED-8176*/} Resolved an issue for hosted `edge-*` AzureHound container images where an invalid collector version string caused BloodHound to reject uploads from the collector as unsupported.
 </Update>

--- a/docs/resources/release-notes/2026-07-07.mdx
+++ b/docs/resources/release-notes/2026-07-07.mdx
@@ -92,7 +92,7 @@ sidebarTitle: "2026-07-07"
   {/*BI-1814*/}
   ## Higher Memory Limits for Cypher Queries
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Run more complex Cypher queries in BloodHound Enterprise and return larger **Entity Panel** sections than were previously supported.
 </Update>
@@ -101,7 +101,7 @@ sidebarTitle: "2026-07-07"
   {/*BED-8276, BED-8781*/}
   ## Variable Analysis Mode
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   See Privilege Zone updates reflected in your graph faster.
 
@@ -139,7 +139,7 @@ sidebarTitle: "2026-07-07"
 
   ## Findings
 
-  <img src="/assets/enterprise-edition-pill-tag.svg" alt="BloodHound Enterprise logo" style={{ width: "25%" }}/>
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   {/*BED-8114*/} Resolved an issue where individual attack paths and their finding counts could appear on the **Posture** page but not on the **Attack Paths** page.
 </Update>


### PR DESCRIPTION
This pull request (PR) aligns the AD/AZ traversable edge icongraphy with the way we're representing that for the newer GitHub, Jamf, and Okta extensions.

It also replaces legacy `<Badge>` components with the preferred logo for differentiating between community and enterprise editions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise Edition labels across shortcuts and release notes with a consistent Enterprise pill.
  * Standardized traversable edge indicators across resource documentation by replacing “Yes” text with a checkmark (✅).
  * Improved consistency and readability of documentation metadata without changing underlying content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->