### PR TITLE
BP-2744: OpenHound setup and config

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -486,7 +486,15 @@
             "group": "OpenHound",
             "pages": [
               "openhound/overview",
-              "openhound/enterprise",
+              {
+                "group": "Enterprise",
+                "pages": [
+                  "openhound/enterprise",
+                  "openhound/deploy-with-compose",
+                  "openhound/deploy-with-kubernetes",
+                  "openhound/configure-extension-assets"
+                ]
+              },
               "openhound/community",
               "openhound/configuration",
               {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -492,7 +492,7 @@
                   "openhound/enterprise",
                   "openhound/deploy-with-compose",
                   "openhound/deploy-with-kubernetes",
-                  "openhound/configure-extension-assets"
+                  "openhound/upload-extension-assets"
                 ]
               },
               "openhound/community",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -490,9 +490,9 @@
                 "group": "Enterprise",
                 "pages": [
                   "openhound/enterprise",
+                  "openhound/upload-extension-assets",
                   "openhound/deploy-with-compose",
-                  "openhound/deploy-with-kubernetes",
-                  "openhound/upload-extension-assets"
+                  "openhound/deploy-with-kubernetes"
                 ]
               },
               "openhound/community",

--- a/docs/openhound/collectors/github/collect-data.mdx
+++ b/docs/openhound/collectors/github/collect-data.mdx
@@ -74,6 +74,7 @@ Click the tab that matches your authentication setup for details and example con
     | `app_id` | The GitHub App ID used to authenticate to the GitHub API. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__APP_ID` |
     | `client_id` | The GitHub App Client ID used to authenticate to the GitHub API. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__CLIENT_ID` |
     | `key_path` | The path to the GitHub App private key file. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__KEY_PATH` |
+    | `install_id` | The GitHub App Installation ID for the organization installation. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__INSTALL_ID` |
 
     **`secrets.toml`**
 
@@ -83,6 +84,7 @@ Click the tab that matches your authentication setup for details and example con
     key_path = "/path/to/private/key.pem"
     app_id = "123456"
     client_id = "your-client-id"
+    install_id = "12345678"
     ```
 
     **Environment variables**
@@ -92,6 +94,7 @@ Click the tab that matches your authentication setup for details and example con
     SOURCES__SOURCE__GITHUB__CREDENTIALS__KEY_PATH=/path/to/private/key.pem
     SOURCES__SOURCE__GITHUB__CREDENTIALS__APP_ID=123456
     SOURCES__SOURCE__GITHUB__CREDENTIALS__CLIENT_ID=your-client-id
+    SOURCES__SOURCE__GITHUB__CREDENTIALS__INSTALL_ID=12345678
     ```
   </Tab>
   <Tab title="Fine-grained PAT">

--- a/docs/openhound/collectors/github/collect-data.mdx
+++ b/docs/openhound/collectors/github/collect-data.mdx
@@ -11,15 +11,15 @@ This page covers configuring the OpenHound GitHub collector for your GitHub orga
 
 ## Prerequisites
 
-- OpenHound installed with the GitHub collector included.
+Before you configure the GitHub collector, ensure that the following prerequisites are met:
 
-  Follow the OpenHound [installation](/openhound/community) instructions to set up OpenHound for BloodHound Community Edition. The GitHub collector is included by default in the OpenHound container image.
+- OpenHound installed with the GitHub collector included.
+  - For BloodHound Community Edition, install the [OpenHound CLI](/openhound/community).
+  - For BloodHound Enterprise, [deploy](/openhound/enterprise) OpenHound as a container.
 - One of the following authentication setups configured:
   - [Enterprise GitHub App installation](/openhound/collectors/github/configure-enterprise-app) (<Badge color="green">recommended</Badge>)
   - [Organization GitHub App installation](/openhound/collectors/github/configure-app)
   - [Fine-grained Personal Access Token (PAT)](/openhound/collectors/github/configure-pat)
-
-<Note>The OpenHound setup instructions for BloodHound Community Edition also apply to BloodHound Enterprise users, for now.</Note>
 
 ## Configure OpenHound
 
@@ -46,7 +46,7 @@ Click the tab that matches your authentication setup for details and example con
 
     **`secrets.toml`**
 
-    ```toml title="secrets.toml"
+    ```toml title="~/.dlt/secrets_github.toml"
     [sources.source.github.credentials]
     client_id = "your-client-id"
     app_id = "your-app-id"
@@ -77,7 +77,7 @@ Click the tab that matches your authentication setup for details and example con
 
     **`secrets.toml`**
 
-    ```toml title="secrets.toml"
+    ```toml title="~/.dlt/secrets_github.toml"
     [sources.source.github.credentials]
     org_name = "your-github-org"
     key_path = "/path/to/private/key.pem"
@@ -104,7 +104,7 @@ Click the tab that matches your authentication setup for details and example con
 
     **`secrets.toml`**
 
-    ```toml title="secrets.toml"
+    ```toml title="~/.dlt/secrets_github.toml"
     [sources.source.github.credentials]
     org_name = "your-github-org"
     token = "github_pat_xxxxxxxxxxxxx"

--- a/docs/openhound/collectors/github/troubleshooting.mdx
+++ b/docs/openhound/collectors/github/troubleshooting.mdx
@@ -7,6 +7,31 @@ description: Common issues and solutions when running the OpenHound GitHub colle
 
 This guide covers common issues encountered when running the OpenHound GitHub collector and how to resolve them.
 
+## Docker Compose Issues
+
+### Docker commands fail from WSL
+
+If you run OpenHound from Windows with WSL and Docker commands fail or cannot find the Docker daemon, verify Docker Desktop WSL integration.
+
+1. Open Docker Desktop.
+1. Click **Settings** > **Resources** > **WSL integration**.
+1. Enable integration for the WSL distribution where you run OpenHound.
+1. Return to your WSL terminal and run:
+
+   ```bash
+   docker compose version
+   ```
+
+### More than one collector starts
+
+The Enterprise Docker Compose example defines services for GitHub, Jamf, and Okta. Start only the service for the extension you configured.
+
+```bash
+docker compose up -d scheduler-github
+```
+
+If you run `docker compose up -d` without a service name, Docker starts every service in the Compose file.
+
 ## Authentication Errors
 
 ### "Bad credentials" or 401 Unauthorized
@@ -42,8 +67,20 @@ This error indicates insufficient GitHub App permissions. Verify:
 If you encounter errors related to the private key:
 
 - Ensure the `.pem` file path is correct and accessible.
+- When you run OpenHound with Docker Compose, ensure `key_path` points to the mounted container path, such as `/app/.dlt/github.pem`.
 - Verify the file contains a complete private key (begins with `-----BEGIN RSA PRIVATE KEY-----`).
 - If the key doesn't match, regenerate a new private key from the GitHub App settings.
+
+### Enterprise and organization parameter mismatch
+
+The GitHub collector uses different parameters for enterprise-scoped and organization-scoped collection:
+
+| Collection scope | Required parameter |
+|---|---|
+| Enterprise GitHub App | `enterprise_name` |
+| Organization GitHub App or PAT | `org_name` |
+
+If collection fails after authentication succeeds, confirm that the configured parameter matches the GitHub authentication method.
 
 ## Rate Limiting
 
@@ -59,8 +96,9 @@ For small to medium environments (< 500 repos), the built-in rate limit handling
 
 For large environments (500+ repos):
 
-1. Use the [App Installation method](/openhound/collectors/github/configure-app) for 3x higher rate limits (15,000/hour vs 5,000/hour).
+1. Use a [GitHub App authentication method](/openhound/collectors/github/configure-enterprise-app) instead of a PAT for higher rate limits.
 2. Run collection during off-peak hours.
+3. Tune the [HTTP request parameters](/openhound/configuration#http-request-parameters) so OpenHound waits out rate limits instead of failing the run.
 
 ## Large Environment Issues
 
@@ -68,8 +106,9 @@ For large environments (500+ repos):
 
 For organizations with thousands of repositories, a full collection can take several hours.
 
-1. Use the [App Installation method](/openhound/collectors/github/configure-app) for higher rate limits.
+1. Use a [GitHub App authentication method](/openhound/collectors/github/configure-enterprise-app) for higher rate limits.
 2. Run collection during off-peak hours.
+3. Tune the [HTTP request parameters](/openhound/configuration#http-request-parameters).
 
 ### Memory Issues
 

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Configuration
 description: "Learn about configuring the OpenHound framework."
 ---
 
+import CollectorSpecificConfig from '/snippets/hounds/collector-specific-config.mdx'
+
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 OpenHound uses [DLT configuration management](https://dlthub.com/docs/general-usage/credentials/setup), which lets you set parameters through configuration files, environment variables, or both.
@@ -90,7 +92,7 @@ truncate_staging_dataset=true
 workers=2
 ```
 
-## BloodHound Enterprise collector parameters
+## BloodHound Enterprise settings
 
 Each extension-specific OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Add the following parameters to the `[destination.bloodhoundenterprise]` section of that collector's secrets file, or set the matching environment variables.
 
@@ -102,31 +104,13 @@ Use the `token_id` and `token_key` generated for the OpenHound collector client 
 | `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
 | `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. |
 
-## Collector-specific configuration parameters
+## Collector-specific settings
 
-Each collector may have additional required or optional configuration parameters that are specific to the data source being collected. These parameters can also be set in the configuration file or via environment variables.
+<CollectorSpecificConfig />
 
-For more information on collector-specific configuration, visit the configuration documentation page for each collector using the links below.
+## Runtime settings
 
-<CardGroup cols={3}>
-
-  <Card title="Github" href="/openhound/collectors/github/collect-data#configure-openhound">
-    View the configuration parameters for the Github collector.
-  </Card>
-
-  <Card title="Jamf" href="/openhound/collectors/jamf/collect-data#configure-openhound" >
-    View the configuration parameters for the Jamf collector.
-  </Card>
-
-  <Card title="Okta" href="/openhound/collectors/okta/collect-data#configure-openhound" >
-      View the configuration parameters for the Okta collector.
-  </Card>
-
-</CardGroup>
-
-## Common configuration parameters
-
-The following parameters are common for all OpenHound deployments and collectors. 
+The following configuration parameters are common for all OpenHound deployments and collectors. 
 
 ### Logging modes
 

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -20,6 +20,24 @@ The syntax allows for nested sections, collector-specific configurations, and co
 
 Configuration precedence follows a global-to-specific order: a collector-specific override in `[sources.source.<collector>.extract]` takes priority over a global setting in `[extract]`, which in turn takes priority over the built-in default.
 
+### File layout
+
+OpenHound reads configuration from DLT configuration files, environment variables, or both. Use separate files for non-sensitive settings and secrets:
+
+| File | Purpose | Example contents |
+|---|---|---|
+| `config.toml` | Non-sensitive runtime and pipeline settings | Logging, retry behavior, worker counts |
+| `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise collector client credentials and source credentials |
+| Extension-specific secrets files | Per-extension secrets mounted into a container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
+
+For Docker Compose deployments, create the DLT files under `~/.dlt` on the host. The Enterprise example Compose file mounts the shared `config.toml` and maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
+
+Some collectors require additional secret files, such as a GitHub App `.pem` private key or an Okta JSON key file. Store these files outside version control and configure the collector-specific path to match the path inside the container.
+
+<Note>
+  For production environments, use environment variables or your container platform's secret management features when local secret files do not meet your organization's credential handling requirements.
+</Note>
+
 The following sample configuration sets global values for runtime, normalize, and load, then overrides the extract worker count for the Okta and GitHub collectors.
 
 ```toml Example ~/.dlt/config.toml
@@ -270,4 +288,3 @@ The following parameters are configured under the `[load]` section in the config
 | `delete_completed_jobs`    | LOAD__DELETE_COMPLETED_JOBS    | Whether to delete completed jobs after a pipeline has completed.                                                | false          |
 | `truncate_staging_dataset` | LOAD__TRUNCATE_STAGING_DATASET | Whether to truncate the staging dataset after loading data into the destination.                                | false          |
 | `workers`                  | LOAD__WORKERS                  | The amount of concurrent workers used during the loading phase, is when uploading data to BloodHound Enterprise | 1             |
-

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -28,9 +28,25 @@ OpenHound reads configuration from DLT configuration files, environment variable
 |---|---|---|
 | `config.toml` | Non-sensitive runtime and pipeline settings | Logging, retry behavior, worker counts |
 | `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise collector client credentials and source credentials |
-| Extension-specific secrets files | Per-extension secrets mounted into a container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
+| Extension-specific secrets files | Per-extension host files used by Docker Compose and mounted into the container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
 
 For Docker Compose deployments, create the DLT files under `~/.dlt` on the host. The Enterprise example Compose file mounts the shared `config.toml` and maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
+
+Each extension-specific secrets file must include the `destination.bloodhoundenterprise` section with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` generated for the matching collector client. It must also include the credentials section required by that collector.
+
+```toml title="~/.dlt/secrets_github.toml"
+[destination.bloodhoundenterprise]
+url = "https://your-tenant.bloodhoundenterprise.io"
+token_id = "client_token_id"
+token_key = "client_token_key"
+
+[sources.source.github.credentials]
+# Add the GitHub collector credentials for your authentication method.
+```
+
+<Note>
+  The `destination.bloodhoundenterprise` settings are for scheduled OpenHound collection. Extension asset upload commands use a separate `destination.bloodhound` section with a browser JWT in `~/.dlt/secrets.toml`.
+</Note>
 
 Some collectors require additional secret files, such as a GitHub App `.pem` private key or an Okta JSON key file. Store these files outside version control and configure the collector-specific path to match the path inside the container.
 
@@ -74,15 +90,17 @@ truncate_staging_dataset=true
 workers=2
 ```
 
-## BloodHound Enterprise configuration parameters
+## BloodHound Enterprise collector parameters
 
-The following parameters must be set in the `[destination.bloodhoundenterprise]` section of the configuration file (or via environment variables) to run OpenHound and schedule data collection for BloodHound Enterprise.
+Each extension-specific OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Add the following parameters to the `[destination.bloodhoundenterprise]` section of that collector's secrets file, or set the matching environment variables.
 
-| Destination Option     | Environment Variable      | Description |
-|--------------------|---------------------------|------------------------------|
-| `token_key`        | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key for authenticating with BloodHound Enterprise.|
-| `token_id`  | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID  | The API token ID for authenticating with BloodHound Enterprise. | 
-| `url`     | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise instance. | 
+Use the `token_id` and `token_key` generated for the OpenHound collector client that matches the extension you are configuring. For example, use the GitHub collector client credentials in the GitHub collector's `~/.dlt/secrets_github.toml` file.
+
+| Destination Option | Environment Variable | Description |
+|---|---|---|
+| `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
+| `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
+| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. |
 
 ## Collector-specific configuration parameters
 

--- a/docs/openhound/configure-extension-assets.mdx
+++ b/docs/openhound/configure-extension-assets.mdx
@@ -1,0 +1,121 @@
+---
+title: Upload Extension Assets
+description: Upload saved queries and Privilege Zone rules for OpenHound extensions.
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise"/>
+
+OpenHound extensions include saved queries and Privilege Zone rules that help users analyze the data collected from GitHub, Jamf, Okta, or another OpenHound source. 
+
+Use the OpenHound CLI to upload these assets after the matching extension definition schema is installed or verified in BloodHound.
+
+<Note>
+  In BloodHound Enterprise v9.3.0 and later, the GitHub, Jamf, and Okta extension schemas are pre-installed. Saved queries and Privilege Zone rules are still managed separately.
+</Note>
+
+## Prerequisites
+
+Before you upload extension assets, ensure that you have done the following:
+
+- Installed the [OpenHound CLI](/openhound/community#install-the-openhound-cli).
+- Verified or installed the matching extension definition schema in [OpenGraph Extension Management](/opengraph/extensions/manage#verify-or-install-an-extension).
+- Downloaded or cloned the extension repository that contains the asset files.
+- Obtained the BloodHound Enterprise tenant URL and browser JWT used by the OpenHound CLI for extension asset uploads.
+- Confirmed that the target Privilege Zone exists before you upload Privilege Zone rules for that zone.
+
+<Note>
+  Use `--strategy overwrite` when you need to update saved queries or Privilege Zone rules that already exist in BloodHound. The default strategy is `skip`, which leaves existing assets unchanged.
+</Note>
+
+## Configure CLI authentication
+
+OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to your DLT secrets file.
+
+The asset upload commands use the `destination.bloodhound` section with a JWT bearer token. This is different from the `destination.bloodhoundenterprise` collector client configuration, which uses `token_id` and `token_key` for scheduled OpenHound collection.
+
+To get the browser JWT, follow the [BloodHound API JWT guidance](/integrations/bloodhound-api/working-with-api#use-a-jwt%2Fbearer-token). Copy only the token value and omit the `Bearer` prefix.
+
+```toml title="~/.dlt/secrets.toml"
+[destination.bloodhound]
+url = "https://your-tenant.bloodhoundenterprise.io"
+token = "your-browser-jwt"
+```
+
+<Warning>
+  Do not commit `secrets.toml` or token values to version control. Browser JWTs are short-lived and intended for user-authenticated API calls, not long-running integrations.
+</Warning>
+
+## Upload saved queries
+
+Saved queries are stored in the extension repository, usually in `extension/saved_searches`.
+
+<Steps>
+  <Step title="Open the extension repository">
+    Change to the repository for the extension assets you want to upload.
+
+    ```bash
+    cd ~/openhound-github
+    ```
+  </Step>
+
+  <Step title="Upload the saved queries">
+    Run the upload command against the saved queries directory.
+
+    <Note>
+      OpenHound makes uploaded saved queries public by default.
+    </Note>
+
+    For example, to create saved queries that do not exist and overwrite matching saved queries with the same name, use the `--strategy overwrite` option.
+
+    ```bash
+    openhound searches upload ./extension/saved_searches --strategy overwrite
+    ```
+
+    <Note>
+      Saved query uploads default to JSON files. To upload saved queries from YAML files, add `--file-format yaml`.
+    </Note>
+  </Step>
+</Steps>
+
+## Upload Privilege Zone rules
+
+Privilege Zone rules are stored in the extension repository, usually in `extension/privilege_zone_rules`.
+
+<Steps>
+  <Step title="Confirm the target zone exists">
+    In BloodHound Enterprise, confirm that the Privilege Zone referenced by the rule files exists.
+
+    If the target zone does not exist, create it before you upload the rules.
+  </Step>
+
+  <Step title="Upload the Privilege Zone rules">
+    Run the upload command against the Privilege Zone rules directory.
+
+    For example, to create rules that do not exist and overwrite matching rules with the same name, use the `--strategy overwrite` option.
+
+    ```bash
+    openhound rules upload ./extension/privilege_zone_rules --strategy overwrite
+    ```
+
+    <Note>
+      Upload Privilege Zone rules from JSON files. YAML support for Privilege Zone rule uploads requires Engineering confirmation.
+    </Note>
+  </Step>
+</Steps>
+
+## Verify the upload
+
+After the upload completes:
+
+- Open **Explore** to confirm the saved queries are available.
+- Open **Privilege Zones** to confirm the expected rules appear in the target zone.
+- Wait for analysis to successfully run to verify rules that affect zone membership or findings.
+
+## Troubleshoot asset uploads
+
+| Symptom | Cause | Resolution |
+|---|---|---|
+| Existing assets do not update | The command used the default `skip` strategy | Run the upload again with `--strategy overwrite`. |
+| Privilege Zone rules do not appear | The target zone does not exist | Create the zone in BloodHound, then upload the rules again. |
+| Upload fails with an authentication error | The BloodHound URL or JWT is invalid or expired | Update `~/.dlt/secrets.toml` with a valid browser JWT and rerun the command. |
+| No files are uploaded | The command points to the wrong directory or file format | Confirm that the path contains JSON files, or add `--file-format yaml` for saved query YAML files. |

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -119,6 +119,8 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     - `[destination.bloodhoundenterprise]` with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` for the matching OpenHound collector client
     - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
 
+      The following GitHub example uses an organization GitHub App. For other GitHub authentication methods, use the required fields from [Configure the Collector](/openhound/collectors/github/collect-data).
+
       ```toml title="~/.dlt/secrets_github.toml"
       [destination.bloodhoundenterprise]
       url = "https://your-tenant.bloodhoundenterprise.io"
@@ -130,6 +132,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
       key_path = "/app/.dlt/github.pem"
       app_id = "123456"
       client_id = "your-client-id"
+      install_id = "12345678"
       ```
 
     <Note>

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -1,0 +1,157 @@
+---
+title: Deploy with Docker Compose
+sidebarTitle: Deploy with Docker
+description: Deploy OpenHound for BloodHound Enterprise with Docker Compose.
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise"/>
+
+Deploy OpenHound with Docker Compose when you want to run OpenHound as a containerized service without Kubernetes.
+
+This guide uses a supported Windows with WSL and Docker Desktop workflow, and the same commands also apply to Linux hosts with Docker or Podman Compose.
+
+<Warning>
+  OpenHound currently runs one extension per container. The example Compose file includes services for GitHub, Jamf, and Okta, but you should start only the service for the extension you want to run.
+  {/* TODO: Confirm current-state behavior. */}
+</Warning>
+
+## Prerequisites
+
+- A BloodHound Enterprise tenant with OpenHound enabled.
+- API credentials for an OpenHound collector [client](/collect-data/enterprise-collection/create-collector) created in BloodHound Enterprise.
+- The required credentials for the extension you want to collect:
+  - [GitHub](/openhound/collectors/github/collect-data)
+  - [Jamf](/openhound/collectors/jamf/collect-data)
+  - [Okta](/openhound/collectors/okta/collect-data)
+- Docker Desktop with WSL integration enabled, or a Linux host with Docker or Podman installed.
+- The Compose plugin installed, such as `docker compose` or `podman compose`.
+- Git installed on the host where you prepare the deployment files.
+
+<Note>
+  On Windows, enable Docker Desktop WSL integration before you run OpenHound from a WSL terminal. In Docker Desktop, open **Settings** > **Resources** > **WSL integration**, then enable integration for the WSL distribution you use.
+</Note>
+
+## Deploy OpenHound
+
+Follow these steps to deploy OpenHound with Docker Compose and run a collector for the extension you want to use.
+
+<Steps>
+  <Step title="Verify Docker Compose">
+    From your Linux or WSL terminal, run:
+
+    ```bash
+    docker compose version
+    ```
+
+    The command returns the installed Docker Compose version.
+  </Step>
+
+  <Step title="Create the working directories">
+    Create a workspace for the Compose file and a DLT configuration directory:
+
+    ```bash
+    mkdir -p ~/openhound ~/.dlt
+    ```
+  </Step>
+
+  <Step title="Download the OpenHound examples">
+    Clone the OpenHound repository:
+
+    ```bash
+    git clone https://github.com/SpecterOps/OpenHound.git ~/openhound/OpenHound
+    ```
+  </Step>
+
+  <Step title="Copy the Enterprise Compose file">
+    Copy the Enterprise example Compose file into your OpenHound workspace:
+
+    ```bash
+    cp ~/openhound/OpenHound/example-configurations/bloodhound-enterprise/docker-compose.yml ~/openhound/docker-compose.yml
+    ```
+  </Step>
+
+  <Step title="Create config.toml">
+    Create `~/.dlt/config.toml` for non-sensitive OpenHound runtime settings.
+
+    ```toml title="~/.dlt/config.toml"
+    [runtime]
+    log_cli_level = "WARNING"
+    log_rotate_when = "midnight"
+    request_max_attempts = 15
+    request_backoff_factor = 1.3
+    request_max_retry_delay = 900
+
+    [extract]
+    workers = 8
+
+    [normalize]
+    workers = 3
+
+    [load]
+    delete_completed_jobs = true
+    truncate_staging_dataset = true
+    ```
+
+    <Tip>
+      See [Configuration](/openhound/configuration) for the full list of common runtime settings.
+    </Tip>
+  </Step>
+
+  <Step title="Create the extension secrets file">
+    Create one secrets file for each extension you want to run.
+    
+    The example Compose file maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
+
+    <Tip>
+      See [collector-specific configuration parameters](/openhound/enterprise#collector-specific-configuration-parameters) for more information.
+    </Tip>
+  </Step>
+
+  <Step title="Add extension secret files">
+    Some extensions require an additional secret file.
+    
+    For example, the GitHub App authentication method requires you to copy the GitHub App private key to the path referenced by the Compose file:
+
+    ```bash
+    cp /path/to/github.pem ~/.dlt/github.pem
+    ```
+  </Step>
+
+  <Step title="Start one OpenHound scheduler">
+    From the OpenHound workspace, start the scheduler for the extension you configured.
+
+    ```bash
+    cd ~/openhound
+    docker compose up -d scheduler-github
+    ```
+
+    To run another extension, configure its secrets file and start the matching service, such as `scheduler-jamf` or `scheduler-okta`.
+
+    <Warning>
+      Running `docker compose up -d` without a service name starts every service defined in the Compose file. Start only the service for the extension you configured.
+    </Warning>
+  </Step>
+
+  <Step title="Verify the scheduler logs">
+    Follow the logs for the service you started:
+
+    ```bash
+    docker compose logs -f scheduler-github
+    ```
+
+    The scheduler checks BloodHound Enterprise for available collection jobs. After you run an on-demand scan or a scheduled scan starts, the logs show the job status.
+  </Step>
+
+  <Step title="Run a collection">
+    In BloodHound Enterprise, run an [on-demand scan](/collect-data/enterprise-collection/on-demand-scan) or create a [collection schedule](/collect-data/enterprise-collection/collection-schedule) for the OpenHound collector client.
+
+    After the job completes, monitor ingest and analysis progress on the [collection activity pages](/collect-data/enterprise-collection/monitor).
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+- If Docker commands fail from WSL, confirm Docker Desktop WSL integration is enabled for your distribution.
+- If the scheduler starts but does not collect data, confirm that the OpenHound collector client credentials in the extension secrets file match the BloodHound Enterprise tenant.
+- If GitHub App authentication fails, confirm that the `.pem` file is mounted at the same path configured in `key_path`.
+- If a collection fails because of GitHub API rate limits, tune the [HTTP request parameters](/openhound/configuration#http-request-parameters).

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -17,8 +17,10 @@ This guide uses a supported Windows with WSL and Docker Desktop workflow, and th
 
 ## Prerequisites
 
+Before you begin, ensure that you have the following:
+
 - A BloodHound Enterprise tenant with OpenHound enabled.
-- API credentials for an OpenHound collector [client](/collect-data/enterprise-collection/create-collector) created in BloodHound Enterprise.
+- API credentials for each OpenHound collector [client](/collect-data/enterprise-collection/create-collector) you plan to run. Use the `token_id` and `token_key` generated for the matching collector client.
 - The required credentials for the extension you want to collect:
   - [GitHub](/openhound/collectors/github/collect-data)
   - [Jamf](/openhound/collectors/jamf/collect-data)
@@ -60,6 +62,9 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     ```bash
     git clone https://github.com/SpecterOps/OpenHound.git ~/openhound/OpenHound
     ```
+
+    You'll use the example Compose file in the next step.
+
   </Step>
 
   <Step title="Copy the Enterprise Compose file">
@@ -70,7 +75,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     ```
   </Step>
 
-  <Step title="Create config.toml">
+  <Step title="Create the OpenHound configuration file">
     Create `~/.dlt/config.toml` for non-sensitive OpenHound runtime settings.
 
     ```toml title="~/.dlt/config.toml"
@@ -97,14 +102,35 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     </Tip>
   </Step>
 
-  <Step title="Create the extension secrets file">
+  <Step title="Create the extension-specific secrets file">
     Create one secrets file for each extension you want to run.
     
-    The example Compose file maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
+    The example Compose file uses [collector-specific](/openhound/enterprise#collector-specific-configuration-parameters) files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
 
-    <Tip>
-      See [collector-specific configuration parameters](/openhound/enterprise#collector-specific-configuration-parameters) for more information.
-    </Tip>
+    | Extension | Host secrets file | Container secrets file |
+    |---|---|---|
+    | GitHub | `~/.dlt/secrets_github.toml` | `/app/.dlt/secrets.toml` |
+    | Jamf | `~/.dlt/secrets_jamf.toml` | `/app/.dlt/secrets.toml` |
+    | Okta | `~/.dlt/secrets_okta.toml` | `/app/.dlt/secrets.toml` |
+
+    Each extension secrets file must include:
+
+    - `[destination.bloodhoundenterprise]` with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` for the matching OpenHound collector client
+    - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
+
+    ```toml title="~/.dlt/secrets_github.toml"
+    [destination.bloodhoundenterprise]
+    url = "https://your-tenant.bloodhoundenterprise.io"
+    token_id = "client_token_id"
+    token_key = "client_token_key"
+
+    [sources.source.github.credentials]
+    # Add the GitHub collector credentials for your authentication method.
+    ```
+
+    <Note>
+      The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Do not use the JWT-based `destination.bloodhound` settings from [Upload Extension Assets](/openhound/upload-extension-assets) for scheduled collection.
+    </Note>
   </Step>
 
   <Step title="Add extension secret files">

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -20,14 +20,14 @@ This guide uses a supported Windows with WSL and Docker Desktop workflow, and th
 Before you begin, ensure that you have the following:
 
 - A BloodHound Enterprise tenant with OpenHound enabled.
-- API credentials for each OpenHound collector [client](/collect-data/enterprise-collection/create-collector) you plan to run. Use the `token_id` and `token_key` generated for the matching collector client.
+- API credentials for each OpenHound [collector client](/collect-data/enterprise-collection/create-collector) you plan to run. Use the `token_id` and `token_key` generated for the matching collector client.
 - The required credentials for the extension you want to collect:
   - [GitHub](/openhound/collectors/github/collect-data)
   - [Jamf](/openhound/collectors/jamf/collect-data)
   - [Okta](/openhound/collectors/okta/collect-data)
+- Uploaded [saved queries and Privilege Zone rules](/openhound/upload-extension-assets) for each extension you want to collect.
 - Docker Desktop with WSL integration enabled, or a Linux host with Docker or Podman installed.
 - The Compose plugin installed, such as `docker compose` or `podman compose`.
-- Git installed on the host where you prepare the deployment files.
 
 <Note>
   On Windows, enable Docker Desktop WSL integration before you run OpenHound from a WSL terminal. In Docker Desktop, open **Settings** > **Resources** > **WSL integration**, then enable integration for the WSL distribution you use.
@@ -46,6 +46,10 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     ```
 
     The command returns the installed Docker Compose version.
+
+    ```text
+    Docker Compose version v5.3.0
+    ```
   </Step>
 
   <Step title="Create the working directories">
@@ -118,15 +122,18 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     - `[destination.bloodhoundenterprise]` with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` for the matching OpenHound collector client
     - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
 
-    ```toml title="~/.dlt/secrets_github.toml"
-    [destination.bloodhoundenterprise]
-    url = "https://your-tenant.bloodhoundenterprise.io"
-    token_id = "client_token_id"
-    token_key = "client_token_key"
+      ```toml title="~/.dlt/secrets_github.toml"
+      [destination.bloodhoundenterprise]
+      url = "https://your-tenant.bloodhoundenterprise.io"
+      token_id = "client_token_id"
+      token_key = "client_token_key"
 
-    [sources.source.github.credentials]
-    # Add the GitHub collector credentials for your authentication method.
-    ```
+      [sources.source.github.credentials]
+      org_name = "your-github-org"
+      key_path = "/path/to/private/key.pem"
+      app_id = "123456"
+      client_id = "your-client-id"
+      ```
 
     <Note>
       The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Do not use the JWT-based `destination.bloodhound` settings from [Upload Extension Assets](/openhound/upload-extension-assets) for scheduled collection.

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -8,11 +8,8 @@ description: Deploy OpenHound for BloodHound Enterprise with Docker Compose.
 
 Deploy OpenHound with Docker Compose when you want to run OpenHound as a containerized service without Kubernetes.
 
-This guide uses a supported Windows with WSL and Docker Desktop workflow, and the same commands also apply to Linux hosts with Docker or Podman Compose.
-
 <Warning>
   OpenHound currently runs one extension per container. The example Compose file includes services for GitHub, Jamf, and Okta, but you should start only the service for the extension you want to run.
-  {/* TODO: Confirm current-state behavior. */}
 </Warning>
 
 ## Prerequisites
@@ -130,7 +127,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
 
       [sources.source.github.credentials]
       org_name = "your-github-org"
-      key_path = "/path/to/private/key.pem"
+      key_path = "/app/.dlt/github.pem"
       app_id = "123456"
       client_id = "your-client-id"
       ```

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -109,7 +109,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
   <Step title="Create the extension-specific secrets file">
     Create one secrets file for each extension you want to run.
     
-    The example Compose file uses [collector-specific](/openhound/enterprise#collector-specific-configuration-parameters) files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
+    The example Compose file uses [collector-specific](/openhound/configuration#collector-specific-settings) files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
 
     | Extension | Host secrets file | Container secrets file |
     |---|---|---|

--- a/docs/openhound/deploy-with-kubernetes.mdx
+++ b/docs/openhound/deploy-with-kubernetes.mdx
@@ -1,0 +1,73 @@
+---
+title: Deploy with Kubernetes
+sidebarTitle: Deploy with Kubernetes
+description: Deploy OpenHound for BloodHound Enterprise in a Kubernetes cluster.
+---
+
+An example Helm chart is available in the [OpenHound GitHub repository](https://github.com/specterops/openhound) for deploying OpenHound in a Kubernetes cluster. The chart can be used as a reference implementation for how OpenHound can be run on Kubernetes. The repository also includes the full `README` with instructions for deploying OpenHound and configuring the collector parameters and secrets required to connect to BloodHound Enterprise.
+
+## Prerequisites
+
+- Kubernetes cluster v1.33+
+- Helm v4.0+
+- The OpenHound repository cloned locally or access to the Helm chart files in the repository
+- A namespace created for OpenHound (e.g., `openhound`)
+
+## ConfigMap / Secret
+
+The chart requires a Kubernetes `ConfigMap` and `Secret` to be pre-created and referenced in `config.existingConfigMap`
+and `config.existingSecret`. The `ConfigMap` should contain the OpenHound configuration file with the non-sensitive DLT configuration parameters while the `Secret` should contain the secrets for authenticating with the target services and BloodHound Enterprise.
+
+The contents of the ConfigMap and Secret are mounted as `/app/.dlt/config.toml` and `/app/.dlt/secrets.toml`. Create the necessary `config.toml` and `secrets.toml` files locally and deploy these resources using `kubectl`.
+
+```bash
+# Using jamf as an example collector, but the same pattern applies for any collector
+kubectl create -n openhound configmap openhound-jamf-config \
+  --from-file=config.toml=<path_to_local_config>.toml
+
+kubectl create -n openhound secret generic openhound-jamf-secrets \
+  --from-file=secrets.toml=<path_to_local_secrets>.toml
+```
+
+## Optional: Additional secret files
+
+Collectors may require extra secret files such as a GitHub app PEM or an Okta JSON key file.
+Use `collector.extraSecretMounts` to mount files from pre-existing Kubernetes `Secret` objects.
+
+```yaml
+collector:
+  extraSecretMounts:
+    github-pem:
+      secretName: github-app-credentials
+      secretKey: github.pem
+      mountPath: /app/.dlt/github.pem
+    okta-json:
+      secretName: okta-client-secret
+      secretKey: okta.json
+      mountPath: /app/.dlt/okta.json
+```
+
+Each item references an existing `Secret`, the key containing the data/file and the target mount path. Similarly to the previously created secrets.toml you can deploy any additional secrets using `kubectl`.
+
+```bash
+kubectl create -n openhound secret generic github-app-credentials \
+  --from-file=github.pem=./github.pem
+
+kubectl create -n openhound secret generic okta-client-secret \
+  --from-file=okta.json=./okta.json
+```
+
+## Installation
+
+Create a `values.yaml` file with your collector configuration using [values.example.yaml](https://raw.githubusercontent.com/SpecterOps/OpenHound/refs/heads/main/deployments/helm/values.example.yaml) as a reference and install the chart using:
+
+```bash
+helm install -f values.yaml -n openhound openhound-[name] [openhound_path]/deployments/helm/openhound
+```
+
+## Verification
+
+Inspect the logs of the deployment to verify that the OpenHound collector is running correctly.
+```bash
+kubectl logs -n openhound -l app.kubernetes.io/name=openhound -f
+```

--- a/docs/openhound/enterprise.mdx
+++ b/docs/openhound/enterprise.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenHound for BloodHound Enterprise
-sidebarTitle: Enterprise
+sidebarTitle: Overview
 description: "Learn about the OpenHound framework for BloodHound Enterprise."
 ---
 
@@ -18,35 +18,48 @@ as:
 
 The OpenHound container image is available on [Docker Hub](https://hub.docker.com/r/specterops/openhound) and includes the collectors for Github, Jamf, and Okta by default.
 
+<Warning>
+  OpenHound currently runs one extension per container. Configure and start a separate OpenHound container for each extension you want to use.
+  {/* TODO: Confirm current-state behavior. */}
+</Warning>
+
 ## Deployment process
 
 To deploy OpenHound and run a collector:
 
 <Steps>
   <Step title="Provision the environment">
-    Provision a server with container (docker/podman) support, a Kubernetes cluster, or cloud-native container service to run OpenHound.
+    Provision a server with container (Docker/Podman) support, a Kubernetes cluster, or cloud-native container service to run OpenHound.
     
-    Ensure that the
-   environment meets the system requirements listed below.
+    <Note>
+      Ensure that the environment meets the [system requirements](/openhound/enterprise#server%2Fcontainer-requirements).
+    </Note>
   </Step>
   <Step title="Create an OpenHound collector client">
-    Register an OpenHound collector [client](/collect-data/enterprise-collection/create-collector) on your BloodHound Enterprise instance to obtain the necessary API credentials for OpenHound to upload data.
+    Create an OpenHound collector [client](/collect-data/enterprise-collection/create-collector) on your BloodHound Enterprise instance to obtain the necessary API credentials for OpenHound to upload data.
   </Step>
-  <Step title="Deploy OpenHound">
-    Deploy the OpenHound container and configure the required parameters using the configuration file or environment variables.
-    
-    For more details on the required parameters, visit the [configuration](/openhound/configuration) page as well as the collector-specific configuration pages in the [collectors](/openhound/enterprise#collector-specific-configuration-parameters) section.
+  <Step title="Configure the OpenHound container">
+    Configure the [OpenHound](/openhound/configuration#bloodhound-enterprise-configuration-parameters) and [collector-specific](/openhound/enterprise#collector-specific-configuration-parameters) container parameters.
+  </Step>
+  <Step title="Deploy the OpenHound container">
+    Use one of the supported methods to deploy the OpenHound container.
+
+    <Tip>
+      For example, see [Deploy with Docker Compose](/openhound/deploy-with-compose) for a Docker Desktop workflow.
+    </Tip>
   </Step>
   <Step title="Run the collector">
     Run an [On Demand](/collect-data/enterprise-collection/on-demand-scan) scan or create a data collection [schedule](/collect-data/enterprise-collection/collection-schedule) to start the collector and collect data from your environment.
   </Step>
+  <Step title="Upload extension assets">
+    Upload [saved queries and Privilege Zone rules](/openhound/configure-extension-assets) for the extension when those assets are not already present or need to be updated.
+  </Step>
 </Steps>
-
-
 
 ## Enterprise collector configuration
 
 ### Minimum configuration parameters
+
 The following parameters must be set in the `[destination.bloodhoundenterprise]` section of the configuration file or via environment variables to run OpenHound and have it upload data to BloodHound Enterprise.
 
 
@@ -57,6 +70,7 @@ The following parameters must be set in the `[destination.bloodhoundenterprise]`
 | `url`     | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise instance. | 
 
 ### Collector-specific configuration parameters
+
 Each collector requires additional configuration parameters that are unique to its data source. These settings can be defined in the configuration file or supplied via environment variables. For details on the available parameters, refer to the collector-specific configuration documentation using the links below.
 
 <CardGroup cols={3}>
@@ -134,105 +148,6 @@ You can provide these configuration files through compose secrets, Kubernetes Se
   </Tab>
 </Tabs>
 
-## Deployment examples
-
-### Kubernetes
-An example Helm chart is available in the [OpenHound GitHub repository](https://github.com/specterops/openhound) for deploying OpenHound in a Kubernetes cluster. The chart can be used as a reference implementation for how OpenHound can be run on Kubernetes. The repository also includes the full `README` with instructions for deploying OpenHound and configuring the collector parameters and secrets required to connect to BloodHound Enterprise.
-
-#### Prerequisites
-
-- Kubernetes cluster v1.33+
-- Helm v4.0+
-- The OpenHound repository cloned locally or access to the Helm chart files in the repository
-- A namespace created for OpenHound (e.g., `openhound`)
-
-
-#### ConfigMap / Secret
-
-The chart requires a Kubernetes `ConfigMap` and `Secret` to be pre-created and referenced in `config.existingConfigMap`
-and `config.existingSecret`. The `ConfigMap` should contain the OpenHound configuration file with the non-sensitive DLT configuration parameters while the `Secret` should contain the secrets for authenticating with the target services and BloodHound Enterprise.
-
-The contents of the ConfigMap and Secret are mounted as `/app/.dlt/config.toml` and `/app/.dlt/secrets.toml`. Create the necessary `config.toml` and `secrets.toml` files locally and deploy these resources using `kubectl`.
-
-```bash
-# Using jamf as an example collector, but the same pattern applies for any collector
-kubectl create -n openhound configmap openhound-jamf-config \
-  --from-file=config.toml=<path_to_local_config>.toml
-
-kubectl create -n openhound secret generic openhound-jamf-secrets \
-  --from-file=secrets.toml=<path_to_local_secrets>.toml
-```
-
-#### Optional: Additional secret files
-
-Collectors may require extra secret files such as a GitHub app PEM or an Okta JSON key file.
-Use `collector.extraSecretMounts` to mount files from pre-existing Kubernetes `Secret` objects.
-
-```yaml
-collector:
-  extraSecretMounts:
-    github-pem:
-      secretName: github-app-credentials
-      secretKey: github.pem
-      mountPath: /app/.dlt/github.pem
-    okta-json:
-      secretName: okta-client-secret
-      secretKey: okta.json
-      mountPath: /app/.dlt/okta.json
-```
-
-Each item references an existing `Secret`, the key containing the data/file and the target mount path. Similarly to the previously created secrets.toml you can deploy any additional secrets using `kubectl`.
-
-```bash
-kubectl create -n openhound secret generic github-app-credentials \
-  --from-file=github.pem=./github.pem
-
-kubectl create -n openhound secret generic okta-client-secret \
-  --from-file=okta.json=./okta.json
-```
-
-
-#### Installation
-Create a `values.yaml` file with your collector configuration using [values.example.yaml](https://raw.githubusercontent.com/SpecterOps/OpenHound/refs/heads/main/deployments/helm/values.example.yaml) as a reference and install the chart using:
-
-```bash
-helm install -f values.yaml -n openhound openhound-[name] [openhound_path]/deployments/helm/openhound
-```
-
-
-#### Verification
-Inspect the logs of the deployment to verify that the OpenHound collector is running correctly.
-```bash
-kubectl logs -n openhound -l app.kubernetes.io/name=openhound -f
-```
-
-
-### Compose
-The OpenHound container image can also be deployed using Docker Compose or Podman Compose on a Linux server. This is an alternative option for testing or environments where Kubernetes is not necessary.
-
-#### Prerequisites
-
-- A Linux server with Docker or Podman installed
-- The Compose plugin installed (e.g., `docker compose` or `podman compose`)
-- A Compose file, such as [`docker-compose.yml`](https://github.com/SpecterOps/OpenHound/blob/main/example-configurations/bloodhound-enterprise/docker-compose.yml)
-
-#### Installation
-
-To get started, create a `config.toml` and `secrets.toml` file with the necessary configuration parameters on the host machine. Use the `docker-compose.yml` file as a reference for how to structure the Compose file and mount the configuration files and secrets.
-
-Then run the following command to start the OpenHound container:
-
-```bash
-docker compose up -d
-```
-
-#### Verification
-Inspect the logs of the container(s) to verify that the OpenHound collector is running correctly.
-```bash
-docker compose logs -f
-```
-
-
 ## Server/container requirements
 
 ### Hardware
@@ -244,8 +159,7 @@ docker compose logs -f
 | *Storage  | 50 GB               | 80 GB or more          |
 
 <Note>
-The requirements vary depending on the size of the environment being collected/converted. Container storage
-persistence is not required. However, it is recommended to have a persistent storage for the logs for troubleshooting.
-The logs are stored in the `~/.local/share/openhound/logs` directory and can be configured to rotate based on time or
-file size.
+  The requirements vary depending on the size of the environment being collected/converted. Container storage persistence is not required. However, it is recommended to have a persistent storage for the logs for troubleshooting.
+  
+  The logs are stored in the `~/.local/share/openhound/logs` directory and can be configured to rotate based on time or file size.
 </Note>

--- a/docs/openhound/enterprise.mdx
+++ b/docs/openhound/enterprise.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Overview
 description: "Learn about the OpenHound framework for BloodHound Enterprise."
 ---
 
+import CollectorSpecificConfig from '/snippets/hounds/collector-specific-config.mdx'
+
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise"/>
 
 <Note>This is a SpecterOps-managed feature. If it is not enabled in your environment, contact your account team for assistance.</Note>
@@ -20,7 +22,6 @@ The OpenHound container image is available on [Docker Hub](https://hub.docker.co
 
 <Warning>
   OpenHound currently runs one extension per container. Configure and start a separate OpenHound container for each extension you want to use.
-  {/* TODO: Confirm current-state behavior. */}
 </Warning>
 
 ## Deployment process
@@ -35,136 +36,58 @@ To deploy OpenHound and run a collector:
       Ensure that the environment meets the [system requirements](/openhound/enterprise#server%2Fcontainer-requirements).
     </Note>
   </Step>
+  <Step title="Upload extension assets">
+    Upload [saved queries and Privilege Zone rules](/openhound/upload-extension-assets) for each collector extension you want to run to your BloodHound Enterprise tenant.
+  </Step>
   <Step title="Create an OpenHound collector client">
-    Create an OpenHound collector [client](/collect-data/enterprise-collection/create-collector) on your BloodHound Enterprise instance to obtain the necessary API credentials for OpenHound to upload data.
+    Create an OpenHound [collector client](/collect-data/enterprise-collection/create-collector) on your BloodHound Enterprise tenant to obtain the necessary API credentials for OpenHound to upload data.
   </Step>
   <Step title="Configure the OpenHound container">
-    Configure the [OpenHound](/openhound/configuration#bloodhound-enterprise-configuration-parameters) and [collector-specific](/openhound/enterprise#collector-specific-configuration-parameters) container parameters.
+    Configure the OpenHound [runtime](/openhound/configuration#runtime-settings) and [collector-specific](/openhound/configuration#collector-specific-settings) configuration parameters.
   </Step>
   <Step title="Deploy the OpenHound container">
     Use one of the supported methods to deploy the OpenHound container.
 
-    <Tip>
-      For example, see [Deploy with Docker Compose](/openhound/deploy-with-compose) for a Docker Desktop workflow.
-    </Tip>
+    - [Deploy with Docker Compose](/openhound/deploy-with-compose)
+    - [Deploy with Kubernetes](/openhound/deploy-with-kubernetes)
   </Step>
   <Step title="Run the collector">
     Run an [On Demand](/collect-data/enterprise-collection/on-demand-scan) scan or create a data collection [schedule](/collect-data/enterprise-collection/collection-schedule) to start the collector and collect data from your environment.
   </Step>
-  <Step title="Upload extension assets">
-    Upload [saved queries and Privilege Zone rules](/openhound/upload-extension-assets) for the extension when those assets are not already present or need to be updated.
-  </Step>
 </Steps>
 
-## Enterprise collector configuration
+## Enterprise configuration
 
-### Minimum configuration parameters
+OpenHound configuration defines how each collector container connects to BloodHound Enterprise, authenticates to the source system, and controls the collection pipeline.
 
-{/* TODO: This needs work to disambiguate collector-specific settings. */}
+Each OpenHound container requires three groups of settings:
 
-The following parameters must be set in the `[destination.bloodhoundenterprise]` section of the `~/.dlt/secrets.toml` file or via environment variables to run OpenHound and upload data to BloodHound Enterprise.
+- **BloodHound Enterprise destination settings** identify the tenant and collector client that receive the collected data.
+- **Collector source settings** authenticate to the system being collected, such as Github, Jamf, or Okta.
+- **Runtime settings** control operational behavior such as logging, retry handling, worker counts, and file handling.
 
-| Runtime option | Environment Variable | Description |
-|---|---|---|
-| `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
-| `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
-| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. |
-
-### Collector-specific configuration parameters
-
-Each collector requires additional configuration parameters that are unique to its data source. These settings can be defined in the configuration file or supplied via environment variables. For details on the available parameters, refer to the collector-specific configuration documentation using the links below.
-
-<CardGroup cols={3}>
-
-  <Card title="Github" href="/openhound/collectors/github/collect-data#configure-openhound">
-    View the required configuration parameters for the Github collector.
-  </Card>
-
-  <Card title="Jamf" href="/openhound/collectors/jamf/collect-data#configure-openhound">
-    View the required configuration parameters for the Jamf collector.
-  </Card>
-
-  <Card title="Okta" href="/openhound/collectors/okta/collect-data#configure-openhound">
-      View the required configuration parameters for the Okta collector.
-  </Card>
-
-</CardGroup>
-
-### Full configuration example
-
-The following example shows the full configuration for OpenHound with the required parameters for BloodHound Enterprise as well as example parameters for the Jamf collector.
-
-The configuration is split into two files:
-
-- `config.toml` for the non-sensitive OpenHound/DLT configuration parameters
-- `secrets.toml` for the sensitive credentials and secrets
-
-You can provide these configuration files through compose secrets, Kubernetes Secret and ConfigMap objects, or environment variables.
+Define non-sensitive runtime settings in `config.toml` and store credentials or tokens in `secrets.toml`, environment variables, or your container platform's secret management system. This separation helps you reuse the same operational defaults across collectors while keeping each collector's credentials isolated.
 
 <Note>
-  In Docker Compose deployments, the host secrets files are collector-specific, such as `~/.dlt/secrets_github.toml` or `~/.dlt/secrets_jamf.toml`. The Compose file mounts the matching host file into the container as `/app/.dlt/secrets.toml`.
+  For the required BloodHound Enterprise destination parameters, file layout, environment variable names, and common runtime options, see [Configuration](/openhound/configuration).
 </Note>
 
-<Tabs>
-  <Tab title="config.toml">
-    <Note>
-      For a full description of these and other available runtime parameters, see [Configuration](/openhound/configuration).
-    </Note>
-    ```toml title="config.toml"
-    [runtime]
-    http_show_error_body = true
-    log_cli_level = "WARNING"
-    log_rotate_when = "midnight"
+## Collector-specific configuration
 
-    # HTTP retry/backoff for source requests; rides out API rate limits
-    # (e.g. GitHub during large collections) instead of failing the run.
-    request_max_attempts = 15
-    request_backoff_factor = 1.3
-    request_max_retry_delay = 900
-
-    # Default: logs are set to human readable text
-    # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
-    # log_format = "JSON"
-
-    [extract]
-    workers = 8
-
-    [normalize]
-    workers = 3
-
-    [load]
-    delete_completed_jobs = true
-    truncate_staging_dataset = true
-    ```
-  </Tab>
-  <Tab title="secrets.toml">
-
-    ```toml title="secrets.toml"
-    [sources.source.jamf]
-    username = "myusername"
-    host = "https://tenant.jamfcloud.com"
-    password = "mypassword"
-
-    [destination.bloodhoundenterprise]
-    token_key = "client_token_key"
-    token_id = "client_token_id"
-    url = "https://test.bloodhoundenterprise.io"
-    ```
-  </Tab>
-</Tabs>
+<CollectorSpecificConfig />
 
 ## Server/container requirements
 
-### Hardware
+Use these requirements to size the host, virtual machine, or container service that runs OpenHound. Actual resource usage depends on the collector, the size of the source environment, and the number of objects OpenHound processes during each collection run.
 
 | Component | Minimum Requirement | Recommended Requirement |
 |-----------|---------------------|-------------------------|
 | CPU       | 2 cores             | 6 cores or more         |
 | Memory    | 4 GB                | 8 GB or more            |
-| *Storage  | 50 GB               | 80 GB or more          |
+| Storage   | 50 GB               | 80 GB or more           |
 
 <Note>
   The requirements vary depending on the size of the environment being collected/converted. Container storage persistence is not required. However, it is recommended to have a persistent storage for the logs for troubleshooting.
   
-  The logs are stored in the `~/.local/share/openhound/logs` directory and can be configured to rotate based on time or file size.
+  OpenHound stores logs in the `~/.local/share/openhound/logs` directory. You can configure log rotation by time or file size in the `config.toml` file.
 </Note>

--- a/docs/openhound/enterprise.mdx
+++ b/docs/openhound/enterprise.mdx
@@ -52,7 +52,7 @@ To deploy OpenHound and run a collector:
     Run an [On Demand](/collect-data/enterprise-collection/on-demand-scan) scan or create a data collection [schedule](/collect-data/enterprise-collection/collection-schedule) to start the collector and collect data from your environment.
   </Step>
   <Step title="Upload extension assets">
-    Upload [saved queries and Privilege Zone rules](/openhound/configure-extension-assets) for the extension when those assets are not already present or need to be updated.
+    Upload [saved queries and Privilege Zone rules](/openhound/upload-extension-assets) for the extension when those assets are not already present or need to be updated.
   </Step>
 </Steps>
 
@@ -60,14 +60,15 @@ To deploy OpenHound and run a collector:
 
 ### Minimum configuration parameters
 
-The following parameters must be set in the `[destination.bloodhoundenterprise]` section of the configuration file or via environment variables to run OpenHound and have it upload data to BloodHound Enterprise.
+{/* TODO: This needs work to disambiguate collector-specific settings. */}
 
+The following parameters must be set in the `[destination.bloodhoundenterprise]` section of the `~/.dlt/secrets.toml` file or via environment variables to run OpenHound and upload data to BloodHound Enterprise.
 
-| Runtime option     | Environment Variable      | Description |
-|--------------------|---------------------------|------------------------------|
-| `token_key`        | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key for authenticating with BloodHound Enterprise.|
-| `token_id`  | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID  | The API token ID for authenticating with BloodHound Enterprise. | 
-| `url`     | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise instance. | 
+| Runtime option | Environment Variable | Description |
+|---|---|---|
+| `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
+| `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
+| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. |
 
 ### Collector-specific configuration parameters
 
@@ -99,6 +100,10 @@ The configuration is split into two files:
 - `secrets.toml` for the sensitive credentials and secrets
 
 You can provide these configuration files through compose secrets, Kubernetes Secret and ConfigMap objects, or environment variables.
+
+<Note>
+  In Docker Compose deployments, the host secrets files are collector-specific, such as `~/.dlt/secrets_github.toml` or `~/.dlt/secrets_jamf.toml`. The Compose file mounts the matching host file into the container as `/app/.dlt/secrets.toml`.
+</Note>
 
 <Tabs>
   <Tab title="config.toml">

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -29,9 +29,15 @@ Before you upload extension assets, ensure that you have done the following:
 
 ## Configure CLI authentication
 
-OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to your DLT secrets file.
+OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to `~/.dlt/secrets.toml`.
 
 The asset upload commands use the `destination.bloodhound` section with a JWT bearer token. This is different from the `destination.bloodhoundenterprise` collector client configuration, which uses `token_id` and `token_key` for scheduled OpenHound collection.
+
+<Note>
+  Docker Compose scheduler examples use collector-specific host files, such as `~/.dlt/secrets_github.toml`, and mount the matching file into the container as `/app/.dlt/secrets.toml`.
+
+  Asset upload commands run from the OpenHound CLI and read the generic `~/.dlt/secrets.toml` file shown below.
+</Note>
 
 To get the browser JWT, follow the [BloodHound API JWT guidance](/integrations/bloodhound-api/working-with-api#use-a-jwt%2Fbearer-token). Copy only the token value and omit the `Bearer` prefix.
 

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -20,6 +20,10 @@ Before you upload extension assets, ensure that you have done the following:
 - Installed the [OpenHound CLI](/openhound/community#install-the-openhound-cli).
 - Verified or installed the matching extension definition schema in [OpenGraph Extension Management](/opengraph/extensions/manage#verify-or-install-an-extension).
 - Downloaded or cloned the extension repository that contains the asset files.
+  {/* TODO: Find a better way to present this. */}
+  - `https://github.com/SpecterOps/openhound-github`
+  - `https://github.com/SpecterOps/openhound-jamf`
+  - `https://github.com/SpecterOps/openhound-okta`
 - Obtained the BloodHound Enterprise tenant URL and browser JWT used by the OpenHound CLI for extension asset uploads.
 - Confirmed that the target Privilege Zone exists before you upload Privilege Zone rules for that zone.
 
@@ -53,6 +57,8 @@ token = "your-browser-jwt"
 
 ## Upload saved queries
 
+{/* TODO: Expand on command options. */}
+
 Saved queries are stored in the extension repository, usually in `extension/saved_searches`.
 
 <Steps>
@@ -84,6 +90,8 @@ Saved queries are stored in the extension repository, usually in `extension/save
 </Steps>
 
 ## Upload Privilege Zone rules
+
+{/* TODO: Expand on command options. */}
 
 Privilege Zone rules are stored in the extension repository, usually in `extension/privilege_zone_rules`.
 

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -5,7 +5,7 @@ description: Upload saved queries and Privilege Zone rules for OpenHound extensi
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise"/>
 
-OpenHound extensions include saved queries and Privilege Zone rules that help users analyze the data collected from GitHub, Jamf, Okta, or another OpenHound source. 
+OpenHound extensions include saved queries and Privilege Zone rules that help you analyze the data collected from the GitHub, Jamf, and Okta extensions. 
 
 Use the OpenHound CLI to upload these assets after the matching extension definition schema is installed or verified in BloodHound.
 
@@ -19,23 +19,15 @@ Before you upload extension assets, ensure that you have done the following:
 
 - Installed the [OpenHound CLI](/openhound/community#install-the-openhound-cli).
 - Verified or installed the matching extension definition schema in [OpenGraph Extension Management](/opengraph/extensions/manage#verify-or-install-an-extension).
-- Downloaded or cloned the extension repository that contains the asset files.
-  {/* TODO: Find a better way to present this. */}
-  - `https://github.com/SpecterOps/openhound-github`
-  - `https://github.com/SpecterOps/openhound-jamf`
-  - `https://github.com/SpecterOps/openhound-okta`
 - Obtained the BloodHound Enterprise tenant URL and browser JWT used by the OpenHound CLI for extension asset uploads.
-- Confirmed that the target Privilege Zone exists before you upload Privilege Zone rules for that zone.
-
-<Note>
-  Use `--strategy overwrite` when you need to update saved queries or Privilege Zone rules that already exist in BloodHound. The default strategy is `skip`, which leaves existing assets unchanged.
-</Note>
 
 ## Configure CLI authentication
 
-OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to `~/.dlt/secrets.toml`.
+OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to your local `~/.dlt/secrets.toml` file.
 
-The asset upload commands use the `destination.bloodhound` section with a JWT bearer token. This is different from the `destination.bloodhoundenterprise` collector client configuration, which uses `token_id` and `token_key` for scheduled OpenHound collection.
+The asset upload commands use the `destination.bloodhound` section with a JWT bearer token.
+
+This is different from the `destination.bloodhoundenterprise` collector client configuration, which uses `token_id` and `token_key` for scheduled OpenHound collection.
 
 <Note>
   Docker Compose scheduler examples use collector-specific host files, such as `~/.dlt/secrets_github.toml`, and mount the matching file into the container as `/app/.dlt/secrets.toml`.
@@ -55,69 +47,91 @@ token = "your-browser-jwt"
   Do not commit `secrets.toml` or token values to version control. Browser JWTs are short-lived and intended for user-authenticated API calls, not long-running integrations.
 </Warning>
 
-## Upload saved queries
+## Upload assets
 
-{/* TODO: Expand on command options. */}
+You must upload saved queries and Privilege Zone rules for each extension.
 
-Saved queries are stored in the extension repository, usually in `extension/saved_searches`.
+Saved queries and Privilege Zone rules are stored in each extension repository in the following directories:
+
+- `extension/saved_searches`
+- `extension/privilege_zone_rules`
+
+<Note>
+  OpenHound makes uploaded saved queries public by default.
+</Note>
 
 <Steps>
-  <Step title="Open the extension repository">
-    Change to the repository for the extension assets you want to upload.
+  <Step title="Clone the extension repositories">
+    Clone each extension repository to your local machine.
 
-    ```bash
-    cd ~/openhound-github
-    ```
+    <Tabs>
+      <Tab title="GitHub">
+        ```bash
+        git clone https://github.com/SpecterOps/openhound-github
+        ```
+      </Tab>
+      <Tab title="Jamf">
+        ```bash
+        git clone https://github.com/SpecterOps/openhound-jamf
+        ```
+      </Tab>
+      <Tab title="Okta">
+        ```bash
+        git clone https://github.com/SpecterOps/openhound-okta
+        ```
+      </Tab>
+    </Tabs>
   </Step>
-
   <Step title="Upload the saved queries">
-    Run the upload command against the saved queries directory.
+    For each extension, run the upload command against the saved queries directory.
 
-    <Note>
-      OpenHound makes uploaded saved queries public by default.
-    </Note>
+    <Tabs>
+      <Tab title="GitHub">
+        ```bash
+        openhound searches upload ~/openhound-github/extension/saved_searches
+        ```
+      </Tab>
+      <Tab title="Jamf">
+        ```bash
+        openhound searches upload ~/openhound-jamf/extension/saved_searches
+        ```
+      </Tab>
+      <Tab title="Okta">
+        ```bash
+        openhound searches upload ~/openhound-okta/extension/saved_searches
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+    <Step title="Upload the Privilege Zone rules">
+    For each extension, run the upload command against the Privilege Zone rules directory.
 
-    For example, to create saved queries that do not exist and overwrite matching saved queries with the same name, use the `--strategy overwrite` option.
+    <Tabs>
+      <Tab title="GitHub">
+        ```bash
+        openhound rules upload ~/openhound-github/extension/privilege_zone_rules
+        ```
+      </Tab>
+      <Tab title="Jamf">
+        ```bash
+        openhound rules upload ~/openhound-jamf/extension/privilege_zone_rules
+        ```
+      </Tab>
+      <Tab title="Okta">
+        ```bash
+        openhound rules upload ~/openhound-okta/extension/privilege_zone_rules
+        ```
+      </Tab>
+    </Tabs>
+      <Tip>
+        The default upload strategy is `skip`, which leaves existing assets unchanged.
 
-    ```bash
-    openhound searches upload ./extension/saved_searches --strategy overwrite
-    ```
-
-    <Note>
-      Saved query uploads default to JSON files. To upload saved queries from YAML files, add `--file-format yaml`.
-    </Note>
+        Use `--strategy overwrite` when you need to update previously uploaded saved queries or Privilege Zone rules. 
+      </Tip>
   </Step>
 </Steps>
 
-## Upload Privilege Zone rules
-
-{/* TODO: Expand on command options. */}
-
-Privilege Zone rules are stored in the extension repository, usually in `extension/privilege_zone_rules`.
-
-<Steps>
-  <Step title="Confirm the target zone exists">
-    In BloodHound Enterprise, confirm that the Privilege Zone referenced by the rule files exists.
-
-    If the target zone does not exist, create it before you upload the rules.
-  </Step>
-
-  <Step title="Upload the Privilege Zone rules">
-    Run the upload command against the Privilege Zone rules directory.
-
-    For example, to create rules that do not exist and overwrite matching rules with the same name, use the `--strategy overwrite` option.
-
-    ```bash
-    openhound rules upload ./extension/privilege_zone_rules --strategy overwrite
-    ```
-
-    <Note>
-      Upload Privilege Zone rules from JSON files. YAML support for Privilege Zone rule uploads requires Engineering confirmation.
-    </Note>
-  </Step>
-</Steps>
-
-## Verify the upload
+## Verify uploads
 
 After the upload completes:
 
@@ -125,11 +139,10 @@ After the upload completes:
 - Open **Privilege Zones** to confirm the expected rules appear in the target zone.
 - Wait for analysis to successfully run to verify rules that affect zone membership or findings.
 
-## Troubleshoot asset uploads
+## Troubleshoot
 
-| Symptom | Cause | Resolution |
+| Issue | Cause | Resolution |
 |---|---|---|
-| Existing assets do not update | The command used the default `skip` strategy | Run the upload again with `--strategy overwrite`. |
-| Privilege Zone rules do not appear | The target zone does not exist | Create the zone in BloodHound, then upload the rules again. |
-| Upload fails with an authentication error | The BloodHound URL or JWT is invalid or expired | Update `~/.dlt/secrets.toml` with a valid browser JWT and rerun the command. |
-| No files are uploaded | The command points to the wrong directory or file format | Confirm that the path contains JSON files, or add `--file-format yaml` for saved query YAML files. |
+| Existing assets do not update | The `upload` command uses the `skip` strategy by default. | Run the upload again with the `--strategy overwrite` option. |
+| Upload fails with an authentication error | The BloodHound Enterprise URL or JWT is invalid or expired. | Update the `~/.dlt/secrets.toml` file with a valid browser JWT and rerun the command. |
+| No files are uploaded | The command points to the wrong directory. | Confirm that the path contains the extension assets. |

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -67,17 +67,17 @@ Saved queries and Privilege Zone rules are stored in each extension repository i
     <Tabs>
       <Tab title="GitHub">
         ```bash
-        git clone https://github.com/SpecterOps/openhound-github
+        git clone https://github.com/SpecterOps/openhound-github ~/openhound-github
         ```
       </Tab>
       <Tab title="Jamf">
         ```bash
-        git clone https://github.com/SpecterOps/openhound-jamf
+        git clone https://github.com/SpecterOps/openhound-jamf ~/openhound-jamf
         ```
       </Tab>
       <Tab title="Okta">
         ```bash
-        git clone https://github.com/SpecterOps/openhound-okta
+        git clone https://github.com/SpecterOps/openhound-okta ~/openhound-okta
         ```
       </Tab>
     </Tabs>

--- a/docs/snippets/hounds/collector-specific-config.mdx
+++ b/docs/snippets/hounds/collector-specific-config.mdx
@@ -1,0 +1,19 @@
+Each collector requires additional configuration parameters that are unique to its data source.
+
+These settings can be defined in the `secrets.toml` file or supplied via environment variables. For details on the available parameters, refer to the collector-specific configuration documentation using the links below.
+
+<CardGroup cols={3}>
+
+  <Card title="Github" href="/openhound/collectors/github/collect-data#configure-openhound">
+    View the required configuration parameters for the Github collector.
+  </Card>
+
+  <Card title="Jamf" href="/openhound/collectors/jamf/collect-data#configure-openhound">
+    View the required configuration parameters for the Jamf collector.
+  </Card>
+
+  <Card title="Okta" href="/openhound/collectors/okta/collect-data#configure-openhound">
+      View the required configuration parameters for the Okta collector.
+  </Card>
+
+</CardGroup>


### PR DESCRIPTION
## Summary

This pull request (PR) adds new OpenHound docs and improves existing docs, including:

- Added a new deployment guide for Docker Compose
- Added instructions for uploading extension assets (saved queries and Privilege Zone rules)
- Expanded and restructured Enterprise-specific sidebar navigation
- Reorganized and streamlined duplicated configuration guidance