### PR TITLE
BP-2744: Add install_id for enterprise github app auth (OpenHound)

### DIFF
--- a/docs/openhound/collectors/github/collect-data.mdx
+++ b/docs/openhound/collectors/github/collect-data.mdx
@@ -42,6 +42,7 @@ Click the tab that matches your authentication setup for details and example con
     | `app_id` | The GitHub App ID used to authenticate to the GitHub API. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__APP_ID` |
     | `key_path` | The path to the GitHub App private key file. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__KEY_PATH` |
     | `enterprise_name` | The slug of the GitHub enterprise to collect data from. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__ENTERPRISE_NAME` |
+    | `install_id` | The GitHub App Installation ID for the enterprise installation. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__INSTALL_ID` |
     | `api_uri` | The GitHub API base URI. For GitHub.com, use `https://api.github.com`. | `SOURCES__SOURCE__GITHUB__CREDENTIALS__API_URI` |
 
     **`secrets.toml`**
@@ -52,6 +53,7 @@ Click the tab that matches your authentication setup for details and example con
     app_id = "your-app-id"
     key_path = "/path/to/private/key.pem"
     enterprise_name = "your-enterprise-slug"
+    install_id = "12345678"
     api_uri = "https://api.github.com"
     ```
 
@@ -62,6 +64,7 @@ Click the tab that matches your authentication setup for details and example con
     SOURCES__SOURCE__GITHUB__CREDENTIALS__APP_ID=your-app-id
     SOURCES__SOURCE__GITHUB__CREDENTIALS__KEY_PATH=/path/to/private/key.pem
     SOURCES__SOURCE__GITHUB__CREDENTIALS__ENTERPRISE_NAME=your-enterprise-slug
+    SOURCES__SOURCE__GITHUB__CREDENTIALS__INSTALL_ID=12345678
     SOURCES__SOURCE__GITHUB__CREDENTIALS__API_URI=https://api.github.com
     ```
   </Tab>

--- a/docs/openhound/collectors/github/configure-enterprise-app.mdx
+++ b/docs/openhound/collectors/github/configure-enterprise-app.mdx
@@ -56,7 +56,7 @@ Follow these steps to create a GitHub App that can be installed at the enterpris
     Save the downloaded `.pem` file securely. On the same page, record the **App ID** and **Client ID**.
 
     <Note>
-      OpenHound uses the **App ID**, **Client ID**, **key path**, **enterprise name**, and **API URI** in the GitHub enterprise app collector configuration.
+      OpenHound uses the **App ID**, **Client ID**, **key path**, **enterprise name**, **Installation ID**, and **API URI** in the GitHub enterprise app collector configuration.
     </Note>
   </Step>
 </Steps>
@@ -67,7 +67,7 @@ Install the same GitHub App in the enterprise account and in each organization y
 
 <Steps>
   <Step title="Install the app on the enterprise account">
-    Open the GitHub App settings page, click **Install App**, select the enterprise account, and complete the installation.
+    Open the GitHub App settings page, click **Install App**, select the enterprise account, and complete the installation. Record the enterprise **Installation ID** for the collector configuration.
   </Step>
   <Step title="Install the app on each organization">
     From the same GitHub App, install the app on every organization owned by the enterprise that you want OpenHound to collect.

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -119,7 +119,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     - `[destination.bloodhoundenterprise]` with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` for the matching OpenHound collector client
     - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
 
-      The following GitHub example uses an organization GitHub App. For other GitHub authentication methods, use the required fields from [Configure the Collector](/openhound/collectors/github/collect-data).
+      The following GitHub example uses an organization GitHub App.
 
       ```toml title="~/.dlt/secrets_github.toml"
       [destination.bloodhoundenterprise]


### PR DESCRIPTION
Fast follow for #348 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Enterprise App setup instructions to require and record the Installation ID.
  * Added Installation ID examples for secrets and environment variable configuration.
  * Clarified Docker Compose guidance for organization GitHub App authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->