### PR TITLE
BP-2636: Unhide Jira integration docs

### DIFF
--- a/docs/integrations/atlassian/jira/configure.mdx
+++ b/docs/integrations/atlassian/jira/configure.mdx
@@ -2,7 +2,6 @@
 title: Integrate BloodHound Enterprise with Jira
 description: Learn how to install and configure the Jira integration for BloodHound Enterprise.
 sidebarTitle: Install and configure
-hidden: true
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />
@@ -35,16 +34,14 @@ Install the integration in your Jira Cloud instance.
 </Note>
 
 <Steps>
-  <Step title="Open Atlassian Marketplace">
-    Go to [Atlassian Marketplace](https://marketplace.atlassian.com/) and search for the BloodHound Enterprise Jira integration.
-  </Step>
-
   <Step title="Start the installation">
-    1. Open the BloodHound Enterprise Jira integration listing.
+    1. Go to the [SpecterOps BloodHound Enterprise](https://marketplace.atlassian.com/apps/2043886069) listing on the Atlassian Marketplace.
 
-    1. Select **Get it now**.
+    1. Click **Get it now**.
 
     1. Select the Jira Cloud site where you want to install the integration.
+
+    1. Click **Install app**.
   </Step>
   <Step title="Review and install">
     Review the installation details, then start the installation.

--- a/docs/integrations/atlassian/jira/reference.mdx
+++ b/docs/integrations/atlassian/jira/reference.mdx
@@ -2,7 +2,6 @@
 title: Jira integration design reference
 description: Technical reference for the Jira integration, including its Atlassian Forge architecture, schedules, and API usage.
 sidebarTitle: Design reference
-hidden: true
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />

--- a/docs/integrations/atlassian/jira/troubleshoot.mdx
+++ b/docs/integrations/atlassian/jira/troubleshoot.mdx
@@ -2,7 +2,6 @@
 title: Troubleshoot the Jira integration
 description: Learn how to diagnose and resolve common Jira integration issues with BloodHound Enterprise.
 sidebarTitle: Troubleshoot
-hidden: true
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />

--- a/docs/integrations/atlassian/jira/use.mdx
+++ b/docs/integrations/atlassian/jira/use.mdx
@@ -2,7 +2,6 @@
 title: Use Jira with BloodHound Enterprise
 description: Learn how to review and manage Jira issues created from BloodHound Enterprise findings.
 sidebarTitle: Manage Jira issues
-hidden: true
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" />

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -74,7 +74,7 @@ The following integrations are officially supported by SpecterOps.
   | **Integration instructions** | <a href="/integrations/google-secops/configure">Configure the Google SecOps integration</a> |
 </Card>
 
-{/* <Card
+<Card
   title="Jira"
   href="/integrations/atlassian/jira/configure"
 >
@@ -85,7 +85,7 @@ The following integrations are officially supported by SpecterOps.
   | **Supported actions** | <ul><li>Automatically synchronize BloodHound Enterprise findings to Jira issues.</li><li>Map BloodHound Enterprise zones to Jira priorities.</li><li>Set due dates based on finding priority.</li><li>Filter by BloodHound Enterprise domains and zones for synchronization.</li><li>Prevent duplicate tickets with finding-aware deduplication.</li><li>Add direct Graph View links to BloodHound Enterprise finding details.</li><li>Close Jira tickets automatically after findings are remediated.</li><li>Support Jira Service Management request types and incidents.</li></ul> |
   | **Common use cases** | <ul><li>Manage identity Attack Paths through existing Jira workflows.</li><li>Create remediation tickets for identity Attack Paths.</li><li>Track remediation against defined SLAs.</li><li>Route findings to the appropriate teams.</li><li>Provide investigation context within every ticket.</li><li>Close tickets automatically when findings are resolved.</li><li>Measure progress in reducing Attack Paths.</li></ul> |
   | **Integration instructions** | <a href="/integrations/atlassian/jira/configure">Configure the Jira integration</a> |
-</Card> */}
+</Card>
 
 <Card
   title="Splunk SIEM"


### PR DESCRIPTION
The Jira integration has been published on the Atlassian Marketplace, so we can now make the docs public and searchable.

Related to #321 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jira to the supported integrations overview.
  * Made Jira setup, usage, reference, and troubleshooting documentation available.

* **Documentation**
  * Simplified Jira installation instructions with direct Marketplace navigation and clearer installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->