### PR TITLE
GH-354: Added new entry for GhostHound

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -83,6 +83,22 @@ Demonstration available in the [@SpecterOps #BloodHoundBasics post on X](https:/
 **Repo**
 - https://github.com/martinsohn/ManagerOfHound
 
+#### <Icon icon="people-group" size={22}/> GhostHound
+
+**Description**
+
+GhostHound is a BloodHound OpenGraph extension for Active Directory tombstone reanimation. SharpHound and other AD collectors skip `CN=Deleted Objects` entirely, so deleted objects (tombstones) are invisible to standard attack-path analysis, even though the AD Recycle Bin and tombstone reanimation mechanisms let a sufficiently privileged principal restore one and take over whatever identity it represents.
+
+GhostHound enumerates tombstones over LDAP with the `SHOW_DELETED`/`SHOW_DEACTIVATED_LINK` controls, determines who holds the Reanimate-Tombstones right, and checks whether a tombstone's group memberships (e.g. Domain Admins) are still recoverable. It emits an OpenGraph payload plus the `model.json` extension definition BloodHound needs to render it.
+
+Implemented as a Rust workspace: LDAP collection plus a from-scratch `nTSecurityDescriptor`/DACL/ACE parser, no `unsafe` code, fuzzed with cargo-fuzz.
+
+**Authors/Maintainers**
+- [João Victor Botelho Gonçalves](https://www.linkedin.com/in/joao-victor-botelho/)
+
+**Repo**
+- https://github.com/JVBotelho/ghosthound
+
 #### <Icon icon="people-group" size={22}/> ProfileHound
 
 **Description**


### PR DESCRIPTION
Resolves #354 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GhostHound to the OpenGraph Library’s community extensions list.
  * Included an overview of its Active Directory tombstone reanimation capabilities, output formats, implementation details, and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->