### PR TITLE
DOCS-15: Separate tenant URL from secrets

### DIFF
--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -28,17 +28,23 @@ OpenHound reads configuration from DLT configuration files, environment variable
 
 | File | Purpose | Example contents |
 |---|---|---|
-| `config.toml` | Non-sensitive runtime and pipeline settings | Logging, retry behavior, worker counts |
-| `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise collector client credentials and source credentials |
+| `config.toml` | Non-sensitive runtime, pipeline, and destination settings | BloodHound Enterprise tenant URL, logging, retry behavior, worker counts |
+| `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise API credentials |
 | Extension-specific secrets files | Per-extension host files used by Docker Compose and mounted into the container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
 
 For Docker Compose deployments, create the DLT files under `~/.dlt` on the host. The Enterprise example Compose file mounts the shared `config.toml` and maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
 
-Each extension-specific secrets file must include the `destination.bloodhoundenterprise` section with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` generated for the matching collector client. It must also include the credentials section required by that collector.
+Add the BloodHound Enterprise tenant URL to the shared `config.toml` file:
+
+```toml title="~/.dlt/config.toml"
+[destination.bloodhoundenterprise]
+url = "https://your-tenant.bloodhoundenterprise.io"
+```
+
+Each extension-specific secrets file must include the `destination.bloodhoundenterprise` section with the `token_id` and `token_key` generated for the matching collector client. It must also include the credentials section required by that collector.
 
 ```toml title="~/.dlt/secrets_github.toml"
 [destination.bloodhoundenterprise]
-url = "https://your-tenant.bloodhoundenterprise.io"
 token_id = "client_token_id"
 token_key = "client_token_key"
 
@@ -48,6 +54,8 @@ token_key = "client_token_key"
 
 <Note>
   The `destination.bloodhoundenterprise` settings are for scheduled OpenHound collection. Extension asset upload commands use a separate `destination.bloodhound` section with a browser JWT in `~/.dlt/secrets.toml`.
+
+  Existing collector secrets files that still define `destination.bloodhoundenterprise.url` continue to work, but new configurations should store the URL in `config.toml`.
 </Note>
 
 Some collectors require additional secret files, such as a GitHub App `.pem` private key or an Okta JSON key file. Store these files outside version control and configure the collector-specific path to match the path inside the container.
@@ -74,6 +82,9 @@ request_max_retry_delay = 900
 # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
 # log_format = "JSON"
 
+[destination.bloodhoundenterprise]
+url = "https://your-tenant.bloodhoundenterprise.io"
+
 [extract]
 workers = 4
 
@@ -94,15 +105,15 @@ workers=2
 
 ## BloodHound Enterprise settings
 
-Each extension-specific OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Add the following parameters to the `[destination.bloodhoundenterprise]` section of that collector's secrets file, or set the matching environment variables.
+Each extension-specific OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Add `url` to the `[destination.bloodhoundenterprise]` section of `config.toml` and add `token_id` and `token_key` to the `[destination.bloodhoundenterprise]` section of that collector's secrets file, or set the matching environment variables.
 
 Use the `token_id` and `token_key` generated for the OpenHound collector client that matches the extension you are configuring. For example, use the GitHub collector client credentials in the GitHub collector's `~/.dlt/secrets_github.toml` file.
 
 | Destination Option | Environment Variable | Description |
 |---|---|---|
+| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. Store this non-sensitive value in `config.toml`. |
 | `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
 | `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
-| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. |
 
 ## Collector-specific settings
 

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -77,7 +77,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
   </Step>
 
   <Step title="Create the OpenHound configuration file">
-    Create `~/.dlt/config.toml` for non-sensitive OpenHound runtime settings.
+    Create `~/.dlt/config.toml` for non-sensitive OpenHound runtime and destination settings.
 
     ```toml title="~/.dlt/config.toml"
     [runtime]
@@ -96,6 +96,9 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     [load]
     delete_completed_jobs = true
     truncate_staging_dataset = true
+
+    [destination.bloodhoundenterprise]
+    url = "https://your-tenant.bloodhoundenterprise.io"
     ```
 
     <Tip>
@@ -116,14 +119,13 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
 
     Each extension secrets file must include:
 
-    - `[destination.bloodhoundenterprise]` with the BloodHound Enterprise tenant URL and the `token_id` and `token_key` for the matching OpenHound collector client
+    - `[destination.bloodhoundenterprise]` with the `token_id` and `token_key` for the matching OpenHound collector client
     - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
 
       The following GitHub example uses an organization GitHub App.
 
       ```toml title="~/.dlt/secrets_github.toml"
       [destination.bloodhoundenterprise]
-      url = "https://your-tenant.bloodhoundenterprise.io"
       token_id = "client_token_id"
       token_key = "client_token_key"
 
@@ -136,7 +138,9 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
       ```
 
     <Note>
-      The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Do not use the JWT-based `destination.bloodhound` settings from [Upload Extension Assets](/openhound/upload-extension-assets) for scheduled collection.
+      The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Store the destination URL in `config.toml` and store `token_id` and `token_key` in the extension secrets file.
+
+      Do not use the JWT-based `destination.bloodhound` settings from [Upload Extension Assets](/openhound/upload-extension-assets) for scheduled collection.
     </Note>
   </Step>
 

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -23,16 +23,14 @@ Before you upload extension assets, ensure that you have done the following:
 
 ## Configure CLI authentication
 
-OpenHound uses DLT configuration management for CLI asset uploads. Add the BloodHound Enterprise tenant URL and browser JWT to your local `~/.dlt/secrets.toml` file.
+OpenHound asset uploads use JWT-based authentication. Add the BloodHound Enterprise tenant URL and browser JWT to your local `~/.dlt/secrets.toml` file.
 
-The asset upload commands use the `destination.bloodhound` section with a JWT bearer token.
-
-This is different from the `destination.bloodhoundenterprise` collector client configuration, which uses `token_id` and `token_key` for scheduled OpenHound collection.
+This workflow uses the `destination.bloodhound` section. It is separate from scheduled OpenHound collection, which uses `destination.bloodhoundenterprise` with collector client credentials.
 
 <Note>
-  Docker Compose scheduler examples use collector-specific host files, such as `~/.dlt/secrets_github.toml`, and mount the matching file into the container as `/app/.dlt/secrets.toml`.
+  Scheduled collector examples separate the BloodHound Enterprise destination URL into `config.toml` and keep collector client credentials in extension-specific secrets files, such as `~/.dlt/secrets_github.toml`.
 
-  Asset upload commands run from the OpenHound CLI and read the generic `~/.dlt/secrets.toml` file shown below.
+  Asset upload commands still run from the OpenHound CLI and read the generic `~/.dlt/secrets.toml` file shown below.
 </Note>
 
 To get the browser JWT, follow the [BloodHound API JWT guidance](/integrations/bloodhound-api/working-with-api#use-a-jwt%2Fbearer-token). Copy only the token value and omit the `Bearer` prefix.


### PR DESCRIPTION
## Purpose

This pull request (PR) updates the OpenHound configuration docs for the v0.2.12 release.

Users can now manage the BloodHound Enterprise URL setting in the `config.toml` file instead of the `secrets.toml` file.

Related to https://github.com/SpecterOps/OpenHound/pull/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how destination URLs, collector tokens, source credentials, and browser JWTs are configured.
  - Updated Docker Compose and collector setup examples to separate non-sensitive settings from secrets.
  - Documented the distinction between scheduled collection and extension asset uploads.
  - Added migration guidance for older configurations that store the destination URL in secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->