### PR TITLE
DOCS-13: Custom entity panel content

### DIFF
--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -40,10 +40,10 @@ This page describes the components of an extension definition schema. For a full
   Extension metadata identifying the extension, including version and namespace.
 </ResponseField>
 <ResponseField name="node_kinds" type="array" required>
-  Defines custom node types and their visual representations for an extension.
+  Defines custom node types, visual representations, and Entity panel content for an extension.
 </ResponseField>
 <ResponseField name="relationship_kinds" type="array" required>
-  Defines custom edge types and their traversability behavior for an extension.
+  Defines custom edge types, traversability behavior, and Entity panel content for an extension.
 </ResponseField>
 <ResponseField name="environments" type="array">
   Defines the environments for a platform and identifies which node kinds an extension treats as principals within each environment.
@@ -70,6 +70,35 @@ Although the `schema.name` field does not use a namespace prefix, it must still 
   - If names are not unique or properly namespaced, schema uploads fail validation.
   - The `tag` namespace prefix is reserved in any letter case, including `tag`, `Tag`, and `TAG`. Do not use this prefix in an extension definition schema. If you do, BloodHound rejects the upload.
 </Warning>
+
+## Custom Entity panel content
+
+Use the `info` object to define custom Entity panel sections for node kinds and relationship kinds. When a user selects a node or relationship in Explore, BloodHound renders matching `info` entries as accordion sections in the Entity panel.
+
+Each `info` object is a map of section identifiers to rendered sections. Use stable identifiers for the keys so future schema updates can modify the same section without changing its identity.
+
+```json
+"info": {
+  "overview": {
+    "title": "Overview",
+    "position": 1,
+    "markdown": {
+      "content": "This content appears in the Entity panel."
+    }
+  }
+}
+```
+
+| Field | Requirement | Description |
+| --- | --- | --- |
+| `info` key | Required | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
+| `title` | Required | Section title shown in the Entity panel accordion. |
+| `position` | Required | Integer that controls section order. Lower values render first. Use `1` or greater. |
+| `markdown.content` | Required | Markdown content rendered in the section body. |
+
+For a single kind, BloodHound orders sections by `position`. If a node has multiple kinds and more than one kind defines `info` entries, BloodHound orders the sections by `position`, then `title`, and then the contributing node kind. Relationship panels use the same ordering behavior with the contributing relationship kind as the final tiebreaker.
+
+If no `info` entries are defined for the selected kind, BloodHound does not render extension-defined Entity panel sections.
 
 ## Findings and metrics
 
@@ -122,7 +151,16 @@ Defines all node types in your extension. Each node kind represents an entity ty
     "description": "An Okta user account",
     "is_display_kind": true,
     "icon": "user",
-    "color": "#d33115"
+    "color": "#d33115",
+    "info": {
+      "overview": {
+        "title": "Overview",
+        "position": 1,
+        "markdown": {
+          "content": "Okta user accounts represent identities that can authenticate to Okta."
+        }
+      }
+    }
   }
 ]
 ```
@@ -147,6 +185,9 @@ Defines all node types in your extension. Each node kind represents an entity ty
 <ResponseField name="color" type="string">
   Optional Hex color code (in `#RGB` or `#RRGGBB` format, the `#` is required) to apply to nodes of this kind in the graph.
 </ResponseField>
+<ResponseField name="info" type="object">
+  Optional [custom Entity panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for nodes of this kind.
+</ResponseField>
 
 ## `relationship_kinds`
 
@@ -157,7 +198,16 @@ Defines what kind of connections exist. Each relationship kind represents a spec
   {
     "name": "Okta_ResetPassword",
     "description": "Ability to reset passwords or temporary credentials for scoped Okta users",
-    "is_traversable": true
+    "is_traversable": true,
+    "info": {
+      "abuse": {
+        "title": "Abuse",
+        "position": 1,
+        "markdown": {
+          "content": "An attacker can use this relationship to reset a user's password and access the account."
+        }
+      }
+    }
   }
 ]
 ```
@@ -172,6 +222,9 @@ Defines what kind of connections exist. Each relationship kind represents a spec
   Controls whether edges of this relationship kind are used for pathfinding and Attack Path detection.
 
   When `is_traversable` is set to `true` on a relationship kind, all edges of that kind inherit the same traversability behavior. Only <Tooltip tip="Represents a relationship where the starting node can take control of the ending node to a degree that lets an attacker abuse the ending node's outgoing edges" cta="Learn more" href="/resources/edges/traversable-edges">traversable edges</Tooltip> are included in pathfinding and considered for findings and metrics.
+</ResponseField>
+<ResponseField name="info" type="object">
+  Optional [custom Entity panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for relationships of this kind.
 </ResponseField>
 
 ## `environments`
@@ -301,14 +354,32 @@ The following example schema is based on Okta to illustrate how the different co
       "description": "An Okta user account",
       "is_display_kind": true,
       "icon": "user",
-      "color": "#d33115"
+      "color": "#d33115",
+      "info": {
+        "overview": {
+          "title": "Overview",
+          "position": 1,
+          "markdown": {
+            "content": "Okta user accounts represent identities that can authenticate to Okta."
+          }
+        }
+      }
     }
   ],
   "relationship_kinds": [
     {
       "name": "Okta_ResetPassword",
       "description": "Ability to reset passwords or temporary credentials for scoped Okta users",
-      "is_traversable": true
+      "is_traversable": true,
+      "info": {
+        "abuse": {
+          "title": "Abuse",
+          "position": 1,
+          "markdown": {
+            "content": "An attacker can use this relationship to reset a user's password and access the account."
+          }
+        }
+      }
     }
   ],
   "environments": [

--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -40,10 +40,10 @@ This page describes the components of an extension definition schema. For a full
   Extension metadata identifying the extension, including version and namespace.
 </ResponseField>
 <ResponseField name="node_kinds" type="array" required>
-  Defines custom node types, visual representations, and Entity panel content for an extension.
+  Defines custom node types, visual representations, and Entity Panel content for an extension.
 </ResponseField>
 <ResponseField name="relationship_kinds" type="array" required>
-  Defines custom edge types, traversability behavior, and Entity panel content for an extension.
+  Defines custom edge types, traversability behavior, and Entity Panel content for an extension.
 </ResponseField>
 <ResponseField name="environments" type="array">
   Defines the environments for a platform and identifies which node kinds an extension treats as principals within each environment.
@@ -71,9 +71,9 @@ Although the `schema.name` field does not use a namespace prefix, it must still 
   - The `tag` namespace prefix is reserved in any letter case, including `tag`, `Tag`, and `TAG`. Do not use this prefix in an extension definition schema. If you do, BloodHound rejects the upload.
 </Warning>
 
-## Custom Entity panel content
+## Custom Entity Panel content
 
-Use the `info` object to define custom Entity panel sections for node kinds and relationship kinds. When a user selects a node or relationship in Explore, BloodHound renders matching `info` entries as accordion sections in the Entity panel.
+Use the `info` object to define custom Entity Panel sections for node kinds and relationship kinds. When a user selects a node or relationship in Explore, BloodHound renders an Entity Panel with the specified accordion sections as defined by the `info` entries.
 
 Each `info` object is a map of section identifiers to rendered sections. Use stable identifiers for the keys so future schema updates can modify the same section without changing its identity.
 
@@ -83,7 +83,7 @@ Each `info` object is a map of section identifiers to rendered sections. Use sta
     "title": "Overview",
     "position": 1,
     "markdown": {
-      "content": "This content appears in the Entity panel."
+      "content": "This content appears in the Entity Panel."
     }
   }
 }
@@ -92,13 +92,15 @@ Each `info` object is a map of section identifiers to rendered sections. Use sta
 | Field | Requirement | Description |
 | --- | --- | --- |
 | `info` key | Required | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
-| `title` | Required | Section title shown in the Entity panel accordion. |
-| `position` | Required | Integer that controls section order. Lower values render first. Use `1` or greater. |
+| `title` | Required | Section title displayed in the Entity Panel accordion header. |
+| `position` | Required | Integer that controls the order of extension-defined sections. Lower values render first. Use `1` or greater. |
 | `markdown.content` | Required | Markdown content rendered in the section body. |
 
-For a single kind, BloodHound orders sections by `position`. If a node has multiple kinds and more than one kind defines `info` entries, BloodHound orders the sections by `position`, then `title`, and then the contributing node kind. Relationship panels use the same ordering behavior with the contributing relationship kind as the final tiebreaker.
+Every Entity Panel starts with **Object Information** at position `0`. This section lists all properties for the selected node or relationship.
 
-If no `info` entries are defined for the selected kind, BloodHound does not render extension-defined Entity panel sections.
+BloodHound renders additional `info` entries for the selected node's primary kind or the selected relationship's kind after **Object Information**. BloodHound orders those extension-defined sections by `position`, then `title`.
+
+If no `info` entries are defined for the selected kind, BloodHound still renders **Object Information**, but does not render additional extension-defined Entity Panel sections.
 
 ## Findings and metrics
 
@@ -186,7 +188,7 @@ Defines all node types in your extension. Each node kind represents an entity ty
   Optional Hex color code (in `#RGB` or `#RRGGBB` format, the `#` is required) to apply to nodes of this kind in the graph.
 </ResponseField>
 <ResponseField name="info" type="object">
-  Optional [custom Entity panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for nodes of this kind.
+  Optional [custom Entity Panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for nodes of this kind.
 </ResponseField>
 
 ## `relationship_kinds`
@@ -224,7 +226,7 @@ Defines what kind of connections exist. Each relationship kind represents a spec
   When `is_traversable` is set to `true` on a relationship kind, all edges of that kind inherit the same traversability behavior. Only <Tooltip tip="Represents a relationship where the starting node can take control of the ending node to a degree that lets an attacker abuse the ending node's outgoing edges" cta="Learn more" href="/resources/edges/traversable-edges">traversable edges</Tooltip> are included in pathfinding and considered for findings and metrics.
 </ResponseField>
 <ResponseField name="info" type="object">
-  Optional [custom Entity panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for relationships of this kind.
+  Optional [custom Entity Panel content](/opengraph/developer/graph-definition#custom-entity-panel-content) for relationships of this kind.
 </ResponseField>
 
 ## `environments`


### PR DESCRIPTION
## Purpose

This pull request (PR) documents an OpenGraph enhancement for v9.5.0.

Developers can use a new `info` object in the extension definition schema to control how content renders in the **Entity** panel for node and relationship kinds.

>[!NOTE]
>This PR intends to add reference content only. I plan to add it to the draft extension development tutorial (#351) to showcase how this influences UI behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for defining custom content in Entity panel accordion sections.
  * Documented section titles, ordering, Markdown content, identifiers, and behavior when no custom content is provided.
  * Updated node and relationship schema examples to show custom panel sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->