### PR TITLE
DOCS-12: Data quality

### DIFF
--- a/docs/collect-data/data-quality.mdx
+++ b/docs/collect-data/data-quality.mdx
@@ -1,0 +1,128 @@
+---
+title: Review Data Quality
+description: Use the Data Quality page to validate collected object counts, trends, and coverage after ingest.
+---
+
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
+
+The **Data Quality** page helps you validate what data exists in your BloodHound database after collection and ingest. Use it to confirm that expected data sources appear, object counts change as expected, and collection coverage supports the analysis workflows you plan to use.
+
+Data Quality is an operational validation page. It helps answer questions about the current shape and recent history of your database before you investigate findings, explore the graph, or troubleshoot collector output.
+
+## What the Data Quality page is for
+
+Use the Data Quality page after you upload or refresh data to:
+
+- Confirm that BloodHound ingested new or updated data.
+- Review object counts across supported data sources.
+- Compare current counts with historical collection trends.
+- Verify that expected object types appear for a directory, platform, or extension.
+- Check privileged Active Directory collection coverage for local groups and sessions.
+
+Data Quality does not replace collector logs or Cypher queries. If the page shows unexpected counts or coverage gaps, use it to identify where to investigate next.
+
+## Before you begin
+
+Before you review Data Quality, complete the collection or upload workflow for the data source you want to validate:
+
+- For Active Directory, collect and ingest SharpHound data.
+- For Azure and Entra ID, collect and ingest AzureHound data.
+- For structured OpenGraph data, verify or install the matching [OpenGraph extension definition schema](/opengraph/extensions/manage#verify-or-install-an-extension), then upload a conforming [data payload](/opengraph/developer/graph-data).
+
+Wait for ingest and analysis processing to complete before you compare counts or trends.
+
+## Review data quality
+
+<Steps>
+  <Step title="Open the Data Quality page">
+    In BloodHound, go to **Administration** > **Data Quality**.
+
+    The page opens with an aggregate view of included object data.
+  </Step>
+  <Step title="Review the total object count">
+    Use the total object count at the top of the page to confirm the current amount of included object data in the database.
+
+    The total helps you verify that a recent upload or collection run changed the database in the expected direction.
+  </Step>
+  <Step title="Review historical trends">
+    Review the historical graph to understand how object counts changed over time.
+
+    Use this trend to spot unexpected drops after a collector configuration change or large increases after onboarding a new data source.
+  </Step>
+  <Step title="Review source-specific details">
+    Use the available selectors and breakdowns to focus on a specific data source, environment, or extension.
+
+    Compare the displayed object types and counts with the data you expected the collector or payload to produce.
+  </Step>
+  <Step title="Review privileged collection coverage">
+    For Active Directory privileged collection, review **Local Group Completeness Over Time** and **Session Completeness Over Time**.
+
+    Use these charts to understand how much visibility BloodHound has into local group membership and session data across active computers.
+  </Step>
+</Steps>
+
+## Understand the page views
+
+The available views depend on the data in your BloodHound database. The page can include aggregate object counts, source-specific breakdowns, environment-specific views, and completeness charts.
+
+| View or metric | What it tells you | Use it to |
+|---|---|---|
+| **Total object count** | Current count of included object data in the database. | Confirm that ingest added, removed, or retained the expected amount of data. |
+| **Historical object count graph** | Object-count changes over time. | Identify unexpected drops, spikes, or missing collection activity. |
+| **Source or extension breakdown** | Current usage by built-in source or OpenGraph extension. | Confirm which data sources contribute objects to the database. |
+| **Object-type breakdown** | Counts by object type for a selected source, environment, or extension. | Verify that expected principal and resource types are present. |
+| **Completeness charts** | Active Directory privileged collection coverage over time. | Evaluate local group and session visibility across active computers. |
+
+## Understand count behavior
+
+Data Quality counts are designed to represent included object data, not every internal label stored in the graph. BloodHound excludes internal or metadata objects when those objects support platform features but are not useful as user-facing object types.
+
+For example, internal labels such as `Base` and `AZBase` can support calculations for Active Directory and Azure totals. They do not appear as separate object types in the breakdown because showing them separately can double count the same objects.
+
+Use Data Quality counts as validation indicators. If the counts do not match your expected collection or ingest results, review collector output, upload history, collection permissions, and extension compatibility before troubleshooting with Cypher.
+
+## Understand completeness charts
+
+Completeness charts apply to Active Directory data collected with SharpHound privileged collection. They help you understand collection coverage for data types that depend on host availability and permissions.
+
+| Chart | What it measures |
+|---|---|
+| **Local Group Completeness Over Time** | Visibility into local group membership collection across active computers. |
+| **Session Completeness Over Time** | Visibility into session collection across active computers. |
+
+Completeness below 100% is common. Workstations and servers can be offline, unavailable, or inaccessible during a collection run. If completeness is lower than expected, review collector permissions, collector logs, and collection scheduling.
+
+## Review structured OpenGraph data
+
+In BloodHound v9.5.0 and later, the Data Quality page includes structured OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
+
+<Note>
+  Structured OpenGraph Data Quality coverage is count-based. It does not add OpenGraph-specific coverage for sessions, data completeness, local group completeness, session completeness, or Environment Targeted Access Control (ETAC).
+</Note>
+
+For structured OpenGraph data, BloodHound organizes counts by extension. Extensions include SpecterOps-supported OpenGraph extensions, community extensions, and custom extensions.
+
+| OpenGraph extension type | Examples | How it appears |
+|---|---|---|
+| SpecterOps-supported | GitHub, Jamf, Okta | Appears as an extension that contributes object counts after ingest. |
+| Community | Public OpenGraph extensions | Appears after you install the extension schema and ingest matching data. |
+| Custom | Organization-specific extensions | Appears after you install the extension schema and ingest matching data. |
+
+Use **All Objects** to review total usage across included data. Select a specific extension to review that extension's total count, object-type breakdown, and historical object count trend.
+
+For example, an Okta extension view can show a total count for Okta objects and object-type counts such as `Okta_User`, `Okta_Group`, and `Okta_Device`.
+
+## Environments and extensions
+
+BloodHound uses environments to group data for platform-specific analysis and access workflows. Active Directory data uses domains, Azure and Entra ID data uses tenants, and structured OpenGraph extensions can define their own environment kinds.
+
+Not every OpenGraph extension defines environments. If an extension does not define environments, use aggregate and extension-specific views to validate the ingested data.
+
+## Next steps
+
+After you validate Data Quality:
+
+- Use [Search and pathfinding](/analyze-data/explore/search) to inspect specific objects.
+- Use [Search with Cypher](/analyze-data/explore/cypher-search) for deeper validation or troubleshooting.
+- Review [Manage Extensions](/opengraph/extensions/manage) if expected structured OpenGraph data does not appear.
+- Review [SharpHound Enterprise troubleshooting](/install-data-collector/install-sharphound/troubleshooting) if Active Directory coverage is lower than expected.

--- a/docs/collect-data/data-quality.mdx
+++ b/docs/collect-data/data-quality.mdx
@@ -3,15 +3,17 @@ title: Review Data Quality
 description: Use the Data Quality page to validate collected object counts, trends, and coverage after ingest.
 ---
 
+import FeatureFlagNote from '/snippets/feature-flag.mdx';
+
 <img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>
 
 The **Data Quality** page helps you validate what data exists in your BloodHound database after collection and ingest. Use it to confirm that expected data sources appear, object counts change as expected, and collection coverage supports the analysis workflows you plan to use.
 
-Data Quality is an operational validation page. It helps answer questions about the current shape and recent history of your database before you investigate findings, explore the graph, or troubleshoot collector output.
+It helps answer questions about the current shape and recent history of your database before you investigate findings, explore the graph, or troubleshoot collector output.
 
 ## What the Data Quality page is for
 
-Use the Data Quality page after you upload or refresh data to:
+Use the **Data Quality** page after you upload or refresh data to:
 
 - Confirm that BloodHound ingested new or updated data.
 - Review object counts across supported data sources.
@@ -19,15 +21,19 @@ Use the Data Quality page after you upload or refresh data to:
 - Verify that expected object types appear for a directory, platform, or extension.
 - Check privileged Active Directory collection coverage for local groups and sessions.
 
-Data Quality does not replace collector logs or Cypher queries. If the page shows unexpected counts or coverage gaps, use it to identify where to investigate next.
+<Note>
+  Data quality does not replace collector logs or Cypher queries. If the page shows unexpected counts or coverage gaps, use it to identify where to investigate next.
+</Note>
 
 ## Before you begin
 
-Before you review Data Quality, complete the collection or upload workflow for the data source you want to validate:
+Before you review data quality, complete the collection or upload workflow for the data source you want to validate:
 
 - For Active Directory, collect and ingest SharpHound data.
 - For Azure and Entra ID, collect and ingest AzureHound data.
 - For structured OpenGraph data, verify or install the matching [OpenGraph extension definition schema](/opengraph/extensions/manage#verify-or-install-an-extension), then upload a conforming [data payload](/opengraph/developer/graph-data).
+
+  <FeatureFlagNote />
 
 Wait for ingest and analysis processing to complete before you compare counts or trends.
 
@@ -50,7 +56,7 @@ Wait for ingest and analysis processing to complete before you compare counts or
     Use this trend to spot unexpected drops after a collector configuration change or large increases after onboarding a new data source.
   </Step>
   <Step title="Review source-specific details">
-    Use the available selectors and breakdowns to focus on a specific data source, environment, or extension.
+    Use the environment selector to focus on a specific data source, environment, or extension.
 
     Compare the displayed object types and counts with the data you expected the collector or payload to produce.
   </Step>
@@ -61,27 +67,26 @@ Wait for ingest and analysis processing to complete before you compare counts or
   </Step>
 </Steps>
 
-## Understand the page views
+## Data quality views
 
 The available views depend on the data in your BloodHound database. The page can include aggregate object counts, source-specific breakdowns, environment-specific views, and completeness charts.
 
 | View or metric | What it tells you | Use it to |
 |---|---|---|
-| **Total object count** | Current count of included object data in the database. | Confirm that ingest added, removed, or retained the expected amount of data. |
-| **Historical object count graph** | Object-count changes over time. | Identify unexpected drops, spikes, or missing collection activity. |
-| **Source or extension breakdown** | Current usage by built-in source or OpenGraph extension. | Confirm which data sources contribute objects to the database. |
-| **Object-type breakdown** | Counts by object type for a selected source, environment, or extension. | Verify that expected principal and resource types are present. |
+| **Object type and relationship counts** | Current object counts (by type) and relationships in the database. | Confirm that ingest added, removed, or retained the expected amount of data. |
+| **Historical object count graph** | Object-type count changes over time. | Identify unexpected drops, spikes, or missing collection activity. |
+| **Source or extension breakdown** | Filter by built-in source or OpenGraph extension. | Confirm which data sources contribute objects to the database. |
 | **Completeness charts** | Active Directory privileged collection coverage over time. | Evaluate local group and session visibility across active computers. |
 
-## Understand count behavior
+## Count behavior
 
-Data Quality counts are designed to represent included object data, not every internal label stored in the graph. BloodHound excludes internal or metadata objects when those objects support platform features but are not useful as user-facing object types.
+Data quality counts are designed to represent included object data, not every internal label stored in the graph. BloodHound excludes internal or metadata objects when those objects support platform features but are not useful as user-facing object types.
 
 For example, internal labels such as `Base` and `AZBase` can support calculations for Active Directory and Azure totals. They do not appear as separate object types in the breakdown because showing them separately can double count the same objects.
 
-Use Data Quality counts as validation indicators. If the counts do not match your expected collection or ingest results, review collector output, upload history, collection permissions, and extension compatibility before troubleshooting with Cypher.
+Use data quality counts as validation indicators. If the counts do not match your expected collection or ingest results, review collector output, upload history, collection permissions, and extension compatibility before troubleshooting with Cypher.
 
-## Understand completeness charts
+## Completeness charts
 
 Completeness charts apply to Active Directory data collected with SharpHound privileged collection. They help you understand collection coverage for data types that depend on host availability and permissions.
 
@@ -92,37 +97,22 @@ Completeness charts apply to Active Directory data collected with SharpHound pri
 
 Completeness below 100% is common. Workstations and servers can be offline, unavailable, or inaccessible during a collection run. If completeness is lower than expected, review collector permissions, collector logs, and collection scheduling.
 
-## Review structured OpenGraph data
+## Structured OpenGraph data
 
-In BloodHound v9.5.0 and later, the Data Quality page includes structured OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
+<FeatureFlagNote />
+
+In BloodHound v9.5.0 and later, the **Data Quality** page includes structured OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
 
 <Note>
-  Structured OpenGraph Data Quality coverage is count-based. It does not add OpenGraph-specific coverage for sessions, data completeness, local group completeness, session completeness, or Environment Targeted Access Control (ETAC).
+  Data quality coverage for structured OpenGraph data is count-based. It does not add OpenGraph-specific coverage for sessions, data completeness, local group completeness, session completeness, or Environment Targeted Access Control (ETAC).
 </Note>
 
 For structured OpenGraph data, BloodHound organizes counts by extension. Extensions include SpecterOps-supported OpenGraph extensions, community extensions, and custom extensions.
 
-| OpenGraph extension type | Examples | How it appears |
-|---|---|---|
-| SpecterOps-supported | GitHub, Jamf, Okta | Appears as an extension that contributes object counts after ingest. |
-| Community | Public OpenGraph extensions | Appears after you install the extension schema and ingest matching data. |
-| Custom | Organization-specific extensions | Appears after you install the extension schema and ingest matching data. |
-
-Use **All Objects** to review total usage across included data. Select a specific extension to review that extension's total count, object-type breakdown, and historical object count trend.
-
-For example, an Okta extension view can show a total count for Okta objects and object-type counts such as `Okta_User`, `Okta_Group`, and `Okta_Device`.
+Select a specific extension or environment to review that extension's object type counts and historical trends.
 
 ## Environments and extensions
 
 BloodHound uses environments to group data for platform-specific analysis and access workflows. Active Directory data uses domains, Azure and Entra ID data uses tenants, and structured OpenGraph extensions can define their own environment kinds.
 
 Not every OpenGraph extension defines environments. If an extension does not define environments, use aggregate and extension-specific views to validate the ingested data.
-
-## Next steps
-
-After you validate Data Quality:
-
-- Use [Search and pathfinding](/analyze-data/explore/search) to inspect specific objects.
-- Use [Search with Cypher](/analyze-data/explore/cypher-search) for deeper validation or troubleshooting.
-- Review [Manage Extensions](/opengraph/extensions/manage) if expected structured OpenGraph data does not appear.
-- Review [SharpHound Enterprise troubleshooting](/install-data-collector/install-sharphound/troubleshooting) if Active Directory coverage is lower than expected.

--- a/docs/collect-data/data-quality.mdx
+++ b/docs/collect-data/data-quality.mdx
@@ -19,7 +19,7 @@ Use the **Data Quality** page after you upload or refresh data to:
 - Review object counts across supported data sources.
 - Compare current counts with historical collection trends.
 - Verify that expected object types appear for a directory, platform, or extension.
-- Check privileged Active Directory collection coverage for local groups and sessions.
+- Check Active Directory data completeness for privileged collection coverage, including local groups and sessions.
 
 <Note>
   Data quality does not replace collector logs or Cypher queries. If the page shows unexpected counts or coverage gaps, use it to identify where to investigate next.
@@ -31,7 +31,9 @@ Before you review data quality, complete the collection or upload workflow for t
 
 - For Active Directory, collect and ingest SharpHound data.
 - For Azure and Entra ID, collect and ingest AzureHound data.
-- For structured OpenGraph data, verify or install the matching [OpenGraph extension definition schema](/opengraph/extensions/manage#verify-or-install-an-extension), then upload a conforming [data payload](/opengraph/developer/graph-data).
+- For <Tooltip tip="OpenGraph data conforming to the basic node, edge, and metadata format required for a data payload and associated with an installed extension definition schema." cta="Learn more" href="/opengraph/overview#structured-graphs">structured</Tooltip> OpenGraph data, verify or install the matching [OpenGraph extension definition schema](/opengraph/extensions/manage#verify-or-install-an-extension), then upload a conforming [data payload](/opengraph/developer/graph-data).
+
+  The **Data Quality** page does not support <Tooltip tip="OpenGraph data conforming to the basic node, edge, and metadata format required for a data payload, with no associated extension definition schema." cta="Learn more" href="/opengraph/overview#generic-graphs">generic</Tooltip> OpenGraph data.
 
   <FeatureFlagNote />
 
@@ -80,15 +82,13 @@ The available views depend on the data in your BloodHound database. The page can
 
 ## Count behavior
 
-Data quality counts are designed to represent included object data, not every internal label stored in the graph. BloodHound excludes internal or metadata objects when those objects support platform features but are not useful as user-facing object types.
+Data quality counts show user-facing object data. They do not include internal labels or metadata objects that BloodHound uses to support platform features.
 
 For example, internal labels such as `Base` and `AZBase` can support calculations for Active Directory and Azure totals. They do not appear as separate object types in the breakdown because showing them separately can double count the same objects.
 
-Use data quality counts as validation indicators. If the counts do not match your expected collection or ingest results, review collector output, upload history, collection permissions, and extension compatibility before troubleshooting with Cypher.
-
 ## Completeness charts
 
-Completeness charts apply to Active Directory data collected with SharpHound privileged collection. They help you understand collection coverage for data types that depend on host availability and permissions.
+Completeness charts apply to Active Directory data collected with SharpHound [privileged collection](/collect-data/enterprise-collection/privileged-collection). They help you understand collection coverage for data types that depend on host availability and permissions.
 
 | Chart | What it measures |
 |---|---|
@@ -101,18 +101,8 @@ Completeness below 100% is common. Workstations and servers can be offline, unav
 
 <FeatureFlagNote />
 
-In BloodHound v9.5.0 and later, the **Data Quality** page includes structured OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
+In BloodHound v9.5.0 and later, the **Data Quality** page includes [structured](/opengraph/overview#graph-structure) OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
 
-<Note>
-  Data quality coverage for structured OpenGraph data is count-based. It does not add OpenGraph-specific coverage for sessions, data completeness, local group completeness, session completeness, or Environment Targeted Access Control (ETAC).
-</Note>
+For structured OpenGraph data, BloodHound organizes counts by extension and registered [`source_kind`](/opengraph/developer/graph-data#data-source). The `source_kind` identifies the OpenGraph data source and can come from payload metadata or from `environments.source_kind` in an extension definition schema.
 
-For structured OpenGraph data, BloodHound organizes counts by extension. Extensions include SpecterOps-supported OpenGraph extensions, community extensions, and custom extensions.
-
-Select a specific extension or environment to review that extension's object type counts and historical trends.
-
-## Environments and extensions
-
-BloodHound uses environments to group data for platform-specific analysis and access workflows. Active Directory data uses domains, Azure and Entra ID data uses tenants, and structured OpenGraph extensions can define their own environment kinds.
-
-Not every OpenGraph extension defines environments. If an extension does not define environments, use aggregate and extension-specific views to validate the ingested data.
+Select a specific extension or source kind to review object type counts and historical trends for that OpenGraph source.

--- a/docs/collect-data/overview.mdx
+++ b/docs/collect-data/overview.mdx
@@ -27,3 +27,9 @@ description: "Learn how to run attack path data collection and ingestion."
 <Card title="AzureHound Community Edition" icon="file" href="/collect-data/ce-collection/azurehound"/>
 <Card title="All AzureHound Community Edition Flags, Explained" icon="star" href="/collect-data/ce-collection/azurehound-flags"/>
 </CardGroup>
+
+## Validate Data
+
+<CardGroup cols={2}>
+<Card title="Review Data Quality" icon="chart-column" href="/collect-data/data-quality"> </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -82,6 +82,7 @@
             "group": "Collect Data",
             "pages": [
               "collect-data/overview",
+              "collect-data/data-quality",
               "collect-data/azurehound-data-permissions",
               "collect-data/sharphound-data-permissions",
               {

--- a/docs/get-started/quickstart/enterprise-quickstart.mdx
+++ b/docs/get-started/quickstart/enterprise-quickstart.mdx
@@ -71,6 +71,10 @@ After collecting data, to verify data quality:
 
 2. Verify that each collector has collected the expected amount of data and that principal types match your expected coverage for each directory and platform.
 
+   <Note>
+    For more information, see [Review Data Quality](/collect-data/data-quality).
+   </Note>
+
 3. If using privileged collection, verify that the charts **Local Group Completeness Over Time** and **Session Completeness Over Time** report higher than 0%.
 
    Obtaining 100% completeness is not possible in most environments due to things like workstations being offline during collection.


### PR DESCRIPTION
## Purpose

This pull request (PR) adds new docs for the **Data Quality** page.

The Core team is shipping an enhancement for structured OpenGraph data in v9.5.0. We don't currently have any docs for the Data Quality page, so we need to add general info _then_ enhancement-specific info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new “Review Data Quality” guide to validate ingest results, including counts, historical trends, source/extension breakdowns, and privileged Active Directory completeness.
  - Included OpenGraph data quality coverage guidance (count-based review), environment/extension handling, and clarifications on what’s available and how counts behave.
  - Updated the Collect Data overview with a “Validate Data” section and added navigation cards/links to the new guide.
  - Enhanced the enterprise quickstart “Verify data quality” step with a note and direct link to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->