### PR TITLE
Add sizing table with more accurate hardware requirements

### DIFF
--- a/docs/on-premises/system-requirements.mdx
+++ b/docs/on-premises/system-requirements.mdx
@@ -26,10 +26,21 @@ The application and Kubernetes run on the same host, along with the bundled Post
 | Filesystem | XFS with ftype=1; ext4 is fine | Blocks install |
 | SELinux | Supported (embedded cluster 2.8.0+) | - |
 | Access | Root or sudo | Blocks install |
-| CPU | 48 cores | No check, but required for performance |
-| RAM | 160 GB | No check, but required for performance |
-| Storage | 680 GB SSD (640 app/db + 40 cluster) | No check, but required for performance |
 | Disk latency | P99 write \<=10ms (use SSDs) | Blocks install |
+
+## Sizing
+
+Use the following size guidance to provision CPU, RAM, storage, collectors, and availability for your BloodHound Enterprise deployment.
+
+<Tip>
+  Scroll to the right to view all columns.
+</Tip>
+
+| Size | Good fit | App nodes | vCPU per node | RAM per node | Storage | Collectors | HA posture | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Small | Smaller enterprise, 1-2 domains, lighter concurrent use | 1 | 8 | 32GB | 250GB SSD | 1 | Backup/restore only | Best entry production size |
+| Medium | Typical enterprise, multiple domains, regular use | 2 | 8-12 | 32-48GB | 500GB SSD | 2 | Basic resilience | Best default starting point |
+| Large | Large or complex enterprise, heavy graph, more concurrency | 3 | 12-16 | 64GB | 1-2TB SSD/NVMe | 3+ | Full HA-oriented design | Best for scale and growth headroom |
 
 <Warning>
   Not supported: STIG/CIS-hardened images, single-stack IPv6.


### PR DESCRIPTION
## Purpose

This pull request (PR) adds a separate system requirements table for on-premises instances. It includes the latest hardware spec recommendations for small, medium, and large instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added disk latency requirements for on-premises deployments, including SSDs and P99 write latency guidance.
  * Added Small, Medium, and Large sizing recommendations covering compute, memory, storage, collectors, and high availability.
  * Replaced outdated hardware sizing statements with clearer deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->