### PR TITLE
Add reserved property for opengraph nodes (ref)

### DIFF
--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -136,6 +136,10 @@ During ingest, BloodHound maps this `id` value internally to `objectid`. If you 
   Do not include `objectid` inside `properties`. Use only the root-level `id` field.
 </Warning>
 
+### `ref`
+
+The property name `ref` is reserved and **must not** be included in the `properties` object of a node definition.
+
 ## Findings and metrics
 
 <img


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that `ref` is a reserved node property and must not be included in node data payloads.
  * Clarified that using `ref` inside `properties` can cause ingestion issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->