### PR TITLE
DOCS-12: Clarify access to data quality enhancement

### DIFF
--- a/docs/resources/release-notes/2026-07-29.mdx
+++ b/docs/resources/release-notes/2026-07-29.mdx
@@ -74,6 +74,10 @@ import FeatureFlagNote from '/snippets/feature-flag.mdx';
   - [`GET /api/v2/data-quality-stats`](/reference/data-quality/get-environment-specific-data-quality-stats)
   - [`GET /api/v2/data-quality-stats-aggregations`](/reference/data-quality/get-data-quality-aggregations-by-environment-kind)
   - [`GET /api/v2/available-domains`](/reference/search/get-available-domains)
+
+  <Note>
+    UI access remains a SpecterOps-managed feature. The supporting API endpoints require you to enable **OpenGraph Extension Management** on the **Early Access Page**.
+  </Note>
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>


### PR DESCRIPTION
Clarify in the v9.5.0 release notes that the data quality API endpoints are governed by the OpenGraph Extension Management feature flag.