### PR TITLE
GH-369: Add Bloodhound Kube to OpenGraph library

### DIFF
--- a/docs/collect-data/data-quality.mdx
+++ b/docs/collect-data/data-quality.mdx
@@ -99,7 +99,7 @@ Completeness below 100% is common. Workstations and servers can be offline, unav
 
 In BloodHound v9.5.1 and later, the **Data Quality** page includes [structured](/opengraph/overview#graph-structure) OpenGraph object counts and historical trends. This enhancement helps you validate OpenGraph ingest without writing custom Cypher queries.
 
-<EarlyAccessNote />
+<EarlyAccessNote feature="OpenGraph Data Quality" />
 
 For structured OpenGraph data, BloodHound organizes counts by extension and registered [`source_kind`](/opengraph/developer/graph-data#data-source). The `source_kind` identifies the OpenGraph data source and can come from payload metadata or from `environments.source_kind` in an extension definition schema.
 

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -401,6 +401,24 @@ The collector is compatible with SpecterOps's [OpenGraph extension for Jamf](/op
 </Accordion>
 <Accordion title="Kubernetes" icon="people-group">
 
+#### <Icon icon="people-group" size={22}/> Bloodhound-Kube
+
+**Description**
+
+Bloodhound-Kube is a BloodHound OpenGraph collector for Kubernetes and OpenShift designed for fast collections from large-scale clusters, helping to visualize multi-step attack paths through a variety of Kubernetes objects and potential vectors. This tool also supports multiple commonly found custom resources:
+
+- CNI Specific network policies (Cilium & Calico)
+- External Secrets
+- Cert-Manager
+
+With more coming soon!
+
+**Authors/Maintainers**
+- [Don Cowan](https://www.linkedin.com/in/don-cowan/) @[IBM X-Force Red](https://www.ibm.com/x-force)
+
+**Repo**
+- https://github.com/HackinAhab/bloodhound-kube
+
 #### <Icon icon="people-group" size={22}/> ClusterHound
 
 **Description**


### PR DESCRIPTION
## Summary

This pull request adds a new entry to the OpenGraph library: BloodHound Kube

Closes #369 

>[!NOTE]
>It also fixes a snippet in the new data quality page that was missing a variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Early Access notice for OpenGraph Data Quality.
  * Added Bloodhound-Kube to the OpenGraph Library’s Kubernetes extensions, including supported resources and project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->