### PR TITLE
DOCS-20: OpenHound configuration improvements

### DIFF
--- a/docs/openhound/collectors/okta/collect-data.mdx
+++ b/docs/openhound/collectors/okta/collect-data.mdx
@@ -44,13 +44,7 @@ via the `[sources.source.okta.credentials]` section of the secrets file or via e
 | `client_id`     | \{PREFIX\}__CLIENT_ID | The client ID of the Okta service application used to authenticate to the Okta API. |
 | `private_key_path` | \{PREFIX\}__PRIVATE_KEY_PATH | The path to the private key (.json) used for authentication. |
 
-### Option 2: Service Application with base64-encoded JSON key string 
-
-<Warning>
-  **Known issue**
-
-  This option currently fails because the collector can only load the private key from a file path, not from `private_key_b64`. Use Option 1 or Option 3 until this is fixed.
-</Warning>
+### Option 2: Service Application with base64-encoded JSON key string
 
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|

--- a/docs/openhound/collectors/okta/collect-data.mdx
+++ b/docs/openhound/collectors/okta/collect-data.mdx
@@ -45,11 +45,18 @@ via the `[sources.source.okta.credentials]` section of the secrets file or via e
 | `private_key_path` | \{PREFIX\}__PRIVATE_KEY_PATH | The path to the private key (.json) used for authentication. |
 
 ### Option 2: Service Application with base64-encoded JSON key string 
+
+<Warning>
+  **Known issue**
+
+  This option currently fails because the collector can only load the private key from a file path, not from `private_key_b64`. Use Option 1 or Option 3 until this is fixed.
+</Warning>
+
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|
 | `base_url`     | \{PREFIX\}__BASE_URL | The base URL of the Okta organization. For example: `https://spectoropspreview.oktapreview.com`. |
 | `client_id`     | \{PREFIX\}__CLIENT_ID | The client ID of the Okta service application used to authenticate to the Okta API. |
-| `private_key_encoded` | \{PREFIX\}__PRIVATE_KEY_ENCODED | The private key (.json) encoded as a base64 string.  |
+| `private_key_b64` | \{PREFIX\}__PRIVATE_KEY_B64 | The private key (.json) encoded as a base64 string.  |
 
 ### Option 3: API Token (SSWS)
 | Parameter Name | Environment Variable            | Description                                                                        |

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -13,7 +13,6 @@ OpenHound uses [DLT configuration management](https://dlthub.com/docs/general-us
 The following sections cover common OpenHound parameters and how to configure them for your deployment.
 You configure OpenHound in nearly the same way whether you run it as a containerized service or as a standalone CLI application.
 
-
 ## Configuration management
 
 OpenHound and DLT use a TOML-based configuration layout that organizes settings into sections based on the component or feature. Each top-level section defines defaults for a specific phase during the collection/conversion pipeline.
@@ -30,7 +29,7 @@ OpenHound reads configuration from DLT configuration files, environment variable
 |---|---|---|
 | `config.toml` | Non-sensitive runtime, pipeline, and destination settings | BloodHound Enterprise tenant URL, logging, retry behavior, worker counts |
 | `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise API credentials |
-| Extension-specific secrets files | Per-extension host files used by Docker Compose and mounted into the container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
+| Collector-specific secrets files | Per-collector host files used by Docker Compose and mounted into the container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
 
 For Docker Compose deployments, create the DLT files under `~/.dlt` on the host. The Enterprise example Compose file mounts the shared `config.toml` and maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
 
@@ -41,12 +40,13 @@ Add the BloodHound Enterprise tenant URL to the shared `config.toml` file:
 url = "https://your-tenant.bloodhoundenterprise.io"
 ```
 
-Each extension-specific secrets file must include the `destination.bloodhoundenterprise` section with the `token_id` and `token_key` generated for the matching collector client. It must also include the credentials section required by that collector.
+Each collector-specific secrets file must include the `destination.bloodhoundenterprise` section with the `token_id` and `token_key` generated for the matching collector client in BloodHound Enterprise and the `collector_name`.
 
 ```toml title="~/.dlt/secrets_github.toml"
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
+collector_name = "github"
 
 [sources.source.github.credentials]
 # Add the GitHub collector credentials for your authentication method.
@@ -105,15 +105,18 @@ workers=2
 
 ## BloodHound Enterprise settings
 
-Each extension-specific OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Add `url` to the `[destination.bloodhoundenterprise]` section of `config.toml` and add `token_id` and `token_key` to the `[destination.bloodhoundenterprise]` section of that collector's secrets file, or set the matching environment variables.
+Each OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Set the following values in the file that matches each setting, or use the equivalent environment variables:
 
-Use the `token_id` and `token_key` generated for the OpenHound collector client that matches the extension you are configuring. For example, use the GitHub collector client credentials in the GitHub collector's `~/.dlt/secrets_github.toml` file.
+- **`config.toml`** — Add the non-sensitive `url` to the `[destination.bloodhoundenterprise]` section. This file is shared across collectors.
+- **The collector's secrets file** (for example, `~/.dlt/secrets_github.toml`) — Add the `token_id` and `token_key` generated for the OpenHound collector client that matches the extension you are configuring to the `[destination.bloodhoundenterprise]` section.
+- **`collector_name`** — Set this to the same extension, such as `github`.
 
 | Destination Option | Environment Variable | Description |
 |---|---|---|
 | `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. Store this non-sensitive value in `config.toml`. |
 | `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
 | `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
+| `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required when running the scheduler (Docker Compose or Helm). Must match the extension being run, such as `okta`, `jamf`, or `github`. |
 
 ## Collector-specific settings
 

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -21,52 +21,26 @@ The syntax allows for nested sections, collector-specific configurations, and co
 
 Configuration precedence follows a global-to-specific order: a collector-specific override in `[sources.source.<collector>.extract]` takes priority over a global setting in `[extract]`, which in turn takes priority over the built-in default.
 
-### File layout
+OpenHound reads configuration from DLT files, environment variables, or both. Keep non-sensitive settings and secrets in separate files:
 
-OpenHound reads configuration from DLT configuration files, environment variables, or both. Use separate files for non-sensitive settings and secrets:
-
-| File | Purpose | Example contents |
-|---|---|---|
-| `config.toml` | Non-sensitive runtime, pipeline, and destination settings | BloodHound Enterprise tenant URL, logging, retry behavior, worker counts |
-| `secrets.toml` | Sensitive values required by the running collector | BloodHound Enterprise API credentials |
-| Collector-specific secrets files | Per-collector host files used by Docker Compose and mounted into the container as `secrets.toml` | `secrets_github.toml`, `secrets_jamf.toml`, `secrets_okta.toml` |
-
-For Docker Compose deployments, create the DLT files under `~/.dlt` on the host. The Enterprise example Compose file mounts the shared `config.toml` and maps the extension-specific secrets file into the container as `/app/.dlt/secrets.toml`.
-
-Add the BloodHound Enterprise tenant URL to the shared `config.toml` file:
-
-```toml title="~/.dlt/config.toml"
-[destination.bloodhoundenterprise]
-url = "https://your-tenant.bloodhoundenterprise.io"
-```
-
-Each collector-specific secrets file must include the `destination.bloodhoundenterprise` section with the `token_id` and `token_key` generated for the matching collector client in BloodHound Enterprise and the `collector_name`.
-
-```toml title="~/.dlt/secrets_github.toml"
-[destination.bloodhoundenterprise]
-token_id = "client_token_id"
-token_key = "client_token_key"
-collector_name = "github"
-
-[sources.source.github.credentials]
-# Add the GitHub collector credentials for your authentication method.
-```
+| File | Purpose |
+|---|---|
+| `config.toml` | Non-sensitive runtime settings shared across collectors. This file also holds your BloodHound Enterprise tenant URL for scheduled collection. |
+| `secrets.toml` | The single secrets file each collector run reads. Its contents [differ by edition](/openhound/configuration#secrets-by-edition). |
+| Collector key files | Extra key material referenced from `secrets.toml`, such as a GitHub App `.pem` private key or an Okta JSON key file. Required only by collectors that use key-based authentication. |
 
 <Note>
-  The `destination.bloodhoundenterprise` settings are for scheduled OpenHound collection. Extension asset upload commands use a separate `destination.bloodhound` section with a browser JWT in `~/.dlt/secrets.toml`.
-
-  Existing collector secrets files that still define `destination.bloodhoundenterprise.url` continue to work, but new configurations should store the URL in `config.toml`.
+  For Docker Compose deployments, create the DLT files under `~/.dlt` on the host.
 </Note>
 
-Some collectors require additional secret files, such as a GitHub App `.pem` private key or an Okta JSON key file. Store these files outside version control and configure the collector-specific path to match the path inside the container.
+## `config.toml`
 
-<Note>
-  For production environments, use environment variables or your container platform's secret management features when local secret files do not meet your organization's credential handling requirements.
-</Note>
+The following example configuration sets global values for runtime, normalize, and load, then overrides the extract worker count for the Okta and GitHub collectors.
 
-The following sample configuration sets global values for runtime, normalize, and load, then overrides the extract worker count for the Okta and GitHub collectors.
+The only difference between Enterprise and Community editions is that the `destination.bloodhoundenterprise` section is required for scheduled collection in BloodHound Enterprise. It is not used for Community Edition collection.
 
-```toml Example ~/.dlt/config.toml
+<CodeGroup>
+```toml title="Enterprise ~/.dlt/config.toml" highlight {16-17}
 [runtime]
 log_level = "INFO"
 log_rotate_when = "midnight"
@@ -103,13 +77,127 @@ truncate_staging_dataset=true
 workers=2
 ```
 
+```toml title="Community ~/.dlt/config.toml"
+[runtime]
+log_level = "INFO"
+log_rotate_when = "midnight"
+log_interval = 1
+
+# HTTP retry/backoff for source requests; rides out API rate limits
+# (e.g. GitHub during large collections) instead of failing the run.
+request_max_attempts = 15
+request_backoff_factor = 1.3
+request_max_retry_delay = 900
+
+# Default: logs are set to human readable text
+# To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
+# log_format = "JSON"
+
+[extract]
+workers = 4
+
+[sources.source.github.extract]
+workers=2
+
+[sources.source.okta.extract]
+workers=12
+
+[normalize]
+workers = 4
+
+[load]
+delete_completed_jobs=true
+truncate_staging_dataset=true
+workers=2
+```
+</CodeGroup>
+
+<Tip>
+  See [Runtime settings](/openhound/configuration#runtime-settings) for the full list of common runtime settings.
+</Tip>
+
+## `secrets.toml`
+
+Each OpenHound container runs a single collector, so each container needs its own `secrets.toml` file. To run multiple collectors on one host, keep a separate secrets file per collector, for example:
+
+- `~/.dlt/secrets_github.toml`
+- `~/.dlt/secrets_okta.toml`
+- `~/.dlt/secrets_jamf.toml`
+
+<Tip>
+  At runtime, OpenHound always reads the `secrets.toml` file. The collector-specific secrets files are an authoring convenience on the host. Your deployment mounts the correct one into each container as `secrets.toml`.
+</Tip>
+
+The example Docker Compose files follow this pattern for both BloodHound Enterprise and BloodHound Community.
+
+Each service mounts one host secrets file as the container's `secrets.toml` and mounts any collector key files (such as `github.pem` or `okta.json`) to the paths referenced by the collector credentials.
+
+Store these key files outside version control and set the collector's key path to match the path inside the container.
+
+### Edition-specific secrets
+
+The structure of the `secrets.toml` file is the main configuration difference between the Enterprise and Community editions. The following table summarizes the required sections for each edition:
+
+| `secrets.toml` section | Enterprise | Community |
+|---|---|---|
+| `[destination.bloodhoundenterprise]` | Required. Authenticates the collector client that uploads data to your tenant. | Omit. Community writes OpenGraph files to the local filesystem instead of a BloodHound Enterprise destination. |
+| `[sources.source.<collector>.credentials]` | Required. Authenticates to the source system. | Required. Authenticates to the source system. |
+
+Because Community collection has no BloodHound Enterprise destination, the `collect`, `preprocess`, and `convert` commands read and write local files, so the secrets file only needs the collector's source credentials.
+
+<CodeGroup>
+```toml title="Community ~/.dlt/secrets_github.toml"
+[sources.source.github.credentials]
+# GitHub collector credentials for your authentication method.
+```
+
+```toml title="Enterprise ~/.dlt/secrets_github.toml"
+[destination.bloodhoundenterprise]
+token_id = "client_token_id"
+token_key = "client_token_key"
+
+[sources.source.github.credentials]
+# GitHub collector credentials for your authentication method.
+```
+</CodeGroup>
+
+### Collector-specific secrets
+
+<CollectorSpecificConfig />
+
 ## BloodHound Enterprise settings
 
-Each OpenHound collector needs a minimum BloodHound Enterprise destination configuration. Set the following values in the file that matches each setting, or use the equivalent environment variables:
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "20%" }}/>
 
-- **`config.toml`** — Add the non-sensitive `url` to the `[destination.bloodhoundenterprise]` section. This file is shared across collectors.
-- **The collector's secrets file** (for example, `~/.dlt/secrets_github.toml`) — Add the `token_id` and `token_key` generated for the OpenHound collector client that matches the extension you are configuring to the `[destination.bloodhoundenterprise]` section.
-- **`collector_name`** — Set this to the same extension, such as `github`.
+Add your BloodHound Enterprise tenant URL to the shared `config.toml` file. This value is non-sensitive, so keep it out of the `secrets.toml` files. The URL is required for scheduled collection and is used by the OpenHound CLI commands that upload extension assets (saved queries, Privilege Zone rules, etc.) to your tenant:
+
+```toml title="~/.dlt/config.toml"
+[destination.bloodhoundenterprise]
+url = "https://your-tenant.bloodhoundenterprise.io"
+```
+
+<Note>
+  For production environments, use environment variables or your container platform's secret management features when local secret files do not meet your organization's credential handling requirements.
+</Note>
+
+The `destination.bloodhoundenterprise` settings apply to BloodHound Enterprise scheduled collection only. They authenticate each collector container to your tenant. Community Edition and standalone CLI runs omit this section.
+
+Each collector-specific secrets file must include a `[destination.bloodhoundenterprise]` section with the `token_id` and `token_key` generated for that collector's client in BloodHound Enterprise.
+
+The scheduler also needs `collector_name` to know which collector to run. The example Docker Compose files set this per service with the `DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME` environment variable, so the shipped secrets files omit it. You can also set it in `config.toml` or the secrets file.
+
+```toml title="~/.dlt/secrets_github.toml"
+[destination.bloodhoundenterprise]
+token_id = "client_token_id"
+token_key = "client_token_key"
+
+[sources.source.github.credentials]
+# Add the GitHub collector credentials for your authentication method.
+```
+
+<Warning>
+  Do not confuse `destination.bloodhoundenterprise` with `destination.bloodhound`. The `destination.bloodhound` section uses a browser JWT (`url` and `token`) and applies only to the OpenHound CLI commands that [upload extension assets](/openhound/upload-extension-assets), such as saved queries and Privilege Zone rules. It is not used for scheduled collection.
+</Warning>
 
 | Destination Option | Environment Variable | Description |
 |---|---|---|
@@ -117,10 +205,6 @@ Each OpenHound collector needs a minimum BloodHound Enterprise destination confi
 | `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
 | `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
 | `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required when running the scheduler (Docker Compose or Helm). Must match the extension being run, such as `okta`, `jamf`, or `github`. |
-
-## Collector-specific settings
-
-<CollectorSpecificConfig />
 
 ## Runtime settings
 

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -25,8 +25,8 @@ OpenHound reads configuration from DLT files, environment variables, or both. Ke
 
 | File | Purpose |
 |---|---|
-| `config.toml` | Non-sensitive runtime settings shared across collectors. This file also holds your BloodHound Enterprise tenant URL for scheduled collection. |
-| `secrets.toml` | The single secrets file each collector run reads. Its contents [differ by edition](/openhound/configuration#secrets-by-edition). |
+| `config.toml` | Non-sensitive runtime settings shared across collectors. Its contents [differ by edition](/openhound/configuration#edition-specific-settings). |
+| `secrets.toml` | The single secrets file each collector run reads. Its contents [differ by edition](/openhound/configuration#edition-specific-secrets). |
 | Collector key files | Extra key material referenced from `secrets.toml`, such as a GitHub App `.pem` private key or an Okta JSON key file. Required only by collectors that use key-based authentication. |
 
 <Note>
@@ -35,83 +35,98 @@ OpenHound reads configuration from DLT files, environment variables, or both. Ke
 
 ## `config.toml`
 
+The `config.toml` file contains non-sensitive runtime settings that apply to all collectors. It can also hold the BloodHound Enterprise tenant URL for scheduled collection.
+
+### Edition-specific settings
+
 The following example configuration sets global values for runtime, normalize, and load, then overrides the extract worker count for the Okta and GitHub collectors.
 
-The only difference between Enterprise and Community editions is that the `destination.bloodhoundenterprise` section is required for scheduled collection in BloodHound Enterprise. It is not used for Community Edition collection.
+<Tabs>
+  <Tab title="Enterprise">
+  The primary difference between BloodHound Enterprise and BloodHound Community editions is that the `destination.bloodhoundenterprise` setting applies to BloodHound Enterprise scheduled collection only. It authenticates each collector container to your tenant.
 
-<CodeGroup>
-```toml title="Enterprise ~/.dlt/config.toml" highlight {16-17}
-[runtime]
-log_level = "INFO"
-log_rotate_when = "midnight"
-log_interval = 1
+  ```toml title="Enterprise ~/.dlt/config.toml" highlight {16-17}
+  [runtime]
+  log_level = "INFO"
+  log_rotate_when = "midnight"
+  log_interval = 1
 
-# HTTP retry/backoff for source requests; rides out API rate limits
-# (e.g. GitHub during large collections) instead of failing the run.
-request_max_attempts = 15
-request_backoff_factor = 1.3
-request_max_retry_delay = 900
+  # HTTP retry/backoff for source requests; rides out API rate limits
+  # (e.g. GitHub during large collections) instead of failing the run.
+  request_max_attempts = 15
+  request_backoff_factor = 1.3
+  request_max_retry_delay = 900
 
-# Default: logs are set to human readable text
-# To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
-# log_format = "JSON"
+  # Default: logs are set to human readable text
+  # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
+  # log_format = "JSON"
 
-[destination.bloodhoundenterprise]
-url = "https://your-tenant.bloodhoundenterprise.io"
+  [destination.bloodhoundenterprise]
+  url = "https://your-tenant.bloodhoundenterprise.io"
 
-[extract]
-workers = 4
+  [extract]
+  workers = 4
 
-[sources.source.github.extract]
-workers=2
+  [sources.source.github.extract]
+  workers=2
 
-[sources.source.okta.extract]
-workers=12
+  [sources.source.okta.extract]
+  workers=12
 
-[normalize]
-workers = 4
+  [normalize]
+  workers = 4
 
-[load]
-delete_completed_jobs=true
-truncate_staging_dataset=true
-workers=2
-```
+  [load]
+  delete_completed_jobs=true
+  truncate_staging_dataset=true
+  workers=2
+  ```
 
-```toml title="Community ~/.dlt/config.toml"
-[runtime]
-log_level = "INFO"
-log_rotate_when = "midnight"
-log_interval = 1
+  OpenHound supports the following environment variables for the `destination.bloodhoundenterprise` section:
 
-# HTTP retry/backoff for source requests; rides out API rate limits
-# (e.g. GitHub during large collections) instead of failing the run.
-request_max_attempts = 15
-request_backoff_factor = 1.3
-request_max_retry_delay = 900
+  | Destination Option | Environment Variable | Description |
+  |---|---|---|
+  | `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. Store this non-sensitive value in `config.toml`. |
+  | `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required when running the scheduler (Docker Compose or Helm). Must match the extension being run, such as `okta`, `jamf`, or `github`. |
+  </Tab>
+  <Tab title="Community">
+  The following example is nearly identical to the Enterprise example, except that it omits the `destination.bloodhoundenterprise` section.
 
-# Default: logs are set to human readable text
-# To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
-# log_format = "JSON"
+  ```toml title="Community ~/.dlt/config.toml"
+  [runtime]
+  log_level = "INFO"
+  log_rotate_when = "midnight"
+  log_interval = 1
 
-[extract]
-workers = 4
+  # HTTP retry/backoff for source requests; rides out API rate limits
+  # (e.g. GitHub during large collections) instead of failing the run.
+  request_max_attempts = 15
+  request_backoff_factor = 1.3
+  request_max_retry_delay = 900
 
-[sources.source.github.extract]
-workers=2
+  # Default: logs are set to human readable text
+  # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
+  # log_format = "JSON"
 
-[sources.source.okta.extract]
-workers=12
+  [extract]
+  workers = 4
 
-[normalize]
-workers = 4
+  [sources.source.github.extract]
+  workers=2
 
-[load]
-delete_completed_jobs=true
-truncate_staging_dataset=true
-workers=2
-```
-</CodeGroup>
+  [sources.source.okta.extract]
+  workers=12
 
+  [normalize]
+  workers = 4
+
+  [load]
+  delete_completed_jobs=true
+  truncate_staging_dataset=true
+  workers=2
+  ```
+  </Tab>
+</Tabs>
 <Tip>
   See [Runtime settings](/openhound/configuration#runtime-settings) for the full list of common runtime settings.
 </Tip>
@@ -136,75 +151,47 @@ Store these key files outside version control and set the collector's key path t
 
 ### Edition-specific secrets
 
-The structure of the `secrets.toml` file is the main configuration difference between the Enterprise and Community editions. The following table summarizes the required sections for each edition:
+The structure of the `secrets.toml` file is the main configuration difference between BloodHound Enterprise and BloodHound Community editions. The following table summarizes the required sections for each edition:
 
 | `secrets.toml` section | Enterprise | Community |
 |---|---|---|
 | `[destination.bloodhoundenterprise]` | Required. Authenticates the collector client that uploads data to your tenant. | Omit. Community writes OpenGraph files to the local filesystem instead of a BloodHound Enterprise destination. |
 | `[sources.source.<collector>.credentials]` | Required. Authenticates to the source system. | Required. Authenticates to the source system. |
 
-Because Community collection has no BloodHound Enterprise destination, the `collect`, `preprocess`, and `convert` commands read and write local files, so the secrets file only needs the collector's source credentials.
+<Tabs>
+  <Tab title="Community">
+  Because Community collection has no BloodHound Enterprise destination, the `collect`, `preprocess`, and `convert` commands read and write local files, so the secrets file only needs the collector's source credentials.
 
-<CodeGroup>
-```toml title="Community ~/.dlt/secrets_github.toml"
-[sources.source.github.credentials]
-# GitHub collector credentials for your authentication method.
-```
+  ```toml title="Community ~/.dlt/secrets_github.toml"
+  [sources.source.github.credentials]
+  # GitHub collector credentials for your authentication method.
+  ```
+  </Tab>
 
-```toml title="Enterprise ~/.dlt/secrets_github.toml"
-[destination.bloodhoundenterprise]
-token_id = "client_token_id"
-token_key = "client_token_key"
+  <Tab title="Enterprise">
+  BloodHound Enterprise requires the `destination.bloodhoundenterprise` section to authenticate the collector client that uploads data to your tenant. Each collector also needs its own source credentials section.
 
-[sources.source.github.credentials]
-# GitHub collector credentials for your authentication method.
-```
-</CodeGroup>
+  ```toml title="Enterprise ~/.dlt/secrets_github.toml"
+  [destination.bloodhoundenterprise]
+  token_id = "client_token_id"
+  token_key = "client_token_key"
+
+  [sources.source.github.credentials]
+  # GitHub collector credentials for your authentication method.
+  ```
+
+  OpenHound supports the following environment variables for the `destination.bloodhoundenterprise` section:
+
+  | Destination Option | Environment Variable | Description |
+  |---|---|---|
+  | `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
+  | `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
+  </Tab>
+</Tabs>
 
 ### Collector-specific secrets
 
 <CollectorSpecificConfig />
-
-## BloodHound Enterprise settings
-
-<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "20%" }}/>
-
-Add your BloodHound Enterprise tenant URL to the shared `config.toml` file. This value is non-sensitive, so keep it out of the `secrets.toml` files. The URL is required for scheduled collection and is used by the OpenHound CLI commands that upload extension assets (saved queries, Privilege Zone rules, etc.) to your tenant:
-
-```toml title="~/.dlt/config.toml"
-[destination.bloodhoundenterprise]
-url = "https://your-tenant.bloodhoundenterprise.io"
-```
-
-<Note>
-  For production environments, use environment variables or your container platform's secret management features when local secret files do not meet your organization's credential handling requirements.
-</Note>
-
-The `destination.bloodhoundenterprise` settings apply to BloodHound Enterprise scheduled collection only. They authenticate each collector container to your tenant. Community Edition and standalone CLI runs omit this section.
-
-Each collector-specific secrets file must include a `[destination.bloodhoundenterprise]` section with the `token_id` and `token_key` generated for that collector's client in BloodHound Enterprise.
-
-The scheduler also needs `collector_name` to know which collector to run. The example Docker Compose files set this per service with the `DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME` environment variable, so the shipped secrets files omit it. You can also set it in `config.toml` or the secrets file.
-
-```toml title="~/.dlt/secrets_github.toml"
-[destination.bloodhoundenterprise]
-token_id = "client_token_id"
-token_key = "client_token_key"
-
-[sources.source.github.credentials]
-# Add the GitHub collector credentials for your authentication method.
-```
-
-<Warning>
-  Do not confuse `destination.bloodhoundenterprise` with `destination.bloodhound`. The `destination.bloodhound` section uses a browser JWT (`url` and `token`) and applies only to the OpenHound CLI commands that [upload extension assets](/openhound/upload-extension-assets), such as saved queries and Privilege Zone rules. It is not used for scheduled collection.
-</Warning>
-
-| Destination Option | Environment Variable | Description |
-|---|---|---|
-| `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. Store this non-sensitive value in `config.toml`. |
-| `token_key` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_KEY | The API token key generated for the matching OpenHound collector client. |
-| `token_id` | DESTINATION__BLOODHOUNDENTERPRISE__TOKEN_ID | The API token ID generated for the matching OpenHound collector client. |
-| `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required when running the scheduler (Docker Compose or Helm). Must match the extension being run, such as `okta`, `jamf`, or `github`. |
 
 ## Runtime settings
 

--- a/docs/openhound/configuration.mdx
+++ b/docs/openhound/configuration.mdx
@@ -87,7 +87,7 @@ The following example configuration sets global values for runtime, normalize, a
   | Destination Option | Environment Variable | Description |
   |---|---|---|
   | `url` | DESTINATION__BLOODHOUNDENTERPRISE__URL | The URL of the BloodHound Enterprise tenant. Store this non-sensitive value in `config.toml`. |
-  | `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required when running the scheduler (Docker Compose or Helm). Must match the extension being run, such as `okta`, `jamf`, or `github`. |
+  | `collector_name` | DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME | Required for scheduled collection. Identifies the extension this scheduler runs, such as `github`, `jamf`, or `okta`. |
   </Tab>
   <Tab title="Community">
   The following example is nearly identical to the Enterprise example, except that it omits the `destination.bloodhoundenterprise` section.
@@ -127,6 +127,11 @@ The following example configuration sets global values for runtime, normalize, a
   ```
   </Tab>
 </Tabs>
+<Note>
+  Each OpenHound scheduler runs one collector, so scheduled collection needs one `collector_name` value per scheduler container.
+
+  The example Docker Compose services set this value for you when you start a service such as `scheduler-github`. Helm and other container deployments must provide the value manually through chart values, environment variables, or the `[destination.bloodhoundenterprise]` section.
+</Note>
 <Tip>
   See [Runtime settings](/openhound/configuration#runtime-settings) for the full list of common runtime settings.
 </Tip>

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy with Docker Compose
-sidebarTitle: Deploy with Docker
+sidebarTitle: Deploy with Compose
 description: Deploy OpenHound for BloodHound Enterprise with Docker Compose.
 ---
 
@@ -161,6 +161,8 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     cd ~/openhound
     docker compose up -d scheduler-github
     ```
+
+    The example Compose file sets `DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME` inside each scheduler service. For example, `scheduler-github` sets the collector name to `github`.
 
     To run another extension, configure its secrets file and start the matching service, such as `scheduler-jamf` or `scheduler-okta`.
 

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -106,12 +106,12 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     </Tip>
   </Step>
 
-  <Step title="Create the extension-specific secrets file">
-    Create one secrets file for each extension you want to run.
-    
+  <Step title="Create the collector-specific secrets file">
+    Create one secrets file for each collector you want to run.
+
     The example Compose file uses [collector-specific](/openhound/configuration#collector-specific-settings) files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
 
-    | Extension | Host secrets file | Container secrets file |
+    | Collector | Host secrets file | Container secrets file |
     |---|---|---|
     | GitHub | `~/.dlt/secrets_github.toml` | `/app/.dlt/secrets.toml` |
     | Jamf | `~/.dlt/secrets_jamf.toml` | `/app/.dlt/secrets.toml` |
@@ -144,8 +144,8 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     </Note>
   </Step>
 
-  <Step title="Add extension secret files">
-    Some extensions require an additional secret file.
+  <Step title="Add collector secret files">
+    Some collectors require an additional secret file.
     
     For example, the GitHub App authentication method requires you to copy the GitHub App private key to the path referenced by the Compose file:
 

--- a/docs/openhound/deploy-with-compose.mdx
+++ b/docs/openhound/deploy-with-compose.mdx
@@ -109,7 +109,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
   <Step title="Create the collector-specific secrets file">
     Create one secrets file for each collector you want to run.
 
-    The example Compose file uses [collector-specific](/openhound/configuration#collector-specific-settings) files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
+    The example Compose file uses [collector-specific](/openhound/configuration#collector-specific-secrets) secrets files on the host and maps the matching file into the container as `/app/.dlt/secrets.toml`.
 
     | Collector | Host secrets file | Container secrets file |
     |---|---|---|
@@ -117,9 +117,9 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
     | Jamf | `~/.dlt/secrets_jamf.toml` | `/app/.dlt/secrets.toml` |
     | Okta | `~/.dlt/secrets_okta.toml` | `/app/.dlt/secrets.toml` |
 
-    Each extension secrets file must include:
+    Each collector-specific secrets file must include:
 
-    - `[destination.bloodhoundenterprise]` with the `token_id` and `token_key` for the matching OpenHound collector client
+    - `[destination.bloodhoundenterprise]` with the `token_id` and `token_key` for the matching OpenHound collector client in BloodHound Enterprise
     - The collector-specific credentials section, such as `[sources.source.github.credentials]`, `[sources.source.jamf.credentials]`, or `[sources.source.okta.credentials]`
 
       The following GitHub example uses an organization GitHub App.
@@ -138,7 +138,7 @@ Follow these steps to deploy OpenHound with Docker Compose and run a collector f
       ```
 
     <Note>
-      The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Store the destination URL in `config.toml` and store `token_id` and `token_key` in the extension secrets file.
+      The scheduler uses `destination.bloodhoundenterprise` with collector client credentials. Store the destination URL in `config.toml` and store `token_id` and `token_key` in the collector's secrets file.
 
       Do not use the JWT-based `destination.bloodhound` settings from [Upload Extension Assets](/openhound/upload-extension-assets) for scheduled collection.
     </Note>

--- a/docs/openhound/deploy-with-kubernetes.mdx
+++ b/docs/openhound/deploy-with-kubernetes.mdx
@@ -59,7 +59,16 @@ kubectl create -n openhound secret generic okta-client-secret \
 
 ## Installation
 
-Create a `values.yaml` file with your collector configuration using [values.example.yaml](https://raw.githubusercontent.com/SpecterOps/OpenHound/refs/heads/main/deployments/helm/values.example.yaml) as a reference and install the chart using:
+Create a `values.yaml` file with your collector configuration using [values.example.yaml](https://raw.githubusercontent.com/SpecterOps/OpenHound/refs/heads/main/deployments/helm/values.example.yaml) as a reference.
+
+Set `collector.name` to the collector this Helm release runs. This value becomes `DESTINATION__BLOODHOUNDENTERPRISE__COLLECTOR_NAME` in the OpenHound scheduler container.
+
+```yaml
+collector:
+  name: github
+```
+
+Then install the chart:
 
 ```bash
 helm install -f values.yaml -n openhound openhound-[name] [openhound_path]/deployments/helm/openhound


### PR DESCRIPTION
## Summary

This pull request (PR) was originally inspired by customer feedback about an incorrectly documented environment variable in one of our [Okta configuration options](https://bloodhound.specterops.io/openhound/collectors/okta/collect-data#option-2-service-application-with-base64-encoded-json-key-string).

However, as I was making my way through the edits I realized that there was quite a bit of duplication on the [main OpenHound configuration](https://bloodhound.specterops.io/openhound/configuration) page re: shared config vs Enterprise-only config.

This PR attempts to solve both issues.

## Staging

We no longer have access to staging builds on Mintlify 😒

But you can [build the site locally](https://www.mintlify.com/docs/cli/preview) to preview the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized configuration guidance to separate general settings, secrets, and collector key files.
  * Added Enterprise and Community configuration examples, runtime settings, and environment-variable mappings.
  * Updated Docker Compose instructions for collector-specific secrets, scheduling, and host-to-container file mappings.
  * Clarified Kubernetes deployment steps, collector naming, and verification instructions.
  * Corrected the Okta private-key setting name to `private_key_b64` and its corresponding environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->