### PR TITLE
docs: add GoLinHound to the OpenGraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -433,6 +433,21 @@ ClusterHound brings Kubernetes into BloodHound CE. It collects a cluster's topol
 - https://github.com/dovesec/ClusterHound
 
 </Accordion>
+<Accordion title="Linux" icon="people-group">
+
+#### <Icon icon="people-group" size={22}/> GoLinHound
+
+**Description**
+
+GoLinHound is a BloodHound collector written in Go that discovers Linux and SSH attack paths. GoLinHound models local privilege escalation, SSH key and certificate authentication, agent forwarding, and paths connecting Linux hosts to Entra ID and Active Directory identities.
+
+**Authors/Maintainers**
+- [Lukas Klein](https://www.linkedin.com/in/klein-lukas/)
+
+**Repo**
+- https://github.com/RantaSec/golinhound
+
+</Accordion>
 <Accordion title="Microsoft Exchange" icon="people-group">
 
 #### <Icon icon="people-group" size={22}/> ExchangeHound


### PR DESCRIPTION
- Add a Linux category to the BloodHound Community Extensions library
- Add GoLinHound OG extension under the Linux category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GoLinHound to the OpenGraph Library’s Linux resources.
  * Documented support for Linux and SSH attack-path collection, including privilege escalation, authentication, agent forwarding, and identity paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->