### PR TITLE
DOCS-28: "ref" no longer a reserved property

### DIFF
--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -136,10 +136,6 @@ During ingest, BloodHound maps this `id` value internally to `objectid`. If you 
   Do not include `objectid` inside `properties`. Use only the root-level `id` field.
 </Warning>
 
-### `ref`
-
-The property name `ref` is reserved and **must not** be included in the `properties` object of a node definition.
-
 ## Findings and metrics
 
 <img


### PR DESCRIPTION
## Summary

In v9.5.1, using a `ref` property in an OpenGraph data payload would cause BloodHound to crash.

While waiting for a fix, we updated the docs to describe `ref` as a "reserved property" that shouldn't be used: https://github.com/SpecterOps/bloodhound-docs/pull/366.

Now that the fix (BED-9076) has been merged and queued for v9.6.0, we should revert the doc update.