### PR TITLE
DOCS-31: OpenGraph feature flag maintenance

### DIFF
--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -21,7 +21,7 @@ An extension definition schema tells BloodHound how to interpret, interact with,
 An extension definition schema is a JSON file that OpenGraph extension developers provide for BloodHound users to install on the [OpenGraph Management](/opengraph/extensions/manage) page before they upload data payloads that conform to the schema.
 
 <Note>
-  In BloodHound Enterprise v9.3.0 and later, supported platform extensions (GitHub, Jamf, and Okta) are pre-installed. Other SpecterOps-supported schemas, such as SCIM, must still be uploaded manually.
+  In BloodHound Enterprise, supported platform extensions (GitHub, Jamf, and Okta) are pre-installed. Other SpecterOps-supported schemas, such as SCIM, must still be uploaded manually.
 </Note>
 
 This page describes the components of an extension definition schema. For a full example of how these components work together, see the [example schema](/opengraph/developer/graph-definition#example-schema) section at the end of the page.

--- a/docs/opengraph/extensions/github/overview.mdx
+++ b/docs/opengraph/extensions/github/overview.mdx
@@ -9,7 +9,7 @@ The GitHub extension is an OpenGraph extension for [GitHub](https://github.com/)
 
 It adds GitHub-specific [nodes](/opengraph/extensions/github/schema#nodes), [edges](/opengraph/extensions/github/schema#edges), [Cypher queries](/opengraph/extensions/github/queries), and [Privilege Zone rules](/opengraph/extensions/github/privilege-zone-rules) to help security professionals visualize and analyze their GitHub configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, GitHub is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, GitHub is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 ## GitHub Attack Paths
 

--- a/docs/opengraph/extensions/jamf/overview.mdx
+++ b/docs/opengraph/extensions/jamf/overview.mdx
@@ -9,7 +9,7 @@ The Jamf extension is an OpenGraph extension for [Jamf Pro](https://www.jamf.com
 
 It adds Jamf-specific [nodes](/opengraph/extensions/jamf/schema#nodes), [edges](/opengraph/extensions/jamf/schema#edges), [Cypher queries](/opengraph/extensions/jamf/queries), and [Privilege Zone rules](/opengraph/extensions/jamf/privilege-zone-rules) to help security professionals visualize and analyze Jamf Pro configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, Jamf is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, Jamf is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 <Note>The other main products in Jamf's portfolio are [Jamf Protect](https://www.jamf.com/products/jamf-protect/), [Jamf Account](https://learn.jamf.com/en-US/bundle/jamf-account-documentation/page/Jamf_Account_Documentation.html), [Jamf Now](https://www.jamf.com/products/jamf-now/), and [Jamf Connect](https://www.jamf.com/products/jamf-connect/). The Jamf extension does not currently support these products.</Note>
 

--- a/docs/opengraph/extensions/manage.mdx
+++ b/docs/opengraph/extensions/manage.mdx
@@ -51,7 +51,7 @@ BloodHound uses several extension management models. Understanding the distincti
 | Extension type | Examples | Management behavior |
 |---|---|---|
 | **Built-in** | Active Directory, Azure | Included in BloodHound and BloodHound Enterprise. Administrators cannot delete these extensions. |
-| **Pre-installed** | GitHub, Jamf, Okta | Included in BloodHound Enterprise v9.3.0 and later. Administrators can verify, update, or delete them, but BloodHound Enterprise reapplies the latest versions at startup according to [automatic update rules](/opengraph/extensions/manage#automatic-updates). |
+| **Pre-installed** | GitHub, Jamf, Okta | Included in BloodHound Enterprise. Administrators can verify, update, or delete them, but BloodHound Enterprise reapplies the latest versions at startup according to [automatic update rules](/opengraph/extensions/manage#automatic-updates). |
 | **Manually managed** | SCIM, custom, and community-built extensions | Administrators must upload and maintain these extensions manually. |
 
 ## Before you begin
@@ -63,29 +63,19 @@ Complete the following steps before you verify or install an extension and uploa
 </Note>
 
 <Steps>
-	<Step title="Confirm OpenGraph Extension Management availability">
-		The OpenGraph Extension Management feature must be enabled before you can manage extensions.
-		
-		Enable this feature on the **Administration** > **Early Access Features** page.
+	<Step title="Get extension artifacts">
+		How you obtain extensions and collectors depends on your BloodHound edition and how they are distributed:
 
-		<Note>
-    	  Support for extension-defined **Findings** in BloodHound Enterprise is a SpecterOps-managed feature. If it is not enabled in your environment, contact your account team for assistance.
-  		</Note>
+		- **BloodHound Community**: Users can download and use [publicly available](/opengraph/library) community-built extensions and collectors from GitHub repositories.
+
+		- **BloodHound Enterprise**: GitHub, Jamf, and Okta are supported as pre-installed extensions. Use the **OpenGraph Management** page to verify the installed version. You can still manually upload publicly available, companion, or custom extensions as needed.
+
+			If you need a newer version of a pre-installed extension outside the standard BloodHound Enterprise release cycle, coordinate with your account team.
+
+			<Note>
+			Pre-installed extensions can include detailed findings and remediation guidance when that feature is enabled in your environment. Contact your account team for availability.
+			</Note>
 	</Step>
-		<Step title="Get extension artifacts">
-			How you obtain extensions and collectors depends on your BloodHound edition and how they are distributed:
-
-
-			- **BloodHound Community**: Users can download and use [publicly available](/opengraph/library) community-built extensions and collectors from GitHub repositories.
-
-			- **BloodHound Enterprise**: In v9.3.0 and later, GitHub, Jamf, and Okta are supported as pre-installed extensions. Use the **OpenGraph Management** page to verify the installed version. You can still manually upload publicly available, companion, or custom extensions as needed.
-
-			  If you need a newer version of a pre-installed extension outside the standard BloodHound Enterprise release cycle, coordinate with your account team.
-
-			  <Note>
-			    Pre-installed extensions can include detailed findings and remediation guidance when that feature is enabled in your environment. Contact your account team for availability.
-			  </Note>
-		</Step>
 	<Step title="Review prerequisites">
 		After you obtain an extension and collector, review the prerequisites in the extension-specific setup documentation.
 		
@@ -197,7 +187,7 @@ sequenceDiagram
 
 Before you upload structured OpenGraph data, make sure BloodHound has the matching extension definition schema.
 
-In BloodHound Enterprise v9.3.0 and later, GitHub, Jamf, and Okta are supported as pre-installed extensions and usually only need verification. Administrators still manage custom or companion extension definition schemas, such as SCIM, manually.
+In BloodHound Enterprise, GitHub, Jamf, and Okta are supported as pre-installed extensions and usually only need verification. Administrators still manage custom or companion extension definition schemas, such as SCIM, manually.
 
 In BloodHound Community, Administrators manage all extension definition schemas manually.
 
@@ -266,7 +256,7 @@ To update an extension, upload the new version using the same process as install
 
 ### Automatic updates
 
-In BloodHound Enterprise v9.3.0 and later, the pre-installed GitHub, Jamf, and Okta extensions follow automatic update rules.
+In BloodHound Enterprise, the pre-installed GitHub, Jamf, and Okta extensions follow automatic update rules.
 
 At application startup, BloodHound Enterprise compares each pre-installed extension with the embedded version included in the current release and keeps whichever version is newer:
 

--- a/docs/opengraph/extensions/okta/overview.mdx
+++ b/docs/opengraph/extensions/okta/overview.mdx
@@ -9,7 +9,7 @@ The Okta extension is an OpenGraph extension for [Okta Platform](https://www.okt
 
 It adds Okta-specific [nodes](/opengraph/extensions/okta/schema#nodes), [edges](/opengraph/extensions/okta/schema#edges), [Cypher queries](/opengraph/extensions/okta/queries), and [Privilege Zone rules](/opengraph/extensions/okta/privilege-zone-rules) to help security professionals visualize and analyze Okta configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, Okta is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, Okta is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 <Note>The other main product in Okta's portfolio is [Auth0](https://auth0.com/) (previously known as Customer Identity Cloud). The Okta extension does not currently support Auth0.</Note>
 

--- a/docs/opengraph/extensions/scim/overview.mdx
+++ b/docs/opengraph/extensions/scim/overview.mdx
@@ -33,7 +33,7 @@ The key edge that ties SCIM to other extensions is **SCIM_Provisioned**, which c
 
 1. Upload the SCIM schema to your BloodHound instance alongside the extension schemas for the collectors you are using (for example, Okta or GitHub).
 
-   In BloodHound Enterprise v9.3.0 and later, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Verify that these are installed before you upload the SCIM companion schema.
+   In BloodHound Enterprise, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Verify that these are installed before you upload the SCIM companion schema.
 
 1. Run the relevant collectors — they will produce SCIM nodes and edges automatically.
 

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -10,7 +10,7 @@ OpenHound extensions include saved queries and Privilege Zone rules that help yo
 Use the OpenHound CLI to upload these assets after the matching extension definition schema is installed or verified in BloodHound.
 
 <Note>
-  In BloodHound Enterprise v9.3.0 and later, the GitHub, Jamf, and Okta extension schemas are pre-installed. Saved queries and Privilege Zone rules are still managed separately.
+  In BloodHound Enterprise, the GitHub, Jamf, and Okta extension schemas are pre-installed. Saved queries and Privilege Zone rules are still managed separately.
 </Note>
 
 ## Prerequisites

--- a/docs/snippets/opengraph/extensions/optional-schemas.mdx
+++ b/docs/snippets/opengraph/extensions/optional-schemas.mdx
@@ -1,3 +1,3 @@
 If {source} is connected to other BloodHound-supported data sources in your environment, such as {otherSources}, make sure the corresponding schema is installed too.
 
-In BloodHound Enterprise v9.3.0 and later, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Upload any companion schemas that are not already installed. Doing so ensures those cross-platform relationships are modeled correctly in BloodHound.
+In BloodHound Enterprise, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Upload any companion schemas that are not already installed. Doing so ensures those cross-platform relationships are modeled correctly in BloodHound.


### PR DESCRIPTION
## Summary

In v9.6.0, the OpenGraph Extension Management feature flag is enabled by default. That makes the step to enable it obsolete, so we should remove it. We'll communicate the change in the release notes.

I also removed references to the specific version of BloodHound Enterprise when we started shipping pre-installed extensions. I can't remember why I thought that would be useful, but it's not necessary.