### PR TITLE
DOCS-27: Collector support bundles

### DIFF
--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -1,0 +1,113 @@
+---
+title: Manage Collector Support Bundles
+description: "Request, download, and delete SharpHound Enterprise support bundles in BloodHound Enterprise."
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
+
+A collector support bundle is a ZIP file that contains diagnostic information from a collector client. Use a support bundle when you need to troubleshoot a SharpHound Enterprise collector without signing in to the system where the collector runs.
+
+You can request a support bundle from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
+
+<Warning>
+Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
+</Warning>
+
+## Requirements
+
+- BloodHound Enterprise with the collector support bundle feature enabled.
+- A SharpHound Enterprise collector client that appears on the **Manage Clients** page.
+- A user assigned the **Administrator** role. The support-bundle controls require permission to manage users and access client-management actions.
+- Environment access to the client. If Environment Targeted Access Control (ETAC) restricts your access to the client's environment, BloodHound blocks support-bundle actions for that client.
+
+<Note>
+Support bundles are currently available for SharpHound Enterprise clients. AzureHound Enterprise and OpenHound clients do not show support-bundle actions.
+</Note>
+
+## Support bundle lifecycle
+
+| State | What you see | What to do |
+| --- | --- | --- |
+| No bundle exists | **Request Support Bundle** | Request a bundle when you need collector diagnostics. |
+| Request in progress | **Requesting Support Bundle...** | Wait for the collector to process the request. |
+| Bundle is ready | **Download Support Bundle** and **Delete Support Bundle** | Download the bundle or delete it when it is no longer needed. |
+| Request failed or was canceled | **Request Support Bundle** | Request a new bundle, or contact support if the request fails again. |
+
+BloodHound allows one downloadable support bundle per client. To request a more recent bundle after one is available, delete the existing bundle first.
+
+Uploaded support bundles expire 90 days after the upload session is created. Deleting a bundle removes it sooner. Downloaded copies are outside BloodHound retention after they leave the application.
+
+## Request a support bundle
+
+<Steps>
+  <Step title="Open the Manage Clients page">
+    In the left menu, click **Administration** > **Manage Clients**.
+  </Step>
+
+  <Step title="Open the client action menu">
+    Find the SharpHound Enterprise client you want to troubleshoot, then click the action menu in that client's row.
+  </Step>
+
+  <Step title="Request the bundle">
+    Click **Request Support Bundle**.
+  </Step>
+
+  <Step title="Confirm the request">
+    BloodHound displays **Support bundle requested successfully.** The action menu changes to **Requesting Support Bundle...** while the collector processes the request.
+  </Step>
+</Steps>
+
+The request is asynchronous. BloodHound checks for completion in the background and displays a notification when the request succeeds, fails, or is canceled. You can also reopen the client action menu and check whether **Download Support Bundle** appears.
+
+## Download a support bundle
+
+<Steps>
+  <Step title="Open the client action menu">
+    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise client.
+  </Step>
+
+  <Step title="Download the bundle">
+    Click **Download Support Bundle**.
+  </Step>
+
+  <Step title="Save the ZIP file">
+    Your browser downloads the bundle as a `.zip` file. The filename includes the client name, support-bundle type, and upload timestamp.
+  </Step>
+</Steps>
+
+BloodHound displays **Support bundle downloaded successfully.** after the download starts successfully. Provide the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
+
+## Delete a support bundle
+
+Delete a support bundle when you no longer need it or when you need to request a newer bundle for the same client.
+
+<Steps>
+  <Step title="Open the client action menu">
+    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise client.
+  </Step>
+
+  <Step title="Start deletion">
+    Click **Delete Support Bundle**.
+  </Step>
+
+  <Step title="Confirm deletion">
+    In the **Delete Support Bundle** confirmation dialog, confirm that you want to delete the bundle.
+  </Step>
+</Steps>
+
+BloodHound displays **Support bundle deleted successfully.** after deletion completes. The client action menu returns to **Request Support Bundle** after the client table refreshes.
+
+## Troubleshoot support bundles
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| **Request Support Bundle** is missing. | The feature is not enabled, the client is not SharpHound Enterprise, or your role cannot use support-bundle controls. | Confirm that the client type is **SharpHound Enterprise** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant. |
+| The action menu is missing. | Your role can read clients but cannot manage client actions. | Ask an administrator to assign a role with client-management permissions or request the bundle for you. |
+| The request fails immediately. | BloodHound cannot queue the request because of permissions, feature availability, client visibility, or a temporary service error. | Retry once. If it fails again, record the client name, request time, and error text. |
+| **Requesting Support Bundle...** stays visible. | The collector has not picked up the request, is offline, or has not finished uploading the bundle. | Confirm the client status on **Manage Clients**. If the client is **Disconnected** or **Delayed**, troubleshoot collector connectivity before retrying. |
+| BloodHound says the bundle does not exist. | The request completed without an uploaded artifact. | Request a new bundle. If the problem repeats, contact support with the client name, collector version, and request time. |
+| The request failed or was canceled. | The collector or server ended the support-bundle operation before a downloadable file was available. | Request a new bundle. If the second request fails, collect the visible notification text and contact support. |
+| Download fails. | The browser, network path, permissions, or stored artifact is unavailable. | Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error. |
+| You need a newer bundle. | BloodHound keeps one downloadable support bundle per client. | Delete the existing support bundle, then request a new one. |
+
+When you contact support, include the tenant name, client name, collector type and version, request time, visible status or notification text, and whether you or a SpecterOps TAM requested the bundle. Do not include secrets, tokens, or unrelated customer data in the support request.

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -10,19 +10,23 @@ A collector support bundle is a ZIP file that contains diagnostic information fr
 You can request a support bundle from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
 
 <Warning>
-Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
+  Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
 </Warning>
 
-## Requirements
+If you contact SpecterOps support, include the tenant name, client name, collector type and version, request time, visible status or notification text, and whether you or a SpecterOps representative requested the bundle. Do not include secrets, tokens, or unrelated data in the support request.
+
+## Prerequisites
+
+Before you can request, download, or delete a support bundle, you must have the following:
 
 - BloodHound Enterprise with the collector support bundle feature enabled.
 - A SharpHound Enterprise collector client that appears on the **Manage Clients** page.
 - A user assigned the **Administrator** role. The support-bundle controls require permission to manage users and access client-management actions.
-- Environment access to the client. If Environment Targeted Access Control (ETAC) restricts your access to the client's environment, BloodHound blocks support-bundle actions for that client.
+- Environment access to the client. If [Environment Targeted Access Control (ETAC)](/manage-bloodhound/auth/environment-targeted-access-control) restricts your access to the client's environment, BloodHound Enterprise blocks support-bundle actions for that client.
 
-<Note>
-Support bundles are currently available for SharpHound Enterprise clients. AzureHound Enterprise and OpenHound clients do not show support-bundle actions.
-</Note>
+  <Note>
+    Support bundles are currently available for SharpHound Enterprise clients. AzureHound Enterprise and OpenHound clients do not show support-bundle actions.
+  </Note>
 
 ## Support bundle lifecycle
 
@@ -33,11 +37,13 @@ Support bundles are currently available for SharpHound Enterprise clients. Azure
 | Bundle is ready | **Download Support Bundle** and **Delete Support Bundle** | Download the bundle or delete it when it is no longer needed. |
 | Request failed or was canceled | **Request Support Bundle** | Request a new bundle, or contact support if the request fails again. |
 
-BloodHound allows one downloadable support bundle per client. To request a more recent bundle after one is available, delete the existing bundle first.
+BloodHound Enterprise allows one downloadable support bundle per client. To request a more recent bundle after one is available, delete the existing bundle first.
 
-Uploaded support bundles expire 90 days after the upload session is created. Deleting a bundle removes it sooner. Downloaded copies are outside BloodHound retention after they leave the application.
+Uploaded support bundles expire 90 days after the upload session is created. Deleting a bundle removes it sooner. Downloaded copies are outside the scope of BloodHound Enterprise retention.
 
 ## Request a support bundle
+
+To request a support bundle, you must have the **Administrator** role and access to the collector's environment. The request is asynchronous. BloodHound Enterprise checks for completion in the background and displays a notification when the request succeeds, fails, or is canceled.
 
 <Steps>
   <Step title="Open the Manage Clients page">
@@ -53,13 +59,15 @@ Uploaded support bundles expire 90 days after the upload session is created. Del
   </Step>
 
   <Step title="Confirm the request">
-    BloodHound displays **Support bundle requested successfully.** The action menu changes to **Requesting Support Bundle...** while the collector processes the request.
+    The action menu changes to **Requesting Support Bundle...** while the collector processes the request.
+
+    BloodHound Enterprise displays **Support bundle requested successfully** when the request is queued. If the request fails, BloodHound Enterprise displays an error notification with a reason for the failure.
   </Step>
 </Steps>
 
-The request is asynchronous. BloodHound checks for completion in the background and displays a notification when the request succeeds, fails, or is canceled. You can also reopen the client action menu and check whether **Download Support Bundle** appears.
-
 ## Download a support bundle
+
+BloodHound Enterprise displays **Support bundle downloaded successfully** after the download starts successfully. Provide the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
 
 <Steps>
   <Step title="Open the client action menu">
@@ -74,8 +82,6 @@ The request is asynchronous. BloodHound checks for completion in the background 
     Your browser downloads the bundle as a `.zip` file. The filename includes the client name, support-bundle type, and upload timestamp.
   </Step>
 </Steps>
-
-BloodHound displays **Support bundle downloaded successfully.** after the download starts successfully. Provide the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
 
 ## Delete a support bundle
 
@@ -92,10 +98,10 @@ Delete a support bundle when you no longer need it or when you need to request a
 
   <Step title="Confirm deletion">
     In the **Delete Support Bundle** confirmation dialog, confirm that you want to delete the bundle.
+
+    BloodHound Enterprise displays **Support bundle deleted successfully** after deletion completes. The client action menu returns to **Request Support Bundle** after the client table refreshes.
   </Step>
 </Steps>
-
-BloodHound displays **Support bundle deleted successfully.** after deletion completes. The client action menu returns to **Request Support Bundle** after the client table refreshes.
 
 ## Troubleshoot support bundles
 
@@ -109,5 +115,3 @@ BloodHound displays **Support bundle deleted successfully.** after deletion comp
 | The request failed or was canceled. | The collector or server ended the support-bundle operation before a downloadable file was available. | Request a new bundle. If the second request fails, collect the visible notification text and contact support. |
 | Download fails. | The browser, network path, permissions, or stored artifact is unavailable. | Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error. |
 | You need a newer bundle. | BloodHound keeps one downloadable support bundle per client. | Delete the existing support bundle, then request a new one. |
-
-When you contact support, include the tenant name, client name, collector type and version, request time, visible status or notification text, and whether you or a SpecterOps TAM requested the bundle. Do not include secrets, tokens, or unrelated customer data in the support request.

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -13,8 +13,6 @@ You can request a support bundle from **Administration** > **Manage Clients**. A
   Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
 </Warning>
 
-If you contact SpecterOps support, include the tenant name, client name, collector type and version, request time, visible status or notification text, and whether you or a SpecterOps representative requested the bundle. Do not include secrets, tokens, or unrelated data in the support request.
-
 ## Prerequisites
 
 Before you can request, download, or delete a support bundle, you must have the following:
@@ -30,6 +28,8 @@ Before you can request, download, or delete a support bundle, you must have the 
 
 ## Support bundle lifecycle
 
+Refer to the following table for the support-bundle lifecycle and what you can do at each stage:
+
 | State | What you see | What to do |
 | --- | --- | --- |
 | No bundle exists | **Request Support Bundle** | Request a bundle when you need collector diagnostics. |
@@ -37,13 +37,15 @@ Before you can request, download, or delete a support bundle, you must have the 
 | Bundle is ready | **Download Support Bundle** and **Delete Support Bundle** | Download the bundle or delete it when it is no longer needed. |
 | Request failed or was canceled | **Request Support Bundle** | Request a new bundle, or contact support if the request fails again. |
 
-BloodHound Enterprise allows one downloadable support bundle per client. To request a more recent bundle after one is available, delete the existing bundle first.
-
 Uploaded support bundles expire 90 days after the upload session is created. Deleting a bundle removes it sooner. Downloaded copies are outside the scope of BloodHound Enterprise retention.
+
+<Note>
+  BloodHound Enterprise allows one downloadable support bundle per client. To request a more recent bundle after one is available, delete the existing bundle first.
+</Note>
 
 ## Request a support bundle
 
-To request a support bundle, you must have the **Administrator** role and access to the collector's environment. The request is asynchronous. BloodHound Enterprise checks for completion in the background and displays a notification when the request succeeds, fails, or is canceled.
+To request a support bundle, you must have the **Administrator** role and access to the collector's environment. The request is asynchronous. BloodHound Enterprise checks for completion in the background and displays status notifications.
 
 <Steps>
   <Step title="Open the Manage Clients page">
@@ -56,18 +58,18 @@ To request a support bundle, you must have the **Administrator** role and access
 
   <Step title="Request the bundle">
     Click **Request Support Bundle**.
+
+    The action menu changes to **Requesting Support Bundle...** while the collector processes the request.
   </Step>
 
   <Step title="Confirm the request">
-    The action menu changes to **Requesting Support Bundle...** while the collector processes the request.
-
     BloodHound Enterprise displays **Support bundle requested successfully** when the request is queued. If the request fails, BloodHound Enterprise displays an error notification with a reason for the failure.
   </Step>
 </Steps>
 
 ## Download a support bundle
 
-BloodHound Enterprise displays **Support bundle downloaded successfully** after the download starts successfully. Provide the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
+Provide your SpecterOps support representative with the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
 
 <Steps>
   <Step title="Open the client action menu">
@@ -76,6 +78,8 @@ BloodHound Enterprise displays **Support bundle downloaded successfully** after 
 
   <Step title="Download the bundle">
     Click **Download Support Bundle**.
+
+    BloodHound Enterprise displays **Support bundle downloaded successfully** when complete.
   </Step>
 
   <Step title="Save the ZIP file">
@@ -99,19 +103,60 @@ Delete a support bundle when you no longer need it or when you need to request a
   <Step title="Confirm deletion">
     In the **Delete Support Bundle** confirmation dialog, confirm that you want to delete the bundle.
 
-    BloodHound Enterprise displays **Support bundle deleted successfully** after deletion completes. The client action menu returns to **Request Support Bundle** after the client table refreshes.
+    BloodHound Enterprise displays **Support bundle deleted successfully** when complete. The client action menu returns to **Request Support Bundle** after the client table refreshes.
   </Step>
 </Steps>
 
 ## Troubleshoot support bundles
 
-| Symptom | Likely cause | Action |
-| --- | --- | --- |
-| **Request Support Bundle** is missing. | The feature is not enabled, the client is not SharpHound Enterprise, or your role cannot use support-bundle controls. | Confirm that the client type is **SharpHound Enterprise** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant. |
-| The action menu is missing. | Your role can read clients but cannot manage client actions. | Ask an administrator to assign a role with client-management permissions or request the bundle for you. |
-| The request fails immediately. | BloodHound cannot queue the request because of permissions, feature availability, client visibility, or a temporary service error. | Retry once. If it fails again, record the client name, request time, and error text. |
-| **Requesting Support Bundle...** stays visible. | The collector has not picked up the request, is offline, or has not finished uploading the bundle. | Confirm the client status on **Manage Clients**. If the client is **Disconnected** or **Delayed**, troubleshoot collector connectivity before retrying. |
-| BloodHound says the bundle does not exist. | The request completed without an uploaded artifact. | Request a new bundle. If the problem repeats, contact support with the client name, collector version, and request time. |
-| The request failed or was canceled. | The collector or server ended the support-bundle operation before a downloadable file was available. | Request a new bundle. If the second request fails, collect the visible notification text and contact support. |
-| Download fails. | The browser, network path, permissions, or stored artifact is unavailable. | Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error. |
-| You need a newer bundle. | BloodHound keeps one downloadable support bundle per client. | Delete the existing support bundle, then request a new one. |
+Use the following issues to troubleshoot support-bundle requests, downloads, and deletion.
+
+<AccordionGroup>
+  <Accordion title="Request Support Bundle is missing">
+    **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise, or your role cannot use support-bundle controls.
+
+    **Action:** Confirm that the client type is **SharpHound Enterprise** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
+  </Accordion>
+
+  <Accordion title="The action menu is missing">
+    **Likely cause:** Your role can read clients but cannot manage client actions.
+
+    **Action:** Ask an administrator to assign a role with client-management permissions or request the bundle for you.
+  </Accordion>
+
+  <Accordion title="The request fails immediately">
+    **Likely cause:** BloodHound Enterprise cannot queue the request because of permissions, feature availability, client visibility, or a temporary service error.
+
+    **Action:** Retry once. If it fails again, record the client name, request time, and error text.
+  </Accordion>
+
+  <Accordion title="Requesting Support Bundle stays visible">
+    **Likely cause:** The collector has not picked up the request, is offline, or has not finished uploading the bundle.
+
+    **Action:** Confirm the client status on **Manage Clients**. If the client is **Disconnected**, **Delayed**, or **Unconfigured**, troubleshoot collector connectivity before retrying.
+  </Accordion>
+
+  <Accordion title="BloodHound says the bundle does not exist">
+    **Likely cause:** The request completed without an uploaded artifact.
+
+    **Action:** Request a new bundle. If the problem repeats, contact support with the client name, collector version, and request time.
+  </Accordion>
+
+  <Accordion title="The request failed or was canceled">
+    **Likely cause:** The collector or server ended the support-bundle operation before a downloadable file was available.
+
+    **Action:** Request a new bundle. If the second request fails, collect the visible notification text and contact support.
+  </Accordion>
+
+  <Accordion title="Download fails">
+    **Likely cause:** The browser, network path, permissions, or stored artifact is unavailable.
+
+    **Action:** Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error.
+  </Accordion>
+
+  <Accordion title="You need a newer bundle">
+    **Likely cause:** BloodHound keeps one downloadable support bundle per client.
+
+    **Action:** Delete the existing support bundle, then request a new one.
+  </Accordion>
+</AccordionGroup>

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -36,7 +36,7 @@ Before you can request, download, or delete a support bundle, you must have the 
   | **Collector** | **Minimum version** |
   | --- | --- |
   | SharpHound Enterprise | v2.16.0 |
-  | OpenHound | v0.3.2 |
+  | OpenHound | v0.4.0 |
 
   <Note>
     Support bundles are currently available for SharpHound Enterprise and OpenHound clients. AzureHound Enterprise clients are not supported.
@@ -159,7 +159,7 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
   <Accordion title="Request Support Bundle is missing">
     **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise or OpenHound, the collector application is below the minimum supported version, or your role cannot use support-bundle controls.
 
-    **Action:** Confirm that the client type is **SharpHound Enterprise** or **OpenHound**, and that the collector meets the minimum version: SharpHound Enterprise v2.16.0 or later or OpenHound v0.3.2 or later. Also confirm that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
+    **Action:** Confirm that the client type is **SharpHound Enterprise** or **OpenHound**, and that the collector meets the minimum version: SharpHound Enterprise v2.16.0 or later or OpenHound v0.4.0 or later. Also confirm that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
   </Accordion>
 
   <Accordion title="The action menu is missing">

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -30,8 +30,13 @@ Use support bundles when you need to shorten the path from a collector issue to 
 Before you can request, download, or delete a support bundle, you must have the following:
 
 - BloodHound Enterprise with the collector support bundle feature enabled by your account team.
-- A SharpHound Enterprise or OpenHound collector client that appears on the **Manage Clients** page.
 - A user assigned the **Administrator** role. The support-bundle controls require permission to manage users and access client-management actions.
+- A SharpHound Enterprise or OpenHound collector client for one of the following collector versions:
+
+  | **Collector** | **Minimum version** |
+  | --- | --- |
+  | SharpHound Enterprise | v2.16.0 |
+  | OpenHound | v0.3.2 |
 
   <Note>
     Support bundles are currently available for SharpHound Enterprise and OpenHound clients. AzureHound Enterprise clients are not supported.

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -1,17 +1,17 @@
 ---
 title: Manage Collector Support Bundles
-description: "Request, download, and delete SharpHound Enterprise support bundles in BloodHound Enterprise."
+description: Request, download, and delete collector support bundles in BloodHound Enterprise.
 ---
 
 import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
-A collector support bundle is a ZIP file that contains diagnostic information from a collector client. Support bundles help you troubleshoot collection issues faster, reduce the need for direct access to the system where the collector runs, and give your team or SpecterOps support a consistent package of collector logs and diagnostics.
+A **collector support bundle** is a `.zip` file that contains diagnostic information from a <Tooltip tip="A configuration object in your BloodHound Enterprise tenant that links your tenant to a collector application. It stores authentication and configuration details used by the collector application to upload data" cta="Learn more" href="/collect-data/enterprise-collection/create-collector">collector client</Tooltip>. Support bundles help you troubleshoot collection issues faster, reduce the need for direct access to the system where the collector runs, and give your team or SpecterOps support a consistent package of collector logs and diagnostics.
 
 <FeatureFlagNote />
 
-This page explains how to request, download, delete, and troubleshoot SharpHound Enterprise support bundles from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
+This page explains how to request, download, delete, and troubleshoot collector support bundles from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
 
 <Warning>
   Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
@@ -29,12 +29,12 @@ Use support bundles when you need to shorten the path from a collector issue to 
 
 Before you can request, download, or delete a support bundle, you must have the following:
 
-- BloodHound Enterprise with the collector support bundle feature enabled.
-- A SharpHound Enterprise collector client that appears on the **Manage Clients** page.
+- BloodHound Enterprise with the collector support bundle feature enabled by your account team.
+- A SharpHound Enterprise or OpenHound collector client that appears on the **Manage Clients** page.
 - A user assigned the **Administrator** role. The support-bundle controls require permission to manage users and access client-management actions.
 
   <Note>
-    Support bundles are currently available for SharpHound Enterprise clients. AzureHound Enterprise and OpenHound clients do not show support-bundle actions.
+    Support bundles are currently available for SharpHound Enterprise and OpenHound clients. AzureHound Enterprise clients are not supported.
   </Note>
 
 ## Support bundle lifecycle
@@ -64,7 +64,7 @@ To request a support bundle, you must have the **Administrator** role. The reque
   </Step>
 
   <Step title="Open the client action menu">
-    Find the SharpHound Enterprise client you want to troubleshoot, then click the action menu in that client's row.
+    Find the SharpHound Enterprise or OpenHound client you want to troubleshoot, then click the action menu in that client's row.
   </Step>
 
   <Step title="Request the bundle">
@@ -80,11 +80,11 @@ To request a support bundle, you must have the **Administrator** role. The reque
 
 ## Download a support bundle
 
-Provide your SpecterOps support representative with the ZIP file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
+Provide your SpecterOps support representative with the `.zip` file through the approved support workflow, or inspect it locally if you are troubleshooting without SpecterOps support.
 
 <Steps>
   <Step title="Open the client action menu">
-    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise client.
+    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise or OpenHound client.
   </Step>
 
   <Step title="Download the bundle">
@@ -94,23 +94,37 @@ Provide your SpecterOps support representative with the ZIP file through the app
   </Step>
 
   <Step title="Confirm the download">
-    Your browser downloads the bundle as a `.zip` file named `sharphound_enterprise_support_bundle_<timestamp>.zip` with the following files:
+    Your browser downloads the bundle as a `.zip` file. The bundle contents depend on the collector type:
 
-    | **File** | **Description** |
-    | --- | --- |
-    | `log_archive/*.zip` | Archived SharpHound Enterprise logs. These files can include previous service logs, collection job logs, management operation logs, computer status CSVs, and archived collection output files. |
-    | `service.log` | The active SharpHound Enterprise service log. This file records service startup, configuration, API communication, tasking, and operational events. |
-    | `settings.json` | The SharpHound Enterprise service configuration file. This file includes connection, collection, and logging settings used by the collector. |
+    <Tabs>
+      <Tab title="SharpHound Enterprise">
+        The file is named `sharphound_enterprise_support_bundle_<timestamp>.zip` and contains the following files:
 
-    <Note>
-      Support bundles do not include `auth.json` files.
-    </Note>
+        | **File** | **Description** |
+        | --- | --- |
+        | `log_archive/*.zip` | Archived SharpHound Enterprise logs. These files can include previous service logs, collection job logs, management operation logs, computer status CSVs, and archived collection output files. |
+        | `service.log` | The active SharpHound Enterprise service log. This file records service startup, configuration, API communication, tasking, and operational events. |
+        | `settings.json` | The SharpHound Enterprise service configuration file. This file includes connection, collection, and logging settings used by the collector. |
+
+        <Note>
+          SharpHound Enterprise support bundles do not include `auth.json` files.
+        </Note>
+      </Tab>
+
+      <Tab title="OpenHound">
+        The file is named `<client_name>_support_bundle_<timestamp>.zip` and contains the following files:
+
+        | **File** | **Description** |
+        | --- | --- |
+        | `openhound.log` | The current OpenHound platform and service log. |
+        | `openhound.log.*` | Rotated OpenHound platform and service logs. |
+        | `ext_*.log` | Current logs for OpenHound collector extensions and pipeline components. |
+        | `ext_*.log.*` | Rotated logs for OpenHound collector extensions and pipeline components. |
+      </Tab>
+    </Tabs>
+
   </Step>
 </Steps>
-
-<Note>
-  If **Download Support Bundle** is disabled and a tooltip says the file is too large to download, contact SpecterOps support to request the bundle on your behalf.
-</Note>
 
 ## Delete a support bundle
 
@@ -118,7 +132,7 @@ Delete a support bundle when you no longer need it or when you need to request a
 
 <Steps>
   <Step title="Open the client action menu">
-    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise client.
+    In **Administration** > **Manage Clients**, open the action menu for the SharpHound Enterprise or OpenHound client.
   </Step>
 
   <Step title="Start deletion">
@@ -138,9 +152,9 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
 
 <AccordionGroup>
   <Accordion title="Request Support Bundle is missing">
-    **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise, or your role cannot use support-bundle controls.
+    **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise or OpenHound, or your role cannot use support-bundle controls.
 
-    **Action:** Confirm that the client type is **SharpHound Enterprise** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
+    **Action:** Confirm that the client type is **SharpHound Enterprise** or **OpenHound** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
   </Accordion>
 
   <Accordion title="The action menu is missing">
@@ -177,12 +191,6 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
     **Likely cause:** The browser, network path, permissions, or stored artifact is unavailable.
 
     **Action:** Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error.
-  </Accordion>
-
-  <Accordion title="Download Support Bundle is disabled with a file size tooltip">
-    **Likely cause:** The support bundle exceeds the size BloodHound Enterprise allows for browser download.
-
-    **Action:** Contact SpecterOps support and provide the client name so support can retrieve the large bundle for you.
   </Accordion>
 
   <Accordion title="You need a newer bundle">

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -99,9 +99,9 @@ Provide your SpecterOps support representative with the ZIP file through the app
 
     | **File** | **Description** |
     | --- | --- |
-    | `settings.json` | The SharpHound Enterprise service configuration file. This file includes connection, collection, and logging settings used by the collector. |
-    | `service.log` | The active SharpHound Enterprise service log. This file records service startup, configuration, API communication, tasking, and operational events. |
     | `log_archive/*.zip` | Archived SharpHound Enterprise logs. These files can include previous service logs, collection job logs, management operation logs, computer status CSVs, and archived collection output files. |
+    | `service.log` | The active SharpHound Enterprise service log. This file records service startup, configuration, API communication, tasking, and operational events. |
+    | `settings.json` | The SharpHound Enterprise service configuration file. This file includes connection, collection, and logging settings used by the collector. |
 
     <Note>
       Support bundles do not include `auth.json` files.

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -75,7 +75,7 @@ To request a support bundle, you must have the **Administrator** role and access
   </Step>
 
   <Step title="Confirm the request">
-    BloodHound Enterprise displays **Support bundle requested successfully** when the request is queued. If the request fails, BloodHound Enterprise displays an error notification with a reason for the failure.
+    BloodHound Enterprise displays **Support bundle requested successfully** when the request is queued.
   </Step>
 </Steps>
 
@@ -94,8 +94,18 @@ Provide your SpecterOps support representative with the ZIP file through the app
     BloodHound Enterprise displays **Support bundle downloaded successfully** when complete.
   </Step>
 
-  <Step title="Save the ZIP file">
-    Your browser downloads the bundle as a `.zip` file. The filename includes the client name, support-bundle type, and upload timestamp.
+  <Step title="Confirm the download">
+    Your browser downloads the bundle as a `.zip` file named `sharphound_enterprise_support_bundle_<timestamp>.zip` with the following files:
+
+    | **File** | **Description** |
+    | --- | --- |
+    | `settings.json` | The SharpHound Enterprise service configuration file. This file includes connection, collection, and logging settings used by the collector. |
+    | `service.log` | The active SharpHound Enterprise service log. This file records service startup, configuration, API communication, tasking, and operational events. |
+    | `log_archive/*.zip` | Archived SharpHound Enterprise logs. These files can include previous service logs, collection job logs, management operation logs, computer status CSVs, and archived collection output files. |
+
+    <Note>
+      Support bundles do not include `auth.json` files.
+    </Note>
   </Step>
 </Steps>
 

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -32,7 +32,6 @@ Before you can request, download, or delete a support bundle, you must have the 
 - BloodHound Enterprise with the collector support bundle feature enabled.
 - A SharpHound Enterprise collector client that appears on the **Manage Clients** page.
 - A user assigned the **Administrator** role. The support-bundle controls require permission to manage users and access client-management actions.
-- Environment access to the client. If [Environment Targeted Access Control (ETAC)](/manage-bloodhound/auth/environment-targeted-access-control) restricts your access to the client's environment, BloodHound Enterprise blocks support-bundle actions for that client.
 
   <Note>
     Support bundles are currently available for SharpHound Enterprise clients. AzureHound Enterprise and OpenHound clients do not show support-bundle actions.
@@ -57,7 +56,7 @@ Uploaded support bundles expire 90 days after the upload session is created. Del
 
 ## Request a support bundle
 
-To request a support bundle, you must have the **Administrator** role and access to the collector's environment. The request is asynchronous. BloodHound Enterprise checks for completion in the background and displays status notifications.
+To request a support bundle, you must have the **Administrator** role. The request is asynchronous. BloodHound Enterprise checks for completion in the background and displays status notifications.
 
 <Steps>
   <Step title="Open the Manage Clients page">
@@ -108,6 +107,10 @@ Provide your SpecterOps support representative with the ZIP file through the app
     </Note>
   </Step>
 </Steps>
+
+<Note>
+  If **Download Support Bundle** is disabled and a tooltip says the file is too large to download, contact SpecterOps support to request the bundle on your behalf.
+</Note>
 
 ## Delete a support bundle
 
@@ -174,6 +177,12 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
     **Likely cause:** The browser, network path, permissions, or stored artifact is unavailable.
 
     **Action:** Try again. If it still fails, confirm that the bundle has not been deleted and contact support with the visible error.
+  </Accordion>
+
+  <Accordion title="Download Support Bundle is disabled with a file size tooltip">
+    **Likely cause:** The support bundle exceeds the size BloodHound Enterprise allows for browser download.
+
+    **Action:** Contact SpecterOps support and provide the client name so support can retrieve the large bundle for you.
   </Accordion>
 
   <Accordion title="You need a newer bundle">

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -3,9 +3,13 @@ title: Manage Collector Support Bundles
 description: "Request, download, and delete SharpHound Enterprise support bundles in BloodHound Enterprise."
 ---
 
+import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
+
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
 A collector support bundle is a ZIP file that contains diagnostic information from a collector client. Support bundles help you troubleshoot collection issues faster, reduce the need for direct access to the system where the collector runs, and give your team or SpecterOps support a consistent package of collector logs and diagnostics.
+
+<FeatureFlagNote />
 
 This page explains how to request, download, delete, and troubleshoot SharpHound Enterprise support bundles from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
 

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -5,13 +5,21 @@ description: "Request, download, and delete SharpHound Enterprise support bundle
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>
 
-A collector support bundle is a ZIP file that contains diagnostic information from a collector client. Use a support bundle when you need to troubleshoot a SharpHound Enterprise collector without signing in to the system where the collector runs.
+A collector support bundle is a ZIP file that contains diagnostic information from a collector client. Support bundles help you troubleshoot collection issues faster, reduce the need for direct access to the system where the collector runs, and give your team or SpecterOps support a consistent package of collector logs and diagnostics.
 
-You can request a support bundle from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
+This page explains how to request, download, delete, and troubleshoot SharpHound Enterprise support bundles from **Administration** > **Manage Clients**. After the collector processes the request and uploads the file, BloodHound Enterprise shows download and delete actions for that client.
 
 <Warning>
   Support bundles can contain diagnostic data from your environment. Handle downloaded bundles according to your organization's data handling process and share them only through approved support channels.
 </Warning>
+
+## Use cases
+
+Use support bundles when you need to shorten the path from a collector issue to troubleshooting:
+
+- **Self-service troubleshooting:** Request and download collector diagnostics from BloodHound Enterprise when you do not have direct access to the system where the collector runs.
+- **SpecterOps-assisted troubleshooting:** Work with a SpecterOps support representative who has authorized access to your tenant. They can use the same BloodHound Enterprise workflow to retrieve the support bundle.
+- **Targeted diagnostic collection:** Collect one support bundle for a specific client, download it through the browser, and delete it when you no longer need it or when you need a newer bundle.
 
 ## Prerequisites
 

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -157,21 +157,15 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
 
 <AccordionGroup>
   <Accordion title="Request Support Bundle is missing">
-    **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise or OpenHound, or your role cannot use support-bundle controls.
+    **Likely cause:** The feature is not enabled, the client is not SharpHound Enterprise or OpenHound, the collector application is below the minimum supported version, or your role cannot use support-bundle controls.
 
-    **Action:** Confirm that the client type is **SharpHound Enterprise** or **OpenHound** and that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
+    **Action:** Confirm that the client type is **SharpHound Enterprise** or **OpenHound**, and that the collector meets the minimum version: SharpHound Enterprise v2.16.0 or later or OpenHound v0.3.2 or later. Also confirm that you are assigned the **Administrator** role. Contact SpecterOps if the feature is not available in your tenant.
   </Accordion>
 
   <Accordion title="The action menu is missing">
     **Likely cause:** Your role can read clients but cannot manage client actions.
 
     **Action:** Ask an administrator to assign a role with client-management permissions or request the bundle for you.
-  </Accordion>
-
-  <Accordion title="The collector version is unsupported">
-    **Likely cause:** The collector application does not meet the minimum version required for support bundles.
-
-    **Action:** Upgrade SharpHound Enterprise to v2.16.0 or later, or OpenHound to v0.3.2 or later. Then request the support bundle again.
   </Accordion>
 
   <Accordion title="The request fails immediately">

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -95,7 +95,7 @@ Provide your SpecterOps support representative with the `.zip` file through the 
   <Step title="Download the bundle">
     Click **Download Support Bundle**.
 
-    BloodHound Enterprise displays **Support bundle downloaded successfully** when complete.
+    BloodHound Enterprise displays **Support bundle download started.** when your browser begins downloading the file.
   </Step>
 
   <Step title="Confirm the download">

--- a/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
+++ b/docs/collect-data/enterprise-collection/collector-support-bundles.mdx
@@ -168,6 +168,12 @@ Use the following issues to troubleshoot support-bundle requests, downloads, and
     **Action:** Ask an administrator to assign a role with client-management permissions or request the bundle for you.
   </Accordion>
 
+  <Accordion title="The collector version is unsupported">
+    **Likely cause:** The collector application does not meet the minimum version required for support bundles.
+
+    **Action:** Upgrade SharpHound Enterprise to v2.16.0 or later, or OpenHound to v0.3.2 or later. Then request the support bundle again.
+  </Accordion>
+
   <Accordion title="The request fails immediately">
     **Likely cause:** BloodHound Enterprise cannot queue the request because of permissions, feature availability, client visibility, or a temporary service error.
 

--- a/docs/collect-data/enterprise-collection/overview.mdx
+++ b/docs/collect-data/enterprise-collection/overview.mdx
@@ -5,14 +5,14 @@ description: "Learn about attack path data collection in BloodHound Enterprise."
 ---
 
 <CardGroup cols={2}>
-<Card title="Data Reconciliation and Retention" icon="database" href="/collect-data/enterprise-collection/data-retention"> Promoted article </Card>
-<Card title="Ad-hoc Data Collection with SharpHound CE" icon="magnifying-glass" href="/collect-data/enterprise-collection/ad-hoc-collection"> </Card>
-<Card title="Create a Collector Client" icon="plus" href="/collect-data/enterprise-collection/create-collector"> </Card>
-<Card title="Run an On Demand Scan" icon="play" href="/collect-data/enterprise-collection/on-demand-scan"> </Card>
-<Card title="Create a Data Collection Schedule" icon="calendar" href="/collect-data/enterprise-collection/collection-schedule"> </Card>
-<Card title="Monitor Data Collection" icon="chart-line" href="/collect-data/enterprise-collection/monitor"> </Card>
-<Card title="Manage Collector Support Bundles" icon="file-zipper" href="/collect-data/enterprise-collection/collector-support-bundles"> </Card>
-<Card title="Why perform privileged collection in SharpHound" icon="key" href="/collect-data/enterprise-collection/privileged-collection"> </Card>
-<Card title="SharpHound Enterprise Cross-Trust Collection" icon="bridge" href="/collect-data/enterprise-collection/cross-trust"> </Card>
-<Card title="SharpHound Collection FAQ" icon="circle-question" href="/collect-data/enterprise-collection/faq"> </Card>
+<Card title="Data Reconciliation and Retention" icon="database" href="/collect-data/enterprise-collection/data-retention"> Learn how BloodHound Enterprise updates collected data and removes stale data after retention periods expire. </Card>
+<Card title="Ad-hoc Data Collection with SharpHound CE" icon="magnifying-glass" href="/collect-data/enterprise-collection/ad-hoc-collection"> Collect data for BloodHound Enterprise manually with SharpHound Community Edition. </Card>
+<Card title="Create a Collector Client" icon="plus" href="/collect-data/enterprise-collection/create-collector"> Create a collector client to connect a collector application to your BloodHound Enterprise tenant. </Card>
+<Card title="Run an On Demand Scan" icon="play" href="/collect-data/enterprise-collection/on-demand-scan"> Start a collector client scan outside its scheduled collection window. </Card>
+<Card title="Create a Data Collection Schedule" icon="calendar" href="/collect-data/enterprise-collection/collection-schedule"> Configure a collector client to collect attack path data on a schedule. </Card>
+<Card title="Monitor Data Collection" icon="chart-line" href="/collect-data/enterprise-collection/monitor"> Interpret collector job status, file uploads, and collection activity. </Card>
+<Card title="Manage Collector Support Bundles" icon="file-zipper" href="/collect-data/enterprise-collection/collector-support-bundles"> Request, download, and delete diagnostic bundles for SharpHound Enterprise collectors. </Card>
+<Card title="Why perform privileged collection in SharpHound" icon="key" href="/collect-data/enterprise-collection/privileged-collection"> Understand how privileged collection improves attack path analysis with local group, session, registry, and user rights data. </Card>
+<Card title="SharpHound Enterprise Cross-Trust Collection" icon="bridge" href="/collect-data/enterprise-collection/cross-trust"> Configure SharpHound Enterprise to collect data across trusted Active Directory domains and forests. </Card>
+<Card title="SharpHound Collection FAQ" icon="circle-question" href="/collect-data/enterprise-collection/faq"> Review common questions about SharpHound Enterprise collection capabilities and behavior. </Card>
 </CardGroup>

--- a/docs/collect-data/enterprise-collection/overview.mdx
+++ b/docs/collect-data/enterprise-collection/overview.mdx
@@ -11,6 +11,7 @@ description: "Learn about attack path data collection in BloodHound Enterprise."
 <Card title="Run an On Demand Scan" icon="play" href="/collect-data/enterprise-collection/on-demand-scan"> </Card>
 <Card title="Create a Data Collection Schedule" icon="calendar" href="/collect-data/enterprise-collection/collection-schedule"> </Card>
 <Card title="Monitor Data Collection" icon="chart-line" href="/collect-data/enterprise-collection/monitor"> </Card>
+<Card title="Manage Collector Support Bundles" icon="file-zipper" href="/collect-data/enterprise-collection/collector-support-bundles"> </Card>
 <Card title="Why perform privileged collection in SharpHound" icon="key" href="/collect-data/enterprise-collection/privileged-collection"> </Card>
 <Card title="SharpHound Enterprise Cross-Trust Collection" icon="bridge" href="/collect-data/enterprise-collection/cross-trust"> </Card>
 <Card title="SharpHound Collection FAQ" icon="circle-question" href="/collect-data/enterprise-collection/faq"> </Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,7 @@
                   "collect-data/enterprise-collection/on-demand-scan",
                   "collect-data/enterprise-collection/collection-schedule",
                   "collect-data/enterprise-collection/monitor",
+                  "collect-data/enterprise-collection/collector-support-bundles",
                   "collect-data/enterprise-collection/privileged-collection",
                   "collect-data/enterprise-collection/least-privileged-collection",
                   "collect-data/enterprise-collection/cross-trust",

--- a/docs/manage-bloodhound/auth/users-and-roles.mdx
+++ b/docs/manage-bloodhound/auth/users-and-roles.mdx
@@ -69,5 +69,6 @@ For OpenGraph extensions, BloodHound separates read and write permissions. Users
 | Run collector client on-demand scan \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
 | Add, modify, and remove a collector client \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
 | Regenerate collector client credentials \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - |
+| Request, download, and delete collector support bundles \[BHE\] | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | - | - | - |
 | File Ingest | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | <Icon icon="square-check" iconType="solid" color="#22c55e"/> | - | - | <Icon icon="square-check" iconType="solid" color="#22c55e"/> |
 

--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -21,7 +21,7 @@ An extension definition schema tells BloodHound how to interpret, interact with,
 An extension definition schema is a JSON file that OpenGraph extension developers provide for BloodHound users to install on the [OpenGraph Management](/opengraph/extensions/manage) page before they upload data payloads that conform to the schema.
 
 <Note>
-  In BloodHound Enterprise v9.3.0 and later, supported platform extensions (GitHub, Jamf, and Okta) are pre-installed. Other SpecterOps-supported schemas, such as SCIM, must still be uploaded manually.
+  In BloodHound Enterprise, supported platform extensions (GitHub, Jamf, and Okta) are pre-installed. Other SpecterOps-supported schemas, such as SCIM, must still be uploaded manually.
 </Note>
 
 This page describes the components of an extension definition schema. For a full example of how these components work together, see the [example schema](/opengraph/developer/graph-definition#example-schema) section at the end of the page.

--- a/docs/opengraph/developer/nodes.mdx
+++ b/docs/opengraph/developer/nodes.mdx
@@ -136,10 +136,6 @@ During ingest, BloodHound maps this `id` value internally to `objectid`. If you 
   Do not include `objectid` inside `properties`. Use only the root-level `id` field.
 </Warning>
 
-### `ref`
-
-The property name `ref` is reserved and **must not** be included in the `properties` object of a node definition.
-
 ## Findings and metrics
 
 <img

--- a/docs/opengraph/extensions/github/overview.mdx
+++ b/docs/opengraph/extensions/github/overview.mdx
@@ -9,7 +9,7 @@ The GitHub extension is an OpenGraph extension for [GitHub](https://github.com/)
 
 It adds GitHub-specific [nodes](/opengraph/extensions/github/schema#nodes), [edges](/opengraph/extensions/github/schema#edges), [Cypher queries](/opengraph/extensions/github/queries), and [Privilege Zone rules](/opengraph/extensions/github/privilege-zone-rules) to help security professionals visualize and analyze their GitHub configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, GitHub is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, GitHub is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 ## GitHub Attack Paths
 

--- a/docs/opengraph/extensions/jamf/overview.mdx
+++ b/docs/opengraph/extensions/jamf/overview.mdx
@@ -9,7 +9,7 @@ The Jamf extension is an OpenGraph extension for [Jamf Pro](https://www.jamf.com
 
 It adds Jamf-specific [nodes](/opengraph/extensions/jamf/schema#nodes), [edges](/opengraph/extensions/jamf/schema#edges), [Cypher queries](/opengraph/extensions/jamf/queries), and [Privilege Zone rules](/opengraph/extensions/jamf/privilege-zone-rules) to help security professionals visualize and analyze Jamf Pro configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, Jamf is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, Jamf is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 <Note>The other main products in Jamf's portfolio are [Jamf Protect](https://www.jamf.com/products/jamf-protect/), [Jamf Account](https://learn.jamf.com/en-US/bundle/jamf-account-documentation/page/Jamf_Account_Documentation.html), [Jamf Now](https://www.jamf.com/products/jamf-now/), and [Jamf Connect](https://www.jamf.com/products/jamf-connect/). The Jamf extension does not currently support these products.</Note>
 

--- a/docs/opengraph/extensions/manage.mdx
+++ b/docs/opengraph/extensions/manage.mdx
@@ -51,7 +51,7 @@ BloodHound uses several extension management models. Understanding the distincti
 | Extension type | Examples | Management behavior |
 |---|---|---|
 | **Built-in** | Active Directory, Azure | Included in BloodHound and BloodHound Enterprise. Administrators cannot delete these extensions. |
-| **Pre-installed** | GitHub, Jamf, Okta | Included in BloodHound Enterprise v9.3.0 and later. Administrators can verify, update, or delete them, but BloodHound Enterprise reapplies the latest versions at startup according to [automatic update rules](/opengraph/extensions/manage#automatic-updates). |
+| **Pre-installed** | GitHub, Jamf, Okta | Included in BloodHound Enterprise. Administrators can verify, update, or delete them, but BloodHound Enterprise reapplies the latest versions at startup according to [automatic update rules](/opengraph/extensions/manage#automatic-updates). |
 | **Manually managed** | SCIM, custom, and community-built extensions | Administrators must upload and maintain these extensions manually. |
 
 ## Before you begin
@@ -63,29 +63,19 @@ Complete the following steps before you verify or install an extension and uploa
 </Note>
 
 <Steps>
-	<Step title="Confirm OpenGraph Extension Management availability">
-		The OpenGraph Extension Management feature must be enabled before you can manage extensions.
-		
-		Enable this feature on the **Administration** > **Early Access Features** page.
+	<Step title="Get extension artifacts">
+		How you obtain extensions and collectors depends on your BloodHound edition and how they are distributed:
 
-		<Note>
-    	  Support for extension-defined **Findings** in BloodHound Enterprise is a SpecterOps-managed feature. If it is not enabled in your environment, contact your account team for assistance.
-  		</Note>
+		- **BloodHound Community**: Users can download and use [publicly available](/opengraph/library) community-built extensions and collectors from GitHub repositories.
+
+		- **BloodHound Enterprise**: GitHub, Jamf, and Okta are supported as pre-installed extensions. Use the **OpenGraph Management** page to verify the installed version. You can still manually upload publicly available, companion, or custom extensions as needed.
+
+			If you need a newer version of a pre-installed extension outside the standard BloodHound Enterprise release cycle, coordinate with your account team.
+
+			<Note>
+			Pre-installed extensions can include detailed findings and remediation guidance when that feature is enabled in your environment. Contact your account team for availability.
+			</Note>
 	</Step>
-		<Step title="Get extension artifacts">
-			How you obtain extensions and collectors depends on your BloodHound edition and how they are distributed:
-
-
-			- **BloodHound Community**: Users can download and use [publicly available](/opengraph/library) community-built extensions and collectors from GitHub repositories.
-
-			- **BloodHound Enterprise**: In v9.3.0 and later, GitHub, Jamf, and Okta are supported as pre-installed extensions. Use the **OpenGraph Management** page to verify the installed version. You can still manually upload publicly available, companion, or custom extensions as needed.
-
-			  If you need a newer version of a pre-installed extension outside the standard BloodHound Enterprise release cycle, coordinate with your account team.
-
-			  <Note>
-			    Pre-installed extensions can include detailed findings and remediation guidance when that feature is enabled in your environment. Contact your account team for availability.
-			  </Note>
-		</Step>
 	<Step title="Review prerequisites">
 		After you obtain an extension and collector, review the prerequisites in the extension-specific setup documentation.
 		
@@ -197,7 +187,7 @@ sequenceDiagram
 
 Before you upload structured OpenGraph data, make sure BloodHound has the matching extension definition schema.
 
-In BloodHound Enterprise v9.3.0 and later, GitHub, Jamf, and Okta are supported as pre-installed extensions and usually only need verification. Administrators still manage custom or companion extension definition schemas, such as SCIM, manually.
+In BloodHound Enterprise, GitHub, Jamf, and Okta are supported as pre-installed extensions and usually only need verification. Administrators still manage custom or companion extension definition schemas, such as SCIM, manually.
 
 In BloodHound Community, Administrators manage all extension definition schemas manually.
 
@@ -266,7 +256,7 @@ To update an extension, upload the new version using the same process as install
 
 ### Automatic updates
 
-In BloodHound Enterprise v9.3.0 and later, the pre-installed GitHub, Jamf, and Okta extensions follow automatic update rules.
+In BloodHound Enterprise, the pre-installed GitHub, Jamf, and Okta extensions follow automatic update rules.
 
 At application startup, BloodHound Enterprise compares each pre-installed extension with the embedded version included in the current release and keeps whichever version is newer:
 

--- a/docs/opengraph/extensions/okta/overview.mdx
+++ b/docs/opengraph/extensions/okta/overview.mdx
@@ -9,7 +9,7 @@ The Okta extension is an OpenGraph extension for [Okta Platform](https://www.okt
 
 It adds Okta-specific [nodes](/opengraph/extensions/okta/schema#nodes), [edges](/opengraph/extensions/okta/schema#edges), [Cypher queries](/opengraph/extensions/okta/queries), and [Privilege Zone rules](/opengraph/extensions/okta/privilege-zone-rules) to help security professionals visualize and analyze Okta configurations in BloodHound.
 
-In BloodHound Enterprise v9.3.0 and later, Okta is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
+In BloodHound Enterprise, Okta is supported as a pre-installed extension. Use [OpenGraph Extension Management](/opengraph/extensions/manage) to verify the installed version or upload a newer supported schema manually.
 
 <Note>The other main product in Okta's portfolio is [Auth0](https://auth0.com/) (previously known as Customer Identity Cloud). The Okta extension does not currently support Auth0.</Note>
 

--- a/docs/opengraph/extensions/scim/overview.mdx
+++ b/docs/opengraph/extensions/scim/overview.mdx
@@ -33,7 +33,7 @@ The key edge that ties SCIM to other extensions is **SCIM_Provisioned**, which c
 
 1. Upload the SCIM schema to your BloodHound instance alongside the extension schemas for the collectors you are using (for example, Okta or GitHub).
 
-   In BloodHound Enterprise v9.3.0 and later, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Verify that these are installed before you upload the SCIM companion schema.
+   In BloodHound Enterprise, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Verify that these are installed before you upload the SCIM companion schema.
 
 1. Run the relevant collectors — they will produce SCIM nodes and edges automatically.
 

--- a/docs/openhound/upload-extension-assets.mdx
+++ b/docs/openhound/upload-extension-assets.mdx
@@ -10,7 +10,7 @@ OpenHound extensions include saved queries and Privilege Zone rules that help yo
 Use the OpenHound CLI to upload these assets after the matching extension definition schema is installed or verified in BloodHound.
 
 <Note>
-  In BloodHound Enterprise v9.3.0 and later, the GitHub, Jamf, and Okta extension schemas are pre-installed. Saved queries and Privilege Zone rules are still managed separately.
+  In BloodHound Enterprise, the GitHub, Jamf, and Okta extension schemas are pre-installed. Saved queries and Privilege Zone rules are still managed separately.
 </Note>
 
 ## Prerequisites

--- a/docs/resources/glossary/overview.mdx
+++ b/docs/resources/glossary/overview.mdx
@@ -52,6 +52,10 @@ A collector client is a configuration object in your BloodHound Enterprise tenan
 
 A collector application is software that collects [Attack Path](#attack-path)-related data from a [directory](#directory) and sends it to your BloodHound Enterprise tenant. Examples include SharpHound Enterprise and AzureHound Enterprise.
 
+## Collector support bundle
+
+A [collector support bundle](/collect-data/enterprise-collection/collector-support-bundles) is a ZIP file that contains diagnostic information from a collector client. In BloodHound Enterprise, administrators can request, download, and delete support bundles to troubleshoot SharpHound Enterprise collectors without signing in to the collector host.
+
 ## Composite Edge
 
 <defCompositeEdge />

--- a/docs/snippets/opengraph/extensions/optional-schemas.mdx
+++ b/docs/snippets/opengraph/extensions/optional-schemas.mdx
@@ -1,3 +1,3 @@
 If {source} is connected to other BloodHound-supported data sources in your environment, such as {otherSources}, make sure the corresponding schema is installed too.
 
-In BloodHound Enterprise v9.3.0 and later, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Upload any companion schemas that are not already installed. Doing so ensures those cross-platform relationships are modeled correctly in BloodHound.
+In BloodHound Enterprise, some extensions (such as GitHub, Jamf, and Okta) are pre-installed. Upload any companion schemas that are not already installed. Doing so ensures those cross-platform relationships are modeled correctly in BloodHound.


### PR DESCRIPTION
## Summary

This pull request (PR) adds net new docs describing the **collector bundle support** feature associated with the BED-7970 epic.

## Staging

We no longer have access to staging builds on Mintlify 😒

But you can [build the site locally](https://www.mintlify.com/docs/cli/preview) to preview the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing SharpHound Enterprise collector support bundles, including prerequisites, permissions, lifecycle, downloads, deletion, contents, data handling, and troubleshooting.
  * Added collector support bundles to the enterprise collection navigation and overview.
  * Documented the administrator-only permission to request, download, and delete support bundles.
  * Added a glossary definition for collector support bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->