### PR TITLE
DOCS-32: Markdown validation for OpenGraph extensions

### DIFF
--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -93,7 +93,7 @@ Each `info` object is a map of section identifiers to rendered sections. Use sta
 | --- | --- | --- |
 | `info` key | Required | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
 | `title` | Required | Section title displayed in the Entity Panel accordion header. |
-| `position` | Required | Integer that controls the order of extension-defined sections. Lower values render first. Use `1` or greater. |
+| `position` | Required | Integer that controls the order of extension-defined sections. Lower values render first. Use `0` or greater. |
 | `markdown.content` | Required | Markdown rendered in the section body. Validated on upload. See [Markdown validation](/opengraph/developer/graph-definition#markdown-validation). |
 
 Every Entity Panel starts with **Object Information** at position `0`. This section lists all properties for the selected node or relationship.
@@ -119,7 +119,7 @@ BloodHound supports [CommonMark](https://commonmark.org/) plus the following [Gi
 - Strikethrough
 - Task lists
 - Autolinks
-- Fenced code blocks with a language hint (for example, a code block tagged as `go`)
+- Fenced code blocks with an alphanumeric language hint (for example, a code block tagged as `go`)
 
 You can also include inline HTML that is on BloodHound's allowlist of safe elements and attributes, such as links and basic text formatting.
 

--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -104,12 +104,18 @@ If no `info` entries are defined for the selected kind, BloodHound still renders
 
 ## Markdown validation
 
-Several fields accept Markdown that BloodHound renders in the UI:
+When you upload an extension definition schema, BloodHound validates each Markdown field to ensure it does not contain unsafe or disallowed HTML.
 
-- `info.<section>.markdown.content` in the `node_kinds` and `relationship_kinds` arrays (see [Custom Entity Panel content](/opengraph/developer/graph-definition#custom-entity-panel-content)).
-- `remediation.short_description`, `remediation.long_description`, `remediation.short_remediation`, and `remediation.long_remediation` in the `relationship_findings` array (BloodHound Enterprise only).
+<Note>
+  Validation only checks the content; BloodHound stores your original Markdown without modifying it.
+</Note>
 
-When you upload an extension definition schema, BloodHound validates each Markdown field to ensure it does not contain unsafe or disallowed HTML. Validation only checks the content; BloodHound stores your original Markdown without modifying it.
+BloodHound validates Markdown in the following fields:
+
+| Field(s) | Where |
+| --- | --- |
+| `info.<section>.markdown.content` | `node_kinds` and `relationship_kinds` arrays (see [Custom Entity Panel content](/opengraph/developer/graph-definition#custom-entity-panel-content)) |
+| `remediation.short_description` `remediation.long_description` `remediation.short_remediation` `remediation.long_remediation` | `relationship_findings` array (BloodHound Enterprise only) |
 
 ### Supported Markdown
 
@@ -119,7 +125,7 @@ BloodHound supports [CommonMark](https://commonmark.org/) plus the following [Gi
 - Strikethrough
 - Task lists
 - Autolinks
-- Fenced code blocks with an alphanumeric language hint (for example, a code block tagged as `go`)
+- Fenced code blocks (with an alphanumeric language hint)
 
 You can also include inline HTML that is on BloodHound's allowlist of safe elements and attributes, such as links and basic text formatting.
 

--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -73,7 +73,7 @@ Although the `schema.name` field does not use a namespace prefix, it must still 
 
 ## Custom Entity Panel content
 
-Use the `info` object to define custom Entity Panel sections for node kinds and relationship kinds. When a user selects a node or relationship in Explore, BloodHound renders an Entity Panel with the specified accordion sections as defined by the `info` entries.
+Use the [`info`](opengraph/developer/graph-definition#param-info) object to define custom Entity Panel sections for node kinds and relationship kinds. When a user selects a node or relationship in Explore, BloodHound renders an Entity Panel with the specified accordion sections as defined by the `info` entries.
 
 Each `info` object is a map of section identifiers to rendered sections. Use stable identifiers for the keys so future schema updates can modify the same section without changing its identity.
 
@@ -89,12 +89,12 @@ Each `info` object is a map of section identifiers to rendered sections. Use sta
 }
 ```
 
-| Field | Requirement | Description |
-| --- | --- | --- |
-| `info` key | Required | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
-| `title` | Required | Section title displayed in the Entity Panel accordion header. |
-| `position` | Required | Integer that controls the order of extension-defined sections. Lower values render first. Use `0` or greater. |
-| `markdown.content` | Required | Markdown rendered in the section body. Validated on upload. See [Markdown validation](/opengraph/developer/graph-definition#markdown-validation). |
+| Field | Description |
+| --- | --- |
+| `info` key | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
+| `title` | Section title displayed in the Entity Panel accordion header. |
+| `position` | Integer that controls the order of extension-defined sections. Lower values render first. Use `1` or greater. |
+| `markdown.content` | Markdown rendered in the section body. Required when `markdown` is present. Validated on upload. See [Markdown validation](/opengraph/developer/graph-definition#markdown-validation). |
 
 Every Entity Panel starts with **Object Information** at position `0`. This section lists all properties for the selected node or relationship.
 

--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -94,13 +94,47 @@ Each `info` object is a map of section identifiers to rendered sections. Use sta
 | `info` key | Required | Stable section identifier. Must match `^[a-z0-9_-]{1,128}$`, which allows lowercase letters, numbers, hyphens, and underscores. |
 | `title` | Required | Section title displayed in the Entity Panel accordion header. |
 | `position` | Required | Integer that controls the order of extension-defined sections. Lower values render first. Use `1` or greater. |
-| `markdown.content` | Required | Markdown content rendered in the section body. |
+| `markdown.content` | Required | Markdown rendered in the section body. Validated on upload. See [Markdown validation](/opengraph/developer/graph-definition#markdown-validation). |
 
 Every Entity Panel starts with **Object Information** at position `0`. This section lists all properties for the selected node or relationship.
 
 BloodHound renders additional `info` entries for the selected node's primary kind or the selected relationship's kind after **Object Information**. BloodHound orders those extension-defined sections by `position`, then `title`.
 
 If no `info` entries are defined for the selected kind, BloodHound still renders **Object Information**, but does not render additional extension-defined Entity Panel sections.
+
+## Markdown validation
+
+Several fields accept Markdown that BloodHound renders in the UI:
+
+- `info.<section>.markdown.content` in the `node_kinds` and `relationship_kinds` arrays (see [Custom Entity Panel content](/opengraph/developer/graph-definition#custom-entity-panel-content)).
+- `remediation.short_description`, `remediation.long_description`, `remediation.short_remediation`, and `remediation.long_remediation` in the `relationship_findings` array (BloodHound Enterprise only).
+
+When you upload an extension definition schema, BloodHound validates each Markdown field to ensure it does not contain unsafe or disallowed HTML. Validation only checks the content; BloodHound stores your original Markdown without modifying it.
+
+### Supported Markdown
+
+BloodHound supports [CommonMark](https://commonmark.org/) plus the following [GitHub Flavored Markdown](https://github.github.com/gfm/) extensions:
+
+- Tables
+- Strikethrough
+- Task lists
+- Autolinks
+- Fenced code blocks with a language hint (for example, a code block tagged as `go`)
+
+You can also include inline HTML that is on BloodHound's allowlist of safe elements and attributes, such as links and basic text formatting.
+
+### Rejected content
+
+BloodHound rejects the upload when a Markdown field contains unsafe or disallowed HTML, including:
+
+- `<script>` tags and other executable content
+- Inline event-handler attributes, such as `onclick`
+- `javascript:` links
+- `<iframe>`, `<style>`, and similar elements
+
+<Warning>
+  If any Markdown field fails validation, the entire extension definition schema upload fails.
+</Warning>
 
 ## Findings and metrics
 
@@ -322,16 +356,16 @@ Defines findings based on relationships. Each finding represents a single instan
   Relationship kind that contributes to this finding when matching edges are present and the edge crosses a Privilege Zone boundary. Must match a `relationship_kinds.name` defined in any installed extension definition schema.
 </ResponseField>
 <ResponseField name="remediation" type="object">
-  Remediation guidance to resolve the finding, including both short and long forms.
+  Remediation guidance to resolve the finding, including both short and long forms. The `short_description`, `long_description`, `short_remediation`, and `long_remediation` fields accept Markdown and are validated on upload. See [Markdown validation](/opengraph/developer/graph-definition#markdown-validation).
 </ResponseField>
 <ResponseField name="remediation.short_description" type="string">
-  A concise summary of the recommended remediation action.
+  A concise summary of the recommended remediation action, which can include Markdown formatting for better readability.
 </ResponseField>
 <ResponseField name="remediation.long_description" type="string">
   A detailed explanation of the finding and its cause, which can include Markdown formatting for better readability.
 </ResponseField>
 <ResponseField name="remediation.short_remediation" type="string">
-  A concise summary of the steps to remediate the finding.
+  A concise summary of the steps to remediate the finding, which can include Markdown formatting for better readability.
 </ResponseField>
 <ResponseField name="remediation.long_remediation" type="string">
   A detailed, step-by-step guide to remediate the finding, which can include Markdown formatting for better readability.


### PR DESCRIPTION
## Summary

This pull request (PR) adds a new section to the [graph definition](https://bloodhound.specterops.io/opengraph/developer/graph-definition) page describing the markdown validation enhancement we're introducing in v9.6.0.

The page is getting pretty long. When we introduce support for templating in a future release, it'll get even longer. We may want to consider splitting the field-level reference from the following sections soon:

- Namespacing
- Custom Entity Panel Content
- Markdown validation
- Findings and metrics

## Staging

We no longer have access to staging builds on Mintlify 😒

But you can [build the site locally](https://www.mintlify.com/docs/cli/preview) to preview the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Entity Panel guidance to allow position values starting at 0.
  * Added Markdown validation guidance, including supported syntax, rejected content, affected fields, and upload-failure behavior.
  * Expanded remediation field descriptions to clarify Markdown support and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->