### PR TITLE
DOCS-21: Update API reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1124,11 +1124,11 @@
           {
             "group": "Custom Node Management",
             "pages": [
-              "reference/custom-node-management/create-custom-nodes",
               "reference/custom-node-management/get-custom-nodes",
+              "reference/custom-node-management/create-custom-nodes",
               "reference/custom-node-management/get-custom-node",
               "reference/custom-node-management/update-custom-node",
-              "reference/custom-node-management/delete-custom-node"
+              "reference/custom-node-management/delete-custom-node-deprecated"
             ]
           },
           {
@@ -1218,7 +1218,9 @@
               "reference/opengraph-experimental/list-opengraph-extensions-information",
               "reference/opengraph-experimental/upserts-the-opengraph-extension",
               "reference/opengraph-experimental/delete-opengraph-extension",
-              "reference/opengraph-experimental/list-edge-kinds"
+              "reference/opengraph-experimental/list-edge-kinds",
+              "reference/opengraph-experimental/get-node-kind",
+              "reference/opengraph-experimental/get-relationship-kind"
             ]
           },
           {
@@ -1454,8 +1456,16 @@
               "reference/clients/list-all-completed-jobs-for-a-client",
               "reference/clients/creates-a-scheduled-task",
               "reference/clients/creates-a-scheduled-job",
+              "reference/clients/queues-a-management-operation",
+              "reference/clients/download-a-management-operation-artifact-for-the-client",
+              "reference/clients/delete-a-management-operation-artifact-for-the-client",
+              "reference/clients/get-available-management-operations",
               "reference/clients/notifies-the-api-of-a-management-operation-start",
-              "reference/clients/notifies-the-api-of-a-management-operation-ending"
+              "reference/clients/notifies-the-api-of-a-management-operation-ending",
+              "reference/clients/create-an-artifact-upload-session",
+              "reference/clients/get-an-artifact-upload-session",
+              "reference/clients/upload-an-artifact-part",
+              "reference/clients/complete-an-artifact-upload-session"
             ]
           },
           {
@@ -1500,14 +1510,15 @@
             "group": "Attack Paths",
             "pages": [
               "reference/attack-paths/export-attack-path-findings",
-              "reference/attack-paths/get-all-attack-path-findings",
+              "reference/attack-paths/list-finding-trends",
               "reference/attack-paths/list-all-attack-path-types",
+              "reference/attack-paths/list-attack-path-finding-types",
               "reference/attack-paths/start-analysis",
+              "reference/attack-paths/get-all-attack-path-findings",
               "reference/attack-paths/list-attack-path-findings",
               "reference/attack-paths/list-available-attack-paths",
               "reference/attack-paths/list-domain-attack-paths-details",
               "reference/attack-paths/list-attack-path-sparkline-values",
-              "reference/attack-paths/list-finding-trends",
               "reference/attack-paths/update-attack-path-risk"
             ]
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1803,8 +1803,12 @@
       "destination": "/opengraph/extensions/okta/overview"
     },
     {
-        "source": "/collect-data/permissions",
-        "destination": "/collect-data/sharphound-data-permissions"
+      "source": "/collect-data/permissions",
+      "destination": "/collect-data/sharphound-data-permissions"
+    },
+    {
+      "source": "reference/custom-node-management/delete-custom-node",
+      "destination": "/reference/custom-node-management/delete-custom-node-deprecated"
     }
   ],
   "integrations": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3295,6 +3295,27 @@
           "404": {
             "$ref": "#/components/responses/not-found"
           },
+          "409": {
+            "description": "**Conflict**\nKind name is owned by a schema extension\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2024-02-19T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "customnodes",
+                      "message": "Conflict: kind name is owned by a schema extension"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "$ref": "#/components/responses/internal-server-error"
           }
@@ -8206,6 +8227,192 @@
           },
           "401": {
             "$ref": "#/components/responses/unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/node-kinds/{node_kind_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "node_kind_id",
+          "description": "Node Kind ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetNodeKind",
+        "summary": "Get Node Kind",
+        "description": "**Experimental** - Retrieves the details of a single OpenGraph node kind by its id, including its entity-panel info map keyed by info key.\n",
+        "tags": [
+          "OpenGraph (Experimental)",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.node-kind-response"
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "node_kind_id": 42,
+                    "name": "User",
+                    "display_name": "User",
+                    "description": "a user node kind",
+                    "is_display_kind": true,
+                    "icon": "user",
+                    "color": "#FFFFFF",
+                    "info": {
+                      "overview": {
+                        "title": "Overview",
+                        "position": 1,
+                        "markdown": {
+                          "content": "This is an overview panel for the node kind"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/relationship-kinds/{relationship_kind_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "relationship_kind_id",
+          "description": "Relationship Kind ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetRelationshipKind",
+        "summary": "Get Relationship Kind",
+        "description": "**Experimental** - Retrieves the details of a single OpenGraph relationship kind by its id, including its extension metadata and entity-panel info map keyed by info key.\n",
+        "tags": [
+          "OpenGraph (Experimental)",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.relationship-kind-response"
+                    }
+                  }
+                },
+                "examples": {
+                  "With info": {
+                    "summary": "Relationship kind with entity-panel info",
+                    "value": {
+                      "data": {
+                        "relationship_kind_id": 42,
+                        "name": "MemberOf",
+                        "description": "a membership relationship",
+                        "is_traversable": true,
+                        "extension": {
+                          "extension_id": 7,
+                          "name": "Active Directory",
+                          "display_name": "Active Directory",
+                          "namespace": "AD",
+                          "version": "v0.0.1"
+                        },
+                        "info": {
+                          "overview": {
+                            "title": "Overview",
+                            "position": 0,
+                            "markdown": {
+                              "content": "This relationship represents group membership."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "Without info": {
+                    "summary": "Relationship kind without entity-panel info",
+                    "value": {
+                      "data": {
+                        "relationship_kind_id": 43,
+                        "name": "HasSession",
+                        "description": "a session relationship",
+                        "is_traversable": true,
+                        "extension": {
+                          "extension_id": 7,
+                          "name": "Active Directory",
+                          "display_name": "Active Directory",
+                          "namespace": "AD",
+                          "version": "v0.0.1"
+                        },
+                        "info": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
           },
           "429": {
             "$ref": "#/components/responses/too-many-requests"
@@ -16752,6 +16959,280 @@
         }
       }
     },
+    "/api/v2/clients/{client_id}/management": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "QueueClientManagementOperation",
+        "summary": "Queues a management operation",
+        "description": "Endpoint for users to queue a management operation for a client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-management-operation-queue-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/{client_id}/artifacts/{artifact_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "DownloadClientArtifact",
+        "summary": "Download a management operation artifact for the client",
+        "description": "Downloads an operation artifact associated with the client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "**OK**\nThis response will contain the artifact file.\n",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteClientArtifact",
+        "summary": "Delete a management operation artifact for the client",
+        "description": "Deletes an operation artifact associated with the client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/available": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "summary": "Get available management operations",
+        "description": "Endpoint for clients to get next available management operations.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/model.client-management-operation"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/clients/management/start": {
       "parameters": [
         {
@@ -16901,6 +17382,356 @@
                     {
                       "context": "",
                       "message": "invalid management operation status transition"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "CreateClientArtifactUploadSession",
+        "summary": "Create an artifact upload session",
+        "description": "Endpoint for clients to create an artifact upload session and associate it\nwith a running management operation.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-artifact-upload-session-create-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session-create-response"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "management operation already has an associated artifact"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetClientArtifactUploadSession",
+        "summary": "Get an artifact upload session",
+        "description": "Endpoint for clients to get artifact upload-session state.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "part_number",
+          "description": "Artifact part number, starting at 1.",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          }
+        }
+      ],
+      "post": {
+        "operationId": "UploadClientArtifactPart",
+        "summary": "Upload an artifact part",
+        "description": "Endpoint for clients to upload one part of an artifact upload session.\n\nThe part checksum is supplied through the Content-Digest header. Supported\ndigest names are sha-256 and sha-512. The digest value must be a structured\nfield byte sequence containing the base64-encoded digest bytes, for example\nsha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "Content-Length",
+            "description": "Size of the uploaded artifact part, in bytes.",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "Content-Digest",
+            "description": "Structured field digest for the uploaded artifact part.",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact part already uploaded with a different checksum"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}/complete": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "CompleteClientArtifactUploadSession",
+        "summary": "Complete an artifact upload session",
+        "description": "Endpoint for clients to complete an artifact upload session after all\nexpected parts have been uploaded.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-artifact-upload-session-complete-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
                     }
                   ]
                 }
@@ -18269,6 +19100,110 @@
         }
       }
     },
+    "/api/v2/attack-paths/finding-types": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAttackPathFindingTypes",
+        "summary": "List attack path finding types",
+        "description": "Returns distinct attack path finding types available to the caller.\nResults are always returned in ascending order by `title`.\n",
+        "tags": [
+          "Attack Paths",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "environment_id",
+            "description": "Filter by one or more environment identifiers. Repeat the parameter to include multiple environments.\nResults are scoped to the caller's Environment access.\n",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "asset_group_tag_id",
+            "description": "Filter by asset group tag identifier. Supported predicates are `eq` and `neq`.\n",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.integer-strict"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "finding": {
+                            "type": "string",
+                            "description": "Finding name."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Finding title."
+                          }
+                        },
+                        "required": [
+                          "finding",
+                          "title"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "examples": {
+                  "Finding types": {
+                    "value": {
+                      "data": [
+                        {
+                          "finding": "Kerberoasting",
+                          "title": "Kerberoastable User Accounts"
+                        },
+                        {
+                          "finding": "T0WriteOwner",
+                          "title": "Write Owner"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/attack-paths": {
       "parameters": [
         {
@@ -18362,7 +19297,7 @@
         "parameters": [
           {
             "name": "sort_by",
-            "description": "Sortable columns are `severity`, `finding_type`, `finding`, `title`, `platform`, `environment_id`, `environment_name`,\n`zone_id`, `zone_name`, `source_principal_id`, `source_principal_kind`, `source_principal_name`, `target_principal_id`, `target_principal_kind`, `target_principal_name`, `status`, `first_seen`, `last_seen`.\n",
+            "description": "Sortable columns are `severity`, `finding_type`, `finding`, `title`, `platform`, `environment_id`, `environment_name`,\n`asset_group_tag_id`, `zone_name`, `source_principal_id`, `source_principal_kind`, `source_principal_name`, `target_principal_id`, `target_principal_kind`, `target_principal_name`, `status`, `first_seen`, `last_seen`.\n",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.query.sort-by"
@@ -18431,20 +19366,7 @@
           },
           {
             "name": "asset_group_tag_id",
-            "description": "Filter by one or more asset group tag identifiers. Repeat the parameter to include multiple asset group tags — results are the union of all specified values.\nCannot be combined with the `zone_id` filter.\n",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            }
-          },
-          {
-            "name": "zone_id",
-            "description": "Filter by a single zone identifier. Cannot be combined with `asset_group_tag_id`.",
+            "description": "Filter by asset group tag identifier.",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.string"
@@ -18548,7 +19470,7 @@
                 },
                 "examples": {
                   "Unified CSV export": {
-                    "value": "Severity,Finding,Title,FindingType,Platform,EnvironmentID,EnvironmentName,ZoneID,ZoneName,SourcePrincipalID,SourcePrincipalKind,SourcePrincipalName,TargetPrincipalID,TargetPrincipalKind,TargetPrincipalName,Status,FirstSeen,LastSeen\ncritical,T0GenericWrite,GenericWrite Privileges on Tier Zero Objects,relationship,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,RPATTON@CORP1.LAB.HOME-LABS.LOL,User,Robert Patton,ADMIN@CORP1.LAB.HOME-LABS.LOL,User,Domain Admin,active,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\nhigh,Kerberoasting,Kerberoastable User Accounts,list,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,,,, PSX_D_BA@CORP1.LAB.HOME-LABS.LOL,User,Backup Admin,accepted,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\n"
+                    "value": "Severity,Finding,Title,FindingType,Platform,EnvironmentID,EnvironmentName,AssetGroupTagID,ZoneName,SourcePrincipalID,SourcePrincipalKind,SourcePrincipalName,TargetPrincipalID,TargetPrincipalKind,TargetPrincipalName,Status,FirstSeen,LastSeen\ncritical,T0GenericWrite,GenericWrite Privileges on Tier Zero Objects,relationship,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,RPATTON@CORP1.LAB.HOME-LABS.LOL,User,Robert Patton,ADMIN@CORP1.LAB.HOME-LABS.LOL,User,Domain Admin,active,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\nhigh,Kerberoasting,Kerberoastable User Accounts,list,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,,,, PSX_D_BA@CORP1.LAB.HOME-LABS.LOL,User,Backup Admin,accepted,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\n"
                   }
                 }
               },
@@ -18604,9 +19526,9 @@
                                 "type": "string",
                                 "description": "Human-readable environment display name resolved from the graph. Falls back to environment_id when unavailable."
                               },
-                              "zone_id": {
+                              "asset_group_tag_id": {
                                 "type": "integer",
-                                "description": "Zone identifier (asset group tag id)."
+                                "description": "Asset group tag identifier."
                               },
                               "zone_name": {
                                 "type": "string",
@@ -18643,7 +19565,8 @@
                                   "active",
                                   "accepted",
                                   "remediated",
-                                  "deprecated"
+                                  "deprecated",
+                                  "orphaned"
                                 ]
                               },
                               "first_seen": {
@@ -18679,7 +19602,7 @@
                           "platform": "Active Directory",
                           "environment_id": "S-1-5-21-1974516972-3116780949-2584384717",
                           "environment_name": "CORP1.LAB.HOME-LABS.LOL",
-                          "zone_id": 1,
+                          "asset_group_tag_id": 1,
                           "zone_name": "Tier Zero",
                           "source_principal_id": "RPATTON@CORP1.LAB.HOME-LABS.LOL",
                           "source_principal_kind": "User",
@@ -18699,7 +19622,7 @@
                           "platform": "Active Directory",
                           "environment_id": "S-1-5-21-1974516972-3116780949-2584384717",
                           "environment_name": "CORP1.LAB.HOME-LABS.LOL",
-                          "zone_id": 1,
+                          "asset_group_tag_id": 1,
                           "zone_name": "Tier Zero",
                           "source_principal_id": "",
                           "source_principal_kind": "",
@@ -22461,15 +23384,12 @@
           },
           "position": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 0
           }
         }
       },
-      "model.kind-info-type-markdown": {
+      "model.kind-info-markdown": {
         "type": "object",
-        "required": [
-          "markdown"
-        ],
         "properties": {
           "markdown": {
             "type": "object",
@@ -22483,6 +23403,19 @@
             }
           }
         }
+      },
+      "model.kind-info-type-markdown": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.kind-info-markdown"
+          },
+          {
+            "type": "object",
+            "required": [
+              "markdown"
+            ]
+          }
+        ]
       },
       "model.kind-info-content": {
         "type": "object",
@@ -22748,33 +23681,14 @@
         "type": "object",
         "description": "A map of named info panels used in extension definitions.\nEach property key is a stable panel identifier and must match the pattern\n`^[a-z0-9_-]{1,128}$` (lowercase alphanumeric characters, hyphens, and underscores only).\nEach property value must be a valid KindInfo object with title, position, and content.\n",
         "additionalProperties": {
-          "type": "object",
-          "required": [
-            "title",
-            "position"
-          ],
-          "properties": {
-            "title": {
-              "type": "string",
-              "example": "Entity Panel Section"
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/model.kind-info-base"
             },
-            "position": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "markdown": {
-              "type": "object",
-              "required": [
-                "content"
-              ],
-              "properties": {
-                "content": {
-                  "type": "string",
-                  "example": "This is markdown content for the info panel"
-                }
-              }
+            {
+              "$ref": "#/components/schemas/model.kind-info-markdown"
             }
-          }
+          ]
         }
       },
       "model.graph-extension.payload": {
@@ -22947,6 +23861,101 @@
           },
           "is_builtin": {
             "type": "boolean"
+          }
+        }
+      },
+      "model.extension-details": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "extension_id": {
+            "type": "integer",
+            "format": "int32",
+            "example": 7
+          },
+          "name": {
+            "type": "string",
+            "example": "AD"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "Active Directory"
+          },
+          "namespace": {
+            "type": "string",
+            "example": "AD"
+          },
+          "version": {
+            "type": "string",
+            "example": "v1"
+          }
+        }
+      },
+      "model.node-kind-response": {
+        "type": "object",
+        "properties": {
+          "node_kind_id": {
+            "type": "integer",
+            "format": "int32",
+            "example": 42
+          },
+          "name": {
+            "type": "string",
+            "example": "User"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "User"
+          },
+          "description": {
+            "type": "string",
+            "example": "a user node kind"
+          },
+          "is_display_kind": {
+            "type": "boolean",
+            "example": true
+          },
+          "icon": {
+            "type": "string",
+            "example": "user"
+          },
+          "color": {
+            "type": "string",
+            "example": "#FFFFFF"
+          },
+          "extension": {
+            "$ref": "#/components/schemas/model.extension-details"
+          },
+          "info": {
+            "$ref": "#/components/schemas/model.graph-extension.kind-info-definition"
+          }
+        }
+      },
+      "model.relationship-kind-response": {
+        "type": "object",
+        "properties": {
+          "relationship_kind_id": {
+            "type": "integer",
+            "format": "int32",
+            "example": 42
+          },
+          "name": {
+            "type": "string",
+            "example": "MemberOf"
+          },
+          "description": {
+            "type": "string",
+            "example": "a membership relationship"
+          },
+          "is_traversable": {
+            "type": "boolean",
+            "example": true
+          },
+          "info": {
+            "$ref": "#/components/schemas/model.graph-extension.kind-info-definition"
+          },
+          "extension": {
+            "$ref": "#/components/schemas/model.extension-details"
           }
         }
       },
@@ -23673,6 +24682,125 @@
           }
         ]
       },
+      "enum.client-management-operation-type": {
+        "type": "string",
+        "enum": [
+          "support_bundle"
+        ]
+      },
+      "enum.client-management-operation-status": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "running",
+          "succeeded",
+          "failed",
+          "canceled"
+        ]
+      },
+      "enum.artifact-status": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "uploading",
+          "complete",
+          "failed",
+          "canceled"
+        ]
+      },
+      "model.client-support-bundle": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.uuid"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "client_id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "artifact_id": {
+                "type": "string",
+                "format": "uuid",
+                "nullable": true
+              },
+              "type": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/enum.client-management-operation-type"
+                  }
+                ]
+              },
+              "status": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/enum.client-management-operation-status"
+                  }
+                ]
+              },
+              "started_at": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.time.response"
+                  }
+                ]
+              },
+              "completed_at": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.time.response"
+                  }
+                ]
+              },
+              "execution_time": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "artifact_status": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/enum.artifact-status"
+                  }
+                ]
+              },
+              "artifact_size": {
+                "type": "integer",
+                "format": "int64",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "model.client-support-bundle-summary": {
+        "type": "object",
+        "properties": {
+          "current": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/model.client-support-bundle"
+              }
+            ]
+          },
+          "last_finished": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/model.client-support-bundle"
+              }
+            ]
+          }
+        }
+      },
       "model.client-display": {
         "allOf": [
           {
@@ -23738,38 +24866,33 @@
               },
               "type": {
                 "$ref": "#/components/schemas/enum.client-type"
+              },
+              "support_bundle_summary": {
+                "$ref": "#/components/schemas/model.client-support-bundle-summary"
               }
             }
           }
         ]
       },
-      "model.client-management-operation-start-request": {
+      "model.client-management-operation-queue-request": {
         "type": "object",
         "required": [
-          "operation_id"
+          "operation_type",
+          "execution_time"
         ],
         "properties": {
-          "operation_id": {
+          "operation_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/enum.client-management-operation-type"
+              }
+            ]
+          },
+          "execution_time": {
             "type": "string",
-            "format": "uuid"
+            "format": "date-time"
           }
         }
-      },
-      "enum.client-management-operation-type": {
-        "type": "string",
-        "enum": [
-          "support_bundle"
-        ]
-      },
-      "enum.client-management-operation-status": {
-        "type": "string",
-        "enum": [
-          "queued",
-          "running",
-          "succeeded",
-          "failed",
-          "canceled"
-        ]
       },
       "model.client-management-operation": {
         "allOf": [
@@ -23785,12 +24908,9 @@
                 "readOnly": true
               },
               "artifact_id": {
-                "readOnly": true,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/null.uuid"
-                  }
-                ]
+                "type": "string",
+                "format": "uuid",
+                "nullable": true
               },
               "type": {
                 "readOnly": true,
@@ -23809,14 +24929,16 @@
                 ]
               },
               "requested_by_user_id": {
-                "readOnly": true,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/null.uuid"
-                  }
-                ]
+                "type": "string",
+                "format": "uuid",
+                "nullable": true
               },
               "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "updated_at": {
                 "type": "string",
                 "format": "date-time",
                 "readOnly": true
@@ -23846,6 +24968,18 @@
           }
         ]
       },
+      "model.client-management-operation-start-request": {
+        "type": "object",
+        "required": [
+          "operation_id"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "model.client-management-operation-end-request": {
         "type": "object",
         "required": [
@@ -23864,6 +24998,208 @@
               "failed",
               "canceled"
             ]
+          }
+        }
+      },
+      "enum.artifact-type": {
+        "type": "string",
+        "enum": [
+          "support_bundle"
+        ]
+      },
+      "enum.checksum-algorithm": {
+        "type": "string",
+        "enum": [
+          "sha256",
+          "sha512"
+        ]
+      },
+      "model.client-artifact-upload-session-create-request": {
+        "type": "object",
+        "required": [
+          "operation_id",
+          "artifact_type",
+          "total_size",
+          "part_count",
+          "checksum_algorithm",
+          "checksum"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "artifact_type": {
+            "$ref": "#/components/schemas/enum.artifact-type"
+          },
+          "total_size": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Optional upload part size. When omitted or zero, the server default is used."
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          },
+          "content_type": {
+            "type": "string",
+            "description": "Optional artifact content type. Support bundle uploads default to application/zip."
+          },
+          "checksum_algorithm": {
+            "$ref": "#/components/schemas/enum.checksum-algorithm"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for the completed artifact."
+          }
+        }
+      },
+      "model.client-artifact-upload-session-create-response": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/enum.artifact-status"
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "missing_parts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "management_operation": {
+            "$ref": "#/components/schemas/model.client-management-operation"
+          }
+        }
+      },
+      "model.client-artifact-upload-session-part": {
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for this uploaded part."
+          },
+          "offset_start": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          }
+        }
+      },
+      "model.client-artifact-upload-session": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": "string"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/enum.artifact-status"
+          },
+          "total_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "checksum_algorithm": {
+            "$ref": "#/components/schemas/enum.checksum-algorithm"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for the completed artifact."
+          },
+          "uploaded_parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.client-artifact-upload-session-part"
+            }
+          },
+          "missing_parts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expires_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          }
+        }
+      },
+      "model.client-artifact-upload-session-complete-request": {
+        "type": "object",
+        "required": [
+          "operation_id"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/docs/reference/attack-paths/list-attack-path-finding-types.mdx
+++ b/docs/reference/attack-paths/list-attack-path-finding-types.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/attack-paths/finding-types
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/complete-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/complete-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts/{artifact_id}/complete
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/create-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/create-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/delete-a-management-operation-artifact-for-the-client.mdx
+++ b/docs/reference/clients/delete-a-management-operation-artifact-for-the-client.mdx
@@ -1,0 +1,5 @@
+---
+openapi: delete /api/v2/clients/{client_id}/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/download-a-management-operation-artifact-for-the-client.mdx
+++ b/docs/reference/clients/download-a-management-operation-artifact-for-the-client.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/{client_id}/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/get-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/get-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/management/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/get-available-management-operations.mdx
+++ b/docs/reference/clients/get-available-management-operations.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/management/available
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/queues-a-management-operation.mdx
+++ b/docs/reference/clients/queues-a-management-operation.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/{client_id}/management
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/clients/upload-an-artifact-part.mdx
+++ b/docs/reference/clients/upload-an-artifact-part.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only"/>

--- a/docs/reference/custom-node-management/delete-custom-node-deprecated.mdx
+++ b/docs/reference/custom-node-management/delete-custom-node-deprecated.mdx
@@ -1,0 +1,6 @@
+---
+openapi: delete /api/v2/custom-nodes/{kind_name}
+deprecated: true
+---
+
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/reference/custom-node-management/delete-custom-node.mdx
+++ b/docs/reference/custom-node-management/delete-custom-node.mdx
@@ -1,6 +1,0 @@
----
-openapi: delete /api/v2/custom-nodes/{kind_name}
-deprecated: true
----
-
-<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/reference/opengraph-experimental/get-node-kind.mdx
+++ b/docs/reference/opengraph-experimental/get-node-kind.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/node-kinds/{node_kind_id}
+---
+
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>

--- a/docs/reference/opengraph-experimental/get-relationship-kind.mdx
+++ b/docs/reference/opengraph-experimental/get-relationship-kind.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/relationship-kinds/{relationship_kind_id}
+---
+
+<img noZoom src="/assets/enterprise-AND-community-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise and CE"/>


### PR DESCRIPTION
## Summary

This pull request (PR) updates the OpenAPI spec that we use to generate the REST API reference for the v9.6.0 release.

Aside from updates to request and response properties for existing paths, the following significant updates were made:

- New endpoints
   - `GET /api/v2/attack-paths/finding-types`
   - `POST /api/v2/clients/management/artifacts`
   - `GET /api/v2/clients/management/artifacts/{artifact_id}`
   - `POST /api/v2/clients/management/artifacts/{artifact_id}/complete`
   - `POST /api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}`
   - `GET /api/v2/clients/management/available`
   - `DELETE /api/v2/clients/{client_id}/artifacts/{artifact_id}`
   - `GET /api/v2/clients/{client_id}/artifacts/{artifact_id}`
   - `POST /api/v2/clients/{client_id}/management`
   - `GET /api/v2/node-kinds/{node_kind_id}`
   - `GET /api/v2/relationship-kinds/{relationship_kind_id}`

See attachment for oasdiff: 
[openapi_change.log](https://github.com/user-attachments/files/30910603/openapi_change.log)