### PR TITLE
Clarify "v" prefix requirment for schema.version field

### DIFF
--- a/docs/opengraph/developer/graph-definition.mdx
+++ b/docs/opengraph/developer/graph-definition.mdx
@@ -135,7 +135,7 @@ Defines metadata about the extension itself.
   Human-readable label shown for this extension in BloodHound.
 </ResponseField>
 <ResponseField name="version" type="string" required>
-  Extension schema version in semantic version format, for example `v1.0.0`.
+  Extension schema version, prefixed with `v` followed by semantic version format, for example `v1.0.0`.
 </ResponseField>
 <ResponseField name="namespace" type="string" required>
   Namespace key used as a prefix for all `name` fields in the `node_kinds`, `relationship_kinds`, and `relationship_findings` arrays to indicate that the data belongs to that namespace.


### PR DESCRIPTION
## Summary

The "v" prefix in the schema [version](https://bloodhound.specterops.io/opengraph/developer/graph-definition#param-version) field is required. Make it explicit in the reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `schema.version` guidance to require a `v` prefix before the semantic version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->