### PR TITLE
Move graph theory page to top of group sidebar nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -463,6 +463,7 @@
               {
                 "group": "Build an Extension",
                 "pages": [
+                  "opengraph/developer/graph-theory",
                   "opengraph/developer/graph-definition",
                   {
                     "group": "Graph Data",
@@ -473,7 +474,6 @@
                       "opengraph/developer/edges"
                     ]
                   },
-                  "opengraph/developer/graph-theory",
                   "opengraph/developer/custom-icons",
                   "opengraph/developer/api",
                   "opengraph/developer/best-practices",


### PR DESCRIPTION
## Summary

Based on recent user feedback, moving the **Graph Theory** page to the top of the **Build an Extension** group in the the sidebar nav.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Build an Extension” navigation to include the Graph Theory developer guide in the appropriate position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->