### PR TITLE
BED-8341: Add new optimizing tenant status for v9.6.0

### DIFF
--- a/docs/collect-data/enterprise-collection/monitor.mdx
+++ b/docs/collect-data/enterprise-collection/monitor.mdx
@@ -21,6 +21,7 @@ Tenant status (also known as [datapipe status](/reference/datapipe/get-datapipe-
 | **Idle** | The tenant is waiting for new data. |
 | **Ingesting** | Data is actively being ingested from one or more collection jobs or file uploads. |
 | **Analyzing** | Analysis is actively running on ingested data. |
+| **Optimizing** | BloodHound is optimizing graph storage after startup or analysis to keep PostgreSQL-backed graph performance responsive. |
 | **Pruning** | Analysis is almost complete; stale objects, edges, and disconnected nodes are being removed based on [data reconciliation](/collect-data/enterprise-collection/data-retention) settings. |
 | **Purging** | Data is actively being deleted from the database (for example, you used the **Database Management** page to delete data). |
 


### PR DESCRIPTION
## Summary

The [Tenant Status](https://bloodhound.specterops.io/collect-data/enterprise-collection/monitor#tenant-status) section should include the new "Optimizing" status introduced in v9.6.0.