### PR TITLE
DOCS-22: v9.6.0 release notes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -928,15 +928,15 @@
                 "group": "Release Notes",
                 "pages": [
                   "resources/release-notes/summary",
+                  "resources/release-notes/2026-08-17",
                   "resources/release-notes/2026-08-04",
-                  "resources/release-notes/2026-07-29",
-                  
                   {
                     "group": "Archive",
                     "pages": [
                       {
                         "group": "2026",
                         "pages": [
+                          "resources/release-notes/2026-07-29",
                           "resources/release-notes/2026-07-07",
                           "resources/release-notes/2026-06-17",
                           "resources/release-notes/2026-05-28",

--- a/docs/resources/release-notes/2026-07-29.mdx
+++ b/docs/resources/release-notes/2026-07-29.mdx
@@ -85,7 +85,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   <FeatureFlagNote />
 
-  BloodHound can now store OpenGraph object IDs exactly as supplied by an extension. SharpHound already sends Active Directory object IDs as fully uppercased values, and current AzureHound versions send Microsoft Entra ID object IDs as fully uppercased values. This ensures consistent data as BloodHound removes server-side object ID normalization.
+  BloodHound can now store OpenGraph object IDs exactly as supplied by an extension. The latest versions of SharpHound and AzureHound now send all Active Directory and Microsoft Entra ID object IDs as fully uppercased values, which ensures consistent data as BloodHound removes server-side object ID normalization.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>

--- a/docs/resources/release-notes/2026-07-29.mdx
+++ b/docs/resources/release-notes/2026-07-29.mdx
@@ -85,7 +85,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   <FeatureFlagNote />
 
-  BloodHound can now store OpenGraph object IDs exactly as supplied by an extension. The latest versions of SharpHound and AzureHound now send all Active Directory and Microsoft Entra ID object IDs as fully uppercased values, which ensures consistent data as BloodHound removes server-side object ID normalization.
+  BloodHound can now store OpenGraph object IDs exactly as supplied by an extension. SharpHound already sends Active Directory object IDs as fully uppercased values, and current AzureHound versions send Microsoft Entra ID object IDs as fully uppercased values. This ensures consistent data as BloodHound removes server-side object ID normalization.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -1,0 +1,163 @@
+---
+title: 2026-08-17 Release Notes
+description: Learn about new features, enhancements, and fixed issues in BloodHound.
+sidebarTitle: "2026-08-17"
+---
+
+import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-08-17 | v9.6.0 | v0.3.0 | v2.15.0 | v3.1.0 |
+
+<CollectorDeprecationNotice />
+
+<Tip>
+  Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
+</Tip>
+
+<Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
+  {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567*/}
+  ## Findings Table Open Beta
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Review and filter Attack Path findings from the new Findings table in BloodHound Enterprise.
+
+  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
+</Update>
+
+<Update label="OpenHound" description="New Feature" tags={["GitHub"]}>
+  {/*BED-9185*/}
+  {/* TODO: BED-9185 is Unrefined in Jira; follow up before publishing. */}
+  ## GitHub Self-Hosted Runner Modeling
+
+  Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes with expanded OpenHound GitHub collection and graph modeling.
+
+  The OpenHound GitHub collector now models enterprise runner groups, enterprise runners, organization runner groups, and runner membership. New relationships expose runner group assignment, inheritance, repository access, and composed repository-to-runner access paths.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-9051, BED-8964, BED-8756, BED-8757*/}
+  ## OpenGraph Management and Kind Metadata Improvements
+
+  Manage OpenGraph extensions by default and retrieve node and relationship kind metadata more easily.
+
+  The **OpenGraph Management** page is now enabled by default. BloodHound also validates markdown supplied in OpenGraph extension remediations and Entity Panel kind information, and adds experimental APIs to retrieve [node kind](/reference/opengraph-experimental/get-node-kind) and [relationship kind](/reference/opengraph-experimental/get-relationship-kind) details by graph-assigned kind ID.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["PostgreSQL"]}>
+  {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
+  ## PostgreSQL Graph Storage Optimization
+
+  Improve PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
+
+  BloodHound now enables graph storage optimization by default, logs optimization timing, and runs `VACUUM` and `ANALYZE` during optimization so PostgreSQL query plans use current partition statistics. Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions on PostgreSQL graph databases.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  {/*BED-8602*/}
+  ## Findings for Uncollected Environments
+
+  Keep finding status clearer when previously collected environments become uncollected.
+
+  BloodHound now archives findings associated with uncollected environments using the **Unassociated Environment** status, helping you separate active findings from findings that no longer have an associated collected environment.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-9096, BED-8973*/}
+  {/* TODO: BED-9096 is Unrefined in Jira; follow up before publishing. */}
+  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
+  ## Collector Compatibility for Raw Object ID Ingest
+
+  Keep graph identities stable during the transition to collector-side Object ID normalization.
+
+  BloodHound Enterprise now rejects older unsupported OpenHound collector versions when raw Object ID ingest is enabled. This compatibility check helps prevent case-sensitive OpenGraph IDs from being ingested with collector versions that still depend on server-side normalization.
+</Update>
+
+<Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8834, BED-8835*/}
+  ## SharpHound Enterprise Support Bundles
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Collect and upload SharpHound Enterprise support bundles from managed collectors with less manual intervention.
+
+  SharpHound Enterprise collectors can now poll for management operations, package current logs into a support bundle, and upload the bundle through resumable, checksum-verified upload sessions.
+</Update>
+
+<Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8968*/}
+  ## Uppercase Active Directory Object IDs
+
+  Preserve existing Active Directory ingest behavior as BloodHound moves Object ID normalization from server-side ingest into collectors.
+
+  SharpHound and SharpHound Enterprise now normalize Active Directory object identifiers to uppercase before output, keeping case-insensitive AD graph identities stable across the raw Object ID ingest migration.
+</Update>
+
+<Update label="AzureHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8944, BED-9100*/}
+  ## AzureHound Identifier Casing Updates
+
+  Preserve stable Entra ID graph identities with expanded collector-side identifier casing normalization.
+
+  AzureHound now normalizes Object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8973*/}
+  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
+  ## OpenHound Okta and Jamf Object ID Normalization
+
+  Preserve stable Okta and Jamf graph identities as BloodHound moves Object ID normalization from server-side ingest into collectors.
+
+  The OpenHound Okta and Jamf collectors now uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive.
+</Update>
+
+<Update label="BloodHound" tags={["Fixed Issues"]}>
+  ## Administration
+
+  - {/*BED-9062*/} Resolved an issue where the **Manage Clients** table in BloodHound Enterprise could show a horizontal scrollbar when column content became too wide.
+  - {/*BED-7910*/} Resolved an issue where the **Download Collectors** page could show redundant scrollbars.
+
+  ## Cypher
+
+  - {/*BED-8967*/} Resolved an issue where backtick-escaped Cypher property accessors did not work correctly for property names that included special characters.
+  - {/*BED-8321*/} Resolved an issue where directed multi-hop pattern predicates could lose row correlation on PostgreSQL graph databases when an outer-bound node appeared after the root traversal step.
+
+  ## Database Management
+
+  {/*BED-8799*/} Resolved an issue where selecting **All graph data** on the **Database Management** page did not call the correct full-graph deletion path.
+
+  ## Explore and UI
+
+  - {/*BED-9094*/} Resolved an issue where pages using the shared `PageWithTitle` layout could lose horizontal spacing below the `xl` breakpoint.
+  - {/*BED-9057*/} Resolved an issue where table virtualization in Explore could stop working and slow rendering for large result sets.
+  - {/*BED-8997*/} Resolved an issue where hovering over environment or zone selector options could invert inline icon colors.
+
+  ## OpenGraph
+
+  - {/*BED-9076*/} Resolved an issue where OpenGraph nodes with a `ref` property could crash the Entity Panel.
+  - {/*BED-9059*/} Resolved an issue where Attack Path pages could display OpenGraph object types instead of object glyphs.
+
+  ## Privilege Zones
+
+  - {/*BED-8922*/} Improved the **Privilege Zone History** display for non-system records with empty notes.
+  - {/*BED-8926*/} Resolved an issue where the Certification view did not preserve `environmentId` in the URL when navigating back from another Privilege Zone view.
+  - {/*BED-8284*/} Resolved an issue where Privilege Zone Cypher rules could fail to tag all expected objects.
+</Update>
+
+<Update label="OpenHound" tags={["Fixed Issues"]}>
+  ## Okta
+
+  - {/*BED-9222*/} {/* TODO: BED-9222 is Unrefined in Jira; follow up before publishing. */} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired. The collector now refreshes OAuth tokens during collection and retries eligible token-related authentication failures once.
+  - {/*BED-9238, BED-9328*/} {/* TODO: BED-9238 is In Progress in Jira; follow up before publishing. */} Resolved an issue where Okta Org2Org group synchronization relationships could fail to resolve because group names and application-group matchers used inconsistent casing and property names.
+  - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing when agent host matching did not use the complete computer `sAMAccountName` and AD domain.
+</Update>
+
+<Update label="AzureHound" tags={["Fixed Issues"]}>
+  ## Data Collection
+
+  {/*GH-205*/} Resolved an issue where AzureHound uppercased `appId` values that must remain case-sensitive.
+</Update>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -11,8 +11,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-08-17 | v9.6.0 | v0.3.0 | v2.15.0 | v3.1.0 |
 
-<CollectorDeprecationNotice />
-
 <Tip>
   Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
 </Tip>
@@ -47,14 +45,27 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-9096, BED-8973*/}
+  {/*BED-9096, BED-8973, BED-8968, BED-8944, BED-9100*/}
   {/* TODO: BED-9096 is Unrefined in Jira; follow up before publishing. */}
   {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
-  ## Collector Compatibility for Raw Object ID Ingest
+  ## Collector Compatibility for Case-Sensitive OpenGraph Object IDs
 
-  Keep graph identities stable during the transition to collector-side Object ID normalization.
+  Keep graph identities stable as BloodHound prepares to support case-sensitive OpenGraph Object IDs by moving Object ID normalization into AzureHound and OpenHound collectors.
 
-  BloodHound Enterprise now rejects older unsupported OpenHound collector versions when raw Object ID ingest is enabled. This compatibility check helps prevent case-sensitive OpenGraph IDs from being ingested with collector versions that still depend on server-side normalization.
+  <CollectorDeprecationNotice />
+
+  BloodHound introduced the supporting case-sensitive OpenGraph ingest behavior in the [2026-07-29 release notes](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids). This 2026-08-17 release updates collector compatibility so BloodHound Enterprise can preserve case-sensitive OpenGraph IDs without changing the effective case-insensitive behavior of Active Directory, Microsoft Entra ID, Okta, and Jamf identities.
+
+  This release includes the following collector compatibility changes:
+
+  | Component | Change |
+  | --- | --- |
+  | BloodHound Enterprise | Rejects older unsupported OpenHound collector versions when raw Object ID ingest is enabled. This prevents case-sensitive OpenGraph IDs from being ingested by collector versions that still depend on server-side normalization. |
+  | OpenHound Okta and Jamf collectors | Uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive. |
+  | AzureHound | Normalizes Object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
+  | SharpHound and SharpHound Enterprise | Already normalize Active Directory object identifiers to uppercase before output. SharpHound is not included in the AzureHound and OpenHound collector deprecation associated with raw Object ID ingest. |
+
+  Upgrade AzureHound and OpenHound before the release the week of November 8, 2026 to keep data collection compatible with current BloodHound versions.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>
@@ -65,34 +76,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes with expanded OpenHound GitHub collection and graph modeling.
 
   The OpenHound GitHub collector now models enterprise runner groups, enterprise runners, organization runner groups, and runner membership. New relationships expose runner group assignment, inheritance, repository access, and composed repository-to-runner access paths.
-</Update>
-
-<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8973*/}
-  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
-  ## OpenHound Okta and Jamf Object ID Normalization
-
-  Preserve stable Okta and Jamf graph identities as BloodHound moves Object ID normalization from server-side ingest into collectors.
-
-  The OpenHound Okta and Jamf collectors now uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive.
-</Update>
-
-<Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8968*/}
-  ## Uppercase Active Directory Object IDs
-
-  Preserve existing Active Directory ingest behavior as BloodHound moves Object ID normalization from server-side ingest into collectors.
-
-  SharpHound and SharpHound Enterprise now normalize Active Directory object identifiers to uppercase before output, keeping case-insensitive AD graph identities stable across the raw Object ID ingest migration.
-</Update>
-
-<Update label="AzureHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8944, BED-9100*/}
-  ## AzureHound Identifier Casing Updates
-
-  Preserve stable Entra ID graph identities with expanded collector-side identifier casing normalization.
-
-  AzureHound now normalizes Object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -38,7 +38,7 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   | Component | Change |
   | --- | --- |
   | BloodHound Enterprise | Rejects client and file ingest uploads from deprecated AzureHound and OpenHound versions after the ingest change is enabled.<br/><br/>This prevents collector output that depends on server-side normalization from creating duplicate nodes or identity mismatches. |
-  | OpenHound Okta and Jamf collectors | Uppercase the object ID values they own before output. |
+  | OpenHound Okta and Jamf collectors | Uppercase the object ID values before output. |
   | OpenHound GitHub collector | Preserves case-sensitive GitHub object IDs before output. |
   | AzureHound | Uppercases object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
   | SharpHound | No change. SharpHound already normalizes Active Directory object identifiers to uppercase before output. |

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -74,14 +74,21 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["PostgreSQL"]}>
-  {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
+  {/*BED-8341, BED-9170, BED-9161*/}
   ## PostgreSQL Graph Storage Optimization
 
   Get more reliable PostgreSQL graph database performance with storage optimization.
 
   BloodHound now runs graph storage optimization automatically after key ingest and analysis workflows and records timing details in the logs. These changes help large PostgreSQL-backed environments stay responsive as graph data changes over time.
-  
-  Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Database Management"]}>
+  {/*BED-8787, BED-8832*/}
+  ## Faster Graph Data Deletion
+
+  Delete graph data from PostgreSQL-backed environments more quickly with **Database Management**.
+
+  BloodHound now uses optimized deletion paths for full graph wipes and targeted deletions by source kind or relationship type. These changes reduce the time it takes to delete large datasets.
 </Update>
 
 <Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -134,12 +134,25 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 <Update label="OpenHound" tags={["Fixed Issues"]}>
   ## GitHub
 
-  - {/*BED-9166*/} Resolved an issue where GitHub App authentication compatibility could be limited. The collector now accepts either `client_id` or `app_id` as the installation JWT issuer, preferring `client_id` when available while continuing to support older GitHub Enterprise Server responses.
+  - {/*BED-9166*/} Resolved an issue where GitHub App authentication compatibility could be limited.
+  
+    The collector now accepts either `client_id` or `app_id` as the installation JWT issuer, preferring `client_id` when available while continuing to support older GitHub Enterprise Server responses.
 
   ## Okta
 
-  - {/*BED-9253*/} Resolved an issue where SAML issuer identifiers could be inaccurate. BloodHound now prefers runtime metadata over configured issuer templates, no longer emits unresolved Okta expressions as issuer identifiers, and retains diagnostics when issuer evidence is missing, unresolved, or superseded.
-  - {/*BED-9222*/} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired. Access tokens now refresh before expiration, eligible authentication failures retry once, and transient refresh failures can reuse a still-valid token. SSWS authentication is unchanged.
-  - {/*BED-9238*/} Resolved an issue where Okta org-to-org group synchronization relationships could fail to resolve. Group names now match using normalized uppercase values, and application group matching uses the correct `okta_domain` property.
-  - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing. `Okta_HostsAgent` now matches the complete computer `sAMAccountName` and AD domain, preserving valid hostname prefixes and correctly targeting Computer nodes.
+  - {/*BED-9253*/} Resolved an issue where SAML issuer identifiers could be inaccurate.
+  
+    BloodHound now prefers runtime metadata over configured issuer templates, no longer emits unresolved Okta expressions as issuer identifiers, and retains diagnostics when issuer evidence is missing, unresolved, or superseded.
+  
+  - {/*BED-9222*/} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired.
+  
+    Access tokens now refresh before expiration, eligible authentication failures retry once, and transient refresh failures can reuse a still-valid token. SSWS authentication is unchanged.
+  
+  - {/*BED-9238*/} Resolved an issue where Okta org-to-org group synchronization relationships could fail to resolve.
+  
+    Group names now match using normalized uppercase values, and application group matching uses the correct `okta_domain` property.
+  
+  - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing.
+  
+    `Okta_HostsAgent` now matches the complete computer `sAMAccountName` and AD domain, preserving valid hostname prefixes and correctly targeting Computer nodes.
 </Update>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -93,6 +93,10 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   Try the new [Findings Table](/analyze-data/findings/table-view) view on the **Attack Paths** page.
 
   Use it to review a list of findings, compare finding state across environments and Privilege Zones, and focus high-volume result sets with multi-select filters for severity, platform, environment, zone, and status.
+
+  <Note>
+    **Known issue:** Filtering environments with special characters in the Findings Table may not work as expected. This issue affects customers participating in the AWS beta.
+  </Note>
   
   <BetaAccessNote feature="Findings Table" />
 </Update>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -5,6 +5,7 @@ sidebarTitle: "2026-08-17"
 ---
 
 import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
 |     |     |     |     |     |
 | --- | --- | --- | --- | --- |
@@ -79,13 +80,15 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 
 <Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
   {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567, BED-8602*/}
-  ## Findings Table Open Beta
+  ## Findings Table <Badge color="yellow">Beta</Badge>
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Review and filter Attack Path findings from the new Findings table in BloodHound Enterprise.
+  Triage findings at scale with the new [Findings Table](/analyze-data/findings/table-view) view on the **Attack Paths** page in BloodHound Enterprise.
 
-  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, archives findings associated with uncollected environments using the **Unassociated Environment** status, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
+  Use it to review a dense list of findings, compare finding state across environments and Privilege Zones, and focus high-volume result sets with multi-select filters for severity, platform, environment, zone, and status.
+  
+  <BetaAccessNote feature="Findings Table" />
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -132,12 +132,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   ## Okta
 
   - {/*BED-9222*/} {/* TODO: BED-9222 is Unrefined in Jira; follow up before publishing. */} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired. The collector now refreshes OAuth tokens during collection and retries eligible token-related authentication failures once.
-  - {/*BED-9238, BED-9328*/} {/* TODO: BED-9238 is In Progress in Jira; follow up before publishing. */} Resolved an issue where Okta Org2Org group synchronization relationships could fail to resolve because group names and application-group matchers used inconsistent casing and property names.
+  - {/*BED-9238*/} {/* TODO: BED-9238 is In Progress in Jira; follow up before publishing. */} Resolved an issue where Okta Org2Org group synchronization relationships could fail to resolve because group names and application-group matchers used inconsistent casing and property names.
   - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing when agent host matching did not use the complete computer `sAMAccountName` and AD domain.
-</Update>
-
-<Update label="AzureHound" tags={["Fixed Issues"]}>
-  ## Data Collection
-
-  {/*GH-205*/} Resolved an issue where AzureHound uppercased `appId` values that must remain case-sensitive.
 </Update>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -50,22 +50,22 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
   ## Collector Compatibility for Case-Sensitive OpenGraph Object IDs
 
-  Keep graph identities stable as BloodHound prepares to support case-sensitive OpenGraph Object IDs by moving Object ID normalization into AzureHound and OpenHound collectors.
+  BloodHound keeps graph identities stable as it prepares default support for case-sensitive OpenGraph object IDs, by moving object ID normalization into the AzureHound and OpenHound collectors.
 
-  <CollectorDeprecationNotice />
-
-  BloodHound introduced the supporting case-sensitive OpenGraph ingest behavior in the [2026-07-29 release notes](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids). This 2026-08-17 release updates collector compatibility so BloodHound Enterprise can preserve case-sensitive OpenGraph IDs without changing the effective case-insensitive behavior of Active Directory, Microsoft Entra ID, Okta, and Jamf identities.
+  BloodHound introduced support for [case-sensitive OpenGraph object IDs](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids) in the 2026-07-29 release.
+  
+  This release updates collector compatibility so BloodHound can preserve case-sensitive OpenGraph object IDs without changing the effective case-insensitive behavior of Active Directory, Microsoft Entra ID, Okta, and Jamf identities.
 
   This release includes the following collector compatibility changes:
 
   | Component | Change |
   | --- | --- |
-  | BloodHound Enterprise | Rejects older unsupported OpenHound collector versions when raw Object ID ingest is enabled. This prevents case-sensitive OpenGraph IDs from being ingested by collector versions that still depend on server-side normalization. |
-  | OpenHound Okta and Jamf collectors | Uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive. |
-  | AzureHound | Normalizes Object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
-  | SharpHound and SharpHound Enterprise | Already normalize Active Directory object identifiers to uppercase before output. SharpHound is not included in the AzureHound and OpenHound collector deprecation associated with raw Object ID ingest. |
+  | BloodHound | Rejects older unsupported OpenHound collector versions when the case-sensitive OpenGraph ID feature is enabled.<br/><br/>This prevents case-sensitive OpenGraph object IDs from being ingested by collector versions that still depend on server-side normalization. |
+  | OpenHound Okta and Jamf collectors | Uppercases the object ID values they own before output. GitHub object IDs remain case-sensitive. |
+  | AzureHound | Normalizes object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
+  | SharpHound | No change. SharpHound already normalizes Active Directory object identifiers to uppercase before output. |
 
-  Upgrade AzureHound and OpenHound before the release the week of November 8, 2026 to keep data collection compatible with current BloodHound versions.
+  <CollectorDeprecationNotice />
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -23,17 +23,24 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
   BloodHound introduced [case-sensitive OpenGraph object IDs](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids) (a SpecterOps-managed feature) in the 2026-07-29 release. This feature is not enabled by default.
   
-  This release updates collector compatibility so BloodHound can preserve case-sensitive OpenGraph object IDs without changing the effective case-insensitive behavior of Active Directory, Microsoft Entra ID, Okta, and Jamf identities.
+  This release updates collector compatibility as BloodHound moves property-value normalization out of ingest and into collectors. BloodHound will ingest object IDs, names, and other properties exactly as collector output supplies them.
 
-  These updates help keep graph identities stable while object ID normalization moves into the AzureHound and OpenHound collectors. This groundwork prepares BloodHound to enable case-sensitive OpenGraph object IDs by default in a future release.
+  This change lets BloodHound preserve case-sensitive OpenGraph object IDs while keeping existing Active Directory, Microsoft Entra ID, Okta, and Jamf graph identities stable. AzureHound and the OpenHound Okta and Jamf collectors now uppercase the object ID and related identifier values they own before output. GitHub object IDs remain case-sensitive to prevent collisions between distinct GitHub objects.
+
+  <Warning>
+    BloodHound treats node object IDs as case-sensitive. After this ingest change is enabled, submitting the same object ID with different casing creates a separate node.
+  </Warning>
+
+  These updates prepare BloodHound to enable case-sensitive OpenGraph object IDs by default in a future release.
 
   See the following table for a summary of collector compatibility changes:
 
   | Component | Change |
   | --- | --- |
-  | BloodHound | Rejects older unsupported OpenHound collector versions when the case-sensitive OpenGraph object ID feature is enabled.<br/><br/>This prevents case-sensitive OpenGraph object IDs from being ingested by collector versions that still depend on server-side normalization. |
-  | OpenHound Okta and Jamf collectors | Uppercases the object ID values they own before output. GitHub object IDs remain case-sensitive. |
-  | AzureHound | Normalizes object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
+  | BloodHound Enterprise | Rejects client and file ingest uploads from deprecated AzureHound and OpenHound versions after the ingest change is enabled.<br/><br/>This prevents collector output that depends on server-side normalization from creating duplicate nodes or identity mismatches. |
+  | OpenHound Okta and Jamf collectors | Uppercase the object ID values they own before output. |
+  | OpenHound GitHub collector | Preserves case-sensitive GitHub object IDs before output. |
+  | AzureHound | Uppercases object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
   | SharpHound | No change. SharpHound already normalizes Active Directory object identifiers to uppercase before output. |
 
   <CollectorDeprecationNotice />

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -18,14 +18,14 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 </Tip>
 
 <Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
-  {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567*/}
+  {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567, BED-8602*/}
   ## Findings Table Open Beta
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Review and filter Attack Path findings from the new Findings table in BloodHound Enterprise.
 
-  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
+  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, archives findings associated with uncollected environments using the **Unassociated Environment** status, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
@@ -44,15 +44,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Improve PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
 
   BloodHound now enables graph storage optimization by default, logs optimization timing, and runs `VACUUM` and `ANALYZE` during optimization so PostgreSQL query plans use current partition statistics. Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions on PostgreSQL graph databases.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
-  {/*BED-8602*/}
-  ## Findings for Uncollected Environments
-
-  Keep finding status clearer when previously collected environments become uncollected.
-
-  BloodHound now archives findings associated with uncollected environments using the **Unassociated Environment** status, helping you separate active findings from findings that no longer have an associated collected environment.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -19,7 +19,6 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 <Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9096, BED-8973, BED-8968, BED-8944, BED-9100*/}
   {/* TODO: BED-9096 is Unrefined in Jira; follow up before publishing. */}
-  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
   ## Collector Compatibility for Case-Sensitive Object IDs
 
   BloodHound keeps graph identities stable as it prepares default support for case-sensitive OpenGraph object IDs, by moving object ID normalization into the AzureHound and OpenHound collectors.
@@ -95,15 +94,12 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   {/*BED-9185*/}
   ## GitHub Self-Hosted Runner Modeling
 
-  Added collection and graph modeling for enterprise and organization-scoped GitHub Actions self-hosted runners and runner groups. New relationships expose membership, delegation, inheritance, organization visibility, and repository access.
+  Added collection and graph modeling for enterprise and organization-scoped GitHub Actions self-hosted runners and runner groups.
+
+  New relationships expose membership, delegation, inheritance, organization visibility, and repository access.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>
-  ## Administration
-
-  - {/*BED-9062*/} Resolved an issue where the **Manage Clients** table in BloodHound Enterprise could show a horizontal scrollbar when column content became too wide.
-  - {/*BED-7910*/} Resolved an issue where the **Download Collectors** page could show redundant scrollbars.
-
   ## Cypher
 
   - {/*BED-8967*/} Resolved an issue where backtick-escaped Cypher property accessors did not work correctly for property names that included special characters.
@@ -111,24 +107,25 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
   ## Database Management
 
-  {/*BED-8799*/} Resolved an issue where selecting **All graph data** on the **Database Management** page did not call the correct full-graph deletion path.
+  - {/*BED-8799*/} Resolved an issue where selecting **All graph data** on the **Database Management** page did not call the correct full-graph deletion path.
 
-  ## Explore and UI
+  ## UI
 
-  - {/*BED-9094*/} Resolved an issue where pages using the shared `PageWithTitle` layout could lose horizontal spacing below the `xl` breakpoint.
-  - {/*BED-9057*/} Resolved an issue where table virtualization in Explore could stop working and slow rendering for large result sets.
+  - {/*BED-9057*/} Resolved an issue where the table layout on the **Explore** page could become difficult to read or scroll correctly at smaller window sizes.
   - {/*BED-8997*/} Resolved an issue where hovering over environment or zone selector options could invert inline icon colors.
+  - {/*BED-7910*/} Resolved an issue where the **Download Collectors** page could show redundant scrollbars.
+  - {/*BED-9062*/} Resolved an issue where the table on the **Manage Clients** page in BloodHound Enterprise could show a horizontal scrollbar when column content became too wide.
 
   ## OpenGraph
 
   - {/*BED-9076*/} Resolved an issue where OpenGraph nodes with a `ref` property could crash the Entity Panel.
-  - {/*BED-9059*/} Resolved an issue where Attack Path pages could display OpenGraph object types instead of object glyphs.
+  - {/*BED-9059*/} Resolved an issue where findings for OpenGraph objects were not correctly displaying schema-defined object icons.
 
-  ## Privilege Zones
+  ## Zone Builder
 
   - {/*BED-8922*/} Improved the **Privilege Zone History** display for non-system records with empty notes.
-  - {/*BED-8926*/} Resolved an issue where the Certification view did not preserve `environmentId` in the URL when navigating back from another Privilege Zone view.
-  - {/*BED-8284*/} Resolved an issue where Privilege Zone Cypher rules could fail to tag all expected objects.
+  - {/*BED-8926*/} Resolved an issue where the **Certification** page did not preserve `environmentId` in the URL when navigating back from another Zone Builder page.
+  - {/*BED-8284*/} Resolved an issue where Cypher-based rules could fail to tag all expected objects.
 </Update>
 
 <Update label="OpenHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -21,17 +21,17 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   {/* TODO: BED-9096 is Unrefined in Jira; follow up before publishing. */}
   ## Collector Compatibility for Case-Sensitive Object IDs
 
-  BloodHound keeps graph identities stable as it prepares default support for case-sensitive OpenGraph object IDs, by moving object ID normalization into the AzureHound and OpenHound collectors.
-
-  BloodHound introduced support for [case-sensitive OpenGraph object IDs](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids) in the 2026-07-29 release.
+  BloodHound introduced [case-sensitive OpenGraph object IDs](/resources/release-notes/2026-07-29#case-sensitive-opengraph-object-ids) (a SpecterOps-managed feature) in the 2026-07-29 release. This feature is not enabled by default.
   
   This release updates collector compatibility so BloodHound can preserve case-sensitive OpenGraph object IDs without changing the effective case-insensitive behavior of Active Directory, Microsoft Entra ID, Okta, and Jamf identities.
 
-  This release includes the following collector compatibility changes:
+  These updates help keep graph identities stable while object ID normalization moves into the AzureHound and OpenHound collectors. This groundwork prepares BloodHound to enable case-sensitive OpenGraph object IDs by default in a future release.
+
+  See the following table for a summary of collector compatibility changes:
 
   | Component | Change |
   | --- | --- |
-  | BloodHound | Rejects older unsupported OpenHound collector versions when the case-sensitive OpenGraph ID feature is enabled.<br/><br/>This prevents case-sensitive OpenGraph object IDs from being ingested by collector versions that still depend on server-side normalization. |
+  | BloodHound | Rejects older unsupported OpenHound collector versions when the case-sensitive OpenGraph object ID feature is enabled.<br/><br/>This prevents case-sensitive OpenGraph object IDs from being ingested by collector versions that still depend on server-side normalization. |
   | OpenHound Okta and Jamf collectors | Uppercases the object ID values they own before output. GitHub object IDs remain case-sensitive. |
   | AzureHound | Normalizes object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required. |
   | SharpHound | No change. SharpHound already normalizes Active Directory object identifiers to uppercase before output. |
@@ -70,7 +70,7 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
   ## PostgreSQL Graph Storage Optimization
 
-  BloodHound improves PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
+  Get more reliable PostgreSQL graph database performance with storage optimization.
 
   BloodHound now runs graph storage optimization automatically after key ingest and analysis workflows and records timing details in the logs. These changes help large PostgreSQL-backed environments stay responsive as graph data changes over time.
   
@@ -83,9 +83,9 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Triage findings at scale with the new [Findings Table](/analyze-data/findings/table-view) view on the **Attack Paths** page in BloodHound Enterprise.
+  Try the new [Findings Table](/analyze-data/findings/table-view) view on the **Attack Paths** page.
 
-  Use it to review a dense list of findings, compare finding state across environments and Privilege Zones, and focus high-volume result sets with multi-select filters for severity, platform, environment, zone, and status.
+  Use it to review a list of findings, compare finding state across environments and Privilege Zones, and focus high-volume result sets with multi-select filters for severity, platform, environment, zone, and status.
   
   <BetaAccessNote feature="Findings Table" />
 </Update>
@@ -109,6 +109,11 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
   - {/*BED-8799*/} Resolved an issue where selecting **All graph data** on the **Database Management** page did not call the correct full-graph deletion path.
 
+  ## OpenGraph
+
+  - {/*BED-9076*/} Resolved an issue where OpenGraph nodes with a `ref` property could crash the Entity Panel.
+  - {/*BED-9059*/} Resolved an issue where findings for OpenGraph objects were not correctly displaying schema-defined object icons.
+
   ## UI
 
   - {/*BED-9057*/} Resolved an issue where the table layout on the **Explore** page could become difficult to read or scroll correctly at smaller window sizes.
@@ -116,16 +121,11 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
   - {/*BED-7910*/} Resolved an issue where the **Download Collectors** page could show redundant scrollbars.
   - {/*BED-9062*/} Resolved an issue where the table on the **Manage Clients** page in BloodHound Enterprise could show a horizontal scrollbar when column content became too wide.
 
-  ## OpenGraph
-
-  - {/*BED-9076*/} Resolved an issue where OpenGraph nodes with a `ref` property could crash the Entity Panel.
-  - {/*BED-9059*/} Resolved an issue where findings for OpenGraph objects were not correctly displaying schema-defined object icons.
-
   ## Zone Builder
 
-  - {/*BED-8922*/} Improved the **Privilege Zone History** display for non-system records with empty notes.
-  - {/*BED-8926*/} Resolved an issue where the **Certification** page did not preserve `environmentId` in the URL when navigating back from another Zone Builder page.
   - {/*BED-8284*/} Resolved an issue where Cypher-based rules could fail to tag all expected objects.
+  - {/*BED-8926*/} Resolved an issue where the **Certification** page did not preserve `environmentId` in the URL when navigating back from another Zone Builder page.
+  - {/*BED-8922*/} Improved the **Privilege Zone History** display for non-system records with empty notes.
 </Update>
 
 <Update label="OpenHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -77,17 +77,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 </Update>
 
 <Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8834, BED-8835*/}
-  ## SharpHound Enterprise Support Bundles
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Collect and upload SharpHound Enterprise support bundles from managed collectors with less manual intervention.
-
-  SharpHound Enterprise collectors can now poll for management operations, package current logs into a support bundle, and upload the bundle through resumable, checksum-verified upload sessions.
-</Update>
-
-<Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-8968*/}
   ## Uppercase Active Directory Object IDs
 

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -28,16 +28,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
 </Update>
 
-<Update label="OpenHound" description="New Feature" tags={["GitHub"]}>
-  {/*BED-9185*/}
-  {/* TODO: BED-9185 is Unrefined in Jira; follow up before publishing. */}
-  ## GitHub Self-Hosted Runner Modeling
-
-  Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes with expanded OpenHound GitHub collection and graph modeling.
-
-  The OpenHound GitHub collector now models enterprise runner groups, enterprise runners, organization runner groups, and runner membership. New relationships expose runner group assignment, inheritance, repository access, and composed repository-to-runner access paths.
-</Update>
-
 <Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
   {/*BED-9051, BED-8964, BED-8756, BED-8757*/}
   ## OpenGraph Management and Kind Metadata Improvements
@@ -76,6 +66,26 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   BloodHound Enterprise now rejects older unsupported OpenHound collector versions when raw Object ID ingest is enabled. This compatibility check helps prevent case-sensitive OpenGraph IDs from being ingested with collector versions that still depend on server-side normalization.
 </Update>
 
+<Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>
+  {/*BED-9185*/}
+  {/* TODO: BED-9185 is Unrefined in Jira; follow up before publishing. */}
+  ## GitHub Self-Hosted Runner Modeling
+
+  Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes with expanded OpenHound GitHub collection and graph modeling.
+
+  The OpenHound GitHub collector now models enterprise runner groups, enterprise runners, organization runner groups, and runner membership. New relationships expose runner group assignment, inheritance, repository access, and composed repository-to-runner access paths.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8973*/}
+  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
+  ## OpenHound Okta and Jamf Object ID Normalization
+
+  Preserve stable Okta and Jamf graph identities as BloodHound moves Object ID normalization from server-side ingest into collectors.
+
+  The OpenHound Okta and Jamf collectors now uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive.
+</Update>
+
 <Update label="SharpHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-8968*/}
   ## Uppercase Active Directory Object IDs
@@ -92,16 +102,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Preserve stable Entra ID graph identities with expanded collector-side identifier casing normalization.
 
   AzureHound now normalizes Object IDs and additional related identifier fields before output while preserving case-sensitive application ID values where required.
-</Update>
-
-<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8973*/}
-  {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
-  ## OpenHound Okta and Jamf Object ID Normalization
-
-  Preserve stable Okta and Jamf graph identities as BloodHound moves Object ID normalization from server-side ingest into collectors.
-
-  The OpenHound Okta and Jamf collectors now uppercase the Object ID values they own before output. GitHub Object IDs remain case-sensitive.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -93,12 +93,9 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 
 <Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>
   {/*BED-9185*/}
-  {/* TODO: BED-9185 is Unrefined in Jira; follow up before publishing. */}
   ## GitHub Self-Hosted Runner Modeling
 
-  Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes with expanded OpenHound GitHub collection and graph modeling.
-
-  The OpenHound GitHub collector now models enterprise runner groups, enterprise runners, organization runner groups, and runner membership. New relationships expose runner group assignment, inheritance, repository access, and composed repository-to-runner access paths.
+  Added collection and graph modeling for enterprise and organization-scoped GitHub Actions self-hosted runners and runner groups. New relationships expose membership, delegation, inheritance, organization visibility, and repository access.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>
@@ -135,9 +132,14 @@ import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 </Update>
 
 <Update label="OpenHound" tags={["Fixed Issues"]}>
+  ## GitHub
+
+  - {/*BED-9166*/} Resolved an issue where GitHub App authentication compatibility could be limited. The collector now accepts either `client_id` or `app_id` as the installation JWT issuer, preferring `client_id` when available while continuing to support older GitHub Enterprise Server responses.
+
   ## Okta
 
-  - {/*BED-9222*/} {/* TODO: BED-9222 is Unrefined in Jira; follow up before publishing. */} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired. The collector now refreshes OAuth tokens during collection and retries eligible token-related authentication failures once.
-  - {/*BED-9238*/} {/* TODO: BED-9238 is In Progress in Jira; follow up before publishing. */} Resolved an issue where Okta Org2Org group synchronization relationships could fail to resolve because group names and application-group matchers used inconsistent casing and property names.
-  - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing when agent host matching did not use the complete computer `sAMAccountName` and AD domain.
+  - {/*BED-9253*/} Resolved an issue where SAML issuer identifiers could be inaccurate. BloodHound now prefers runtime metadata over configured issuer templates, no longer emits unresolved Okta expressions as issuer identifiers, and retains diagnostics when issuer evidence is missing, unresolved, or superseded.
+  - {/*BED-9222*/} Resolved an issue where long-running Okta collections using OAuth application credentials could fail after bearer tokens expired. Access tokens now refresh before expiration, eligible authentication failures retry once, and transient refresh failures can reuse a still-valid token. SSWS authentication is unchanged.
+  - {/*BED-9238*/} Resolved an issue where Okta org-to-org group synchronization relationships could fail to resolve. Group names now match using normalized uppercase values, and application group matching uses the correct `okta_domain` property.
+  - {/*BED-9242*/} Resolved an issue where relationships between Active Directory computers and their Okta AD Agents could be missing. `Okta_HostsAgent` now matches the complete computer `sAMAccountName` and AD domain, preserving valid hostname prefixes and correctly targeting Computer nodes.
 </Update>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -48,11 +48,11 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 
 <Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
   {/*BED-8964*/}
-  ## Markdown Validation
+  ## OpenGraph Markdown Validation
 
-  BloodHound [validates](/opengraph/developer/graph-definition#markdown-validation) fields that support custom Markdown content during extension definition schema upload so OpenGraph content can render safely.
+  Upload extension definition schemas with more confidence that custom Markdown content can render safely in BloodHound.
 
-  Validation accepts supported Markdown and safe allowlisted inline HTML, stores the original Markdown without modifying it, and rejects the schema upload if any field contains unsafe or disallowed HTML.
+  BloodHound now [validates Markdown](/opengraph/developer/graph-definition#markdown-validation) used for custom Entity Panel sections and BloodHound Enterprise remediation guidance when you upload an extension definition schema. Supported Markdown continues to work, and BloodHound rejects uploads that include unsafe HTML or links before the content appears in the product.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["API"]}>
@@ -70,9 +70,11 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
   ## PostgreSQL Graph Storage Optimization
 
-  Improve PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
+  BloodHound improves PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
 
-  BloodHound now enables graph storage optimization by default, logs optimization timing, and runs `VACUUM` and `ANALYZE` during optimization so PostgreSQL query plans use current partition statistics. Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions on PostgreSQL graph databases.
+  BloodHound now runs graph storage optimization automatically after key ingest and analysis workflows and records timing details in the logs. These changes help large PostgreSQL-backed environments stay responsive as graph data changes over time.
+  
+  Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions.
 </Update>
 
 <Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>

--- a/docs/resources/release-notes/2026-08-17.mdx
+++ b/docs/resources/release-notes/2026-08-17.mdx
@@ -15,40 +15,11 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
 </Tip>
 
-<Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
-  {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567, BED-8602*/}
-  ## Findings Table Open Beta
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Review and filter Attack Path findings from the new Findings table in BloodHound Enterprise.
-
-  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, archives findings associated with uncollected environments using the **Unassociated Environment** status, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
-  {/*BED-9051, BED-8964, BED-8756, BED-8757*/}
-  ## OpenGraph Management and Kind Metadata Improvements
-
-  Manage OpenGraph extensions by default and retrieve node and relationship kind metadata more easily.
-
-  The **OpenGraph Management** page is now enabled by default. BloodHound also validates markdown supplied in OpenGraph extension remediations and Entity Panel kind information, and adds experimental APIs to retrieve [node kind](/reference/opengraph-experimental/get-node-kind) and [relationship kind](/reference/opengraph-experimental/get-relationship-kind) details by graph-assigned kind ID.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["PostgreSQL"]}>
-  {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
-  ## PostgreSQL Graph Storage Optimization
-
-  Improve PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
-
-  BloodHound now enables graph storage optimization by default, logs optimization timing, and runs `VACUUM` and `ANALYZE` during optimization so PostgreSQL query plans use current partition statistics. Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions on PostgreSQL graph databases.
-</Update>
-
 <Update label="BloodHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9096, BED-8973, BED-8968, BED-8944, BED-9100*/}
   {/* TODO: BED-9096 is Unrefined in Jira; follow up before publishing. */}
   {/* TODO: BED-8973 is In Review in Jira; follow up before publishing. */}
-  ## Collector Compatibility for Case-Sensitive OpenGraph Object IDs
+  ## Collector Compatibility for Case-Sensitive Object IDs
 
   BloodHound keeps graph identities stable as it prepares default support for case-sensitive OpenGraph object IDs, by moving object ID normalization into the AzureHound and OpenHound collectors.
 
@@ -66,6 +37,53 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   | SharpHound | No change. SharpHound already normalizes Active Directory object identifiers to uppercase before output. |
 
   <CollectorDeprecationNotice />
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-9051*/}
+  ## Extension Management Enabled by Default
+  
+  The [OpenGraph Management](/opengraph/extensions/manage) page is now enabled by default so you can manage OpenGraph extensions without enabling the feature on the **Early Access Features** page first.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-8964*/}
+  ## Markdown Validation
+
+  BloodHound [validates](/opengraph/developer/graph-definition#markdown-validation) fields that support custom Markdown content during extension definition schema upload so OpenGraph content can render safely.
+
+  Validation accepts supported Markdown and safe allowlisted inline HTML, stores the original Markdown without modifying it, and rejects the schema upload if any field contains unsafe or disallowed HTML.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["API"]}>
+  {/*BED-8756, BED-8757*/}
+  ## Kind Metadata APIs
+
+  Retrieve node and relationship kind metadata by graph-assigned kind ID.
+
+  BloodHound now exposes experimental APIs for looking up [node kind](/reference/opengraph-experimental/get-node-kind) and [relationship kind](/reference/opengraph-experimental/get-relationship-kind) details.
+  
+  Use these endpoints to retrieve kind names, descriptions, extension metadata, display properties, and markdown-backed Entity Panel information for OpenGraph automation and integrations.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["PostgreSQL"]}>
+  {/*BED-8341, BED-9170, BED-9161, BED-8832, BED-8787*/}
+  ## PostgreSQL Graph Storage Optimization
+
+  Improve PostgreSQL graph database performance with more reliable storage optimization after ingest and analysis.
+
+  BloodHound now enables graph storage optimization by default, logs optimization timing, and runs `VACUUM` and `ANALYZE` during optimization so PostgreSQL query plans use current partition statistics. Graph data deletion paths are also faster for full graph wipes and source-kind or relationship deletions on PostgreSQL graph databases.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["Attack Paths"]}>
+  {/*BED-9191, BED-9151, BED-8921, BED-8920, BED-8626, BED-8621, BED-8619, BED-8673, BED-8567, BED-8602*/}
+  ## Findings Table Open Beta
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Review and filter Attack Path findings from the new Findings table in BloodHound Enterprise.
+
+  This release makes the Findings table available as an open beta and adds filtering by status, severity, platform, environment, and Privilege Zone. The table also shows finding status with clearer status pills, archives findings associated with uncollected environments using the **Unassociated Environment** status, and the [Attack Path findings APIs](/reference/attack-paths/list-attack-path-findings) now use `asset_group_tag_id` consistently and expose [finding types](/reference/attack-paths/list-attack-path-finding-types) for aggregated environments.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["GitHub"]}>

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -4,8 +4,6 @@ description: Stay informed about new features, enhancements, and fixed issues in
 sidebarTitle: Summary
 ---
 
-import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
-
 This page provides a summary of recent BloodHound product releases, including release dates, version numbers, and links to detailed release notes.
 
 <Tip>
@@ -19,32 +17,30 @@ This page provides a summary of recent BloodHound product releases, including re
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-08-17 | v9.6.0 | v0.3.0 | v2.15.0 | v3.1.0 |
 
-<CollectorDeprecationNotice />
-
-This release opens the BloodHound Enterprise **Findings Table** beta, improves OpenGraph management and metadata APIs, optimizes PostgreSQL graph storage operations, and prepares AzureHound and OpenHound collectors for case-sensitive OpenGraph Object ID support.
-
-It also expands OpenHound GitHub runner modeling and improves collector support and reliability.
+This release improves OpenGraph extension management and APIs, optimizes PostgreSQL graph storage operations, and prepares AzureHound and OpenHound collectors for case-sensitive OpenGraph object ID support. Key highlights include:
 
 ### <Icon icon="sparkles" /> New Features
 
-| Component | Update | Summary |
-| --- | --- | --- |
-| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Triage Attack Path findings at scale with a sortable table, multi-select filters, lifecycle status values, and shareable table views in BloodHound Enterprise. |
-| GitHub | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes. |
+<Callout color="#8E92EB">
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Triage Attack Path findings at scale with the new [Findings Table](/resources/release-notes/2026-08-17#findings-table-beta) (beta) on the **Attack Paths** page.
+</Callout>
 
 ### <Icon icon="check-circle" /> Enhancements
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| OpenGraph | [OpenGraph Extension Management Enabled by Default](/resources/release-notes/2026-08-17#opengraph-extension-management-enabled-by-default) | Manage OpenGraph extensions without enabling an early access feature flag first. |
-| OpenGraph | [OpenGraph Markdown Validation](/resources/release-notes/2026-08-17#opengraph-markdown-validation) | Check custom Entity Panel and remediation Markdown during schema upload so unsafe content is rejected before it appears in BloodHound. |
-| API | [OpenGraph Kind Metadata APIs](/resources/release-notes/2026-08-17#opengraph-kind-metadata-apis) | Retrieve node and relationship kind details by graph-assigned kind ID for OpenGraph automation and integrations. |
-| PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
-| Data Collection | [Collector Compatibility for Case-Sensitive OpenGraph Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-object-ids) | Upgrade AzureHound and OpenHound before the November 2026 enforcement window so collector output remains compatible with case-sensitive OpenGraph Object ID ingest. |
+| OpenGraph | [Extension Management Enabled by Default](/resources/release-notes/2026-08-17#extension-management-enabled-by-default) | Manage OpenGraph extensions without having to manually enable the feature. |
+| OpenGraph | [OpenGraph Markdown Validation](/resources/release-notes/2026-08-17#opengraph-markdown-validation) | Upload extension definition schemas with more confidence that custom Markdown content can render safely in BloodHound. |
+| API | [Kind Metadata APIs](/resources/release-notes/2026-08-17#kind-metadata-apis) | Retrieve node and relationship kind details by graph-assigned kind ID for OpenGraph automation and integrations. |
+| PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Get more reliable PostgreSQL graph database performance with storage optimization that runs after ingest and analysis. |
+| Data Collection | [Collector Compatibility for Case-Sensitive Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-object-ids) | Learn how to keep collector output compatible with case-sensitive OpenGraph Object ID ingest. |
+| OpenHound GitHub Collector | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify membership, delegation, and access paths for enterprise and organization-scoped GitHub Actions self-hosted runners and runner groups. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 
-See the [release notes](/resources/release-notes/2026-08-17#administration) for a full list of fixed issues in this release.
+See the [release notes](/resources/release-notes/2026-08-17#cypher) for a full list of fixed issues in this release.
 
 ## 2026-08-04
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -36,9 +36,11 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| OpenGraph | [OpenGraph Management and Kind Metadata Improvements](/resources/release-notes/2026-08-17#opengraph-management-and-kind-metadata-improvements) | Manage OpenGraph extensions by default, validate extension markdown, and retrieve node or relationship kind metadata by graph kind ID. |
+| OpenGraph | [OpenGraph Extension Management Enabled by Default](/resources/release-notes/2026-08-17#opengraph-extension-management-enabled-by-default) | Manage OpenGraph extensions without enabling an early access feature flag first. |
+| OpenGraph | [OpenGraph Extension Markdown Validation](/resources/release-notes/2026-08-17#opengraph-extension-markdown-validation) | Validate extension-defined Markdown during schema upload and reject unsafe HTML without modifying stored Markdown. |
+| API | [OpenGraph Kind Metadata APIs](/resources/release-notes/2026-08-17#opengraph-kind-metadata-apis) | Retrieve node and relationship kind details by graph-assigned kind ID for OpenGraph automation and integrations. |
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
-| Data Collection | [Collector Compatibility for Case-Sensitive OpenGraph Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-opengraph-object-ids) | Upgrade AzureHound and OpenHound before the November 2026 enforcement window so collector output remains compatible with case-sensitive OpenGraph Object ID ingest. |
+| Data Collection | [Collector Compatibility for Case-Sensitive OpenGraph Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-object-ids) | Upgrade AzureHound and OpenHound before the November 2026 enforcement window so collector output remains compatible with case-sensitive OpenGraph Object ID ingest. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -4,25 +4,49 @@ description: Stay informed about new features, enhancements, and fixed issues in
 sidebarTitle: Summary
 ---
 
+import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+
 This page provides a summary of recent BloodHound product releases, including release dates, version numbers, and links to detailed release notes.
 
 <Tip>
   See the release notes [archive](/resources/release-notes/v8-4-0) for previous releases.
 </Tip>
 
-## <Icon icon="bullhorn" /> Announcements
+## 2026-08-17
 
-### Webinar: Designing MCP Experiences Agents Can Actually Use
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-08-17 | v9.6.0 | v0.3.0 | v2.15.0 | v3.1.0 |
 
-Building MCP-powered experiences isn't just about connecting tools, it's about creating interfaces that agents can effectively understand, navigate, and reason through.
+<CollectorDeprecationNotice />
 
-Join Kaleb Pomeroy and John Hopper on August 19 for a webinar discussing how to measure agent performance, manage context, think through security and access boundaries, and apply lessons from decades of interface design to this new era of AI. [Register here](https://app.livestorm.co/p/93e60e4f-6a97-4b97-b892-9d3410a6bff5).
+This release opens the BloodHound Enterprise **Findings Table** beta, improves OpenGraph management and metadata APIs, optimizes PostgreSQL graph storage operations, and prepares collectors for raw object ID ingest.
 
-### Webinar: The Evolution of Identity Attack Path Management
+It also expands OpenHound GitHub runner modeling and improves collector support and reliability across OpenHound, SharpHound, and AzureHound.
 
-On August 25, join Jared Atkinson and Justin Kohler for a thought leadership discussion on the latest evolution of Identity Attack Path Management and the research behind BloodHound Enterprise's newest capabilities.
+### <Icon icon="sparkles" /> New Features
 
-This webinar will examine how identity attack paths are evolving, the attack trends SpecterOps is seeing across enterprise environments, and the business impact these attacks continue to have on organizations. [Register here](https://app.livestorm.co/p/baa4a8fc-6ab7-43cf-9259-23a10bbc3a26).
+| Component | Update | Summary |
+| --- | --- | --- |
+| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Review and filter Attack Path findings by status, severity, platform, environment, and Privilege Zone in BloodHound Enterprise. |
+| GitHub | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes. |
+
+### <Icon icon="check-circle" /> Enhancements
+
+| Component | Update | Summary |
+| --- | --- | --- |
+| OpenGraph | [OpenGraph Management and Kind Metadata Improvements](/resources/release-notes/2026-08-17#opengraph-management-and-kind-metadata-improvements) | Manage OpenGraph extensions by default, validate extension markdown, and retrieve node or relationship kind metadata by graph kind ID. |
+| PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
+| Attack Paths | [Findings for Uncollected Environments](/resources/release-notes/2026-08-17#findings-for-uncollected-environments) | Archive findings associated with uncollected environments using a clearer status. |
+| Data Collection | [Collector Compatibility for Raw Object ID Ingest](/resources/release-notes/2026-08-17#collector-compatibility-for-raw-object-id-ingest) | Reject unsupported OpenHound collector versions when raw Object ID ingest is enabled. |
+| Data Collection | [SharpHound Enterprise Support Bundles](/resources/release-notes/2026-08-17#sharphound-enterprise-support-bundles) | Package and upload SharpHound Enterprise support bundles through resumable, checksum-verified upload sessions. |
+| Data Collection | [Uppercase Active Directory Object IDs](/resources/release-notes/2026-08-17#uppercase-active-directory-object-ids) | Keep case-insensitive Active Directory graph identities stable as normalization moves into collectors. |
+| Data Collection | [AzureHound Identifier Casing Updates](/resources/release-notes/2026-08-17#azurehound-identifier-casing-updates) | Normalize Entra ID collector output while preserving case-sensitive application ID values. |
+
+### <Icon icon="wrench" /> Fixed Issues
+
+See the [release notes](/resources/release-notes/2026-08-17#administration) for a full list of fixed issues in this release.
 
 ## 2026-08-04
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -21,9 +21,9 @@ This page provides a summary of recent BloodHound product releases, including re
 
 <CollectorDeprecationNotice />
 
-This release opens the BloodHound Enterprise **Findings Table** beta, improves OpenGraph management and metadata APIs, optimizes PostgreSQL graph storage operations, and prepares collectors for raw object ID ingest.
+This release opens the BloodHound Enterprise **Findings Table** beta, improves OpenGraph management and metadata APIs, optimizes PostgreSQL graph storage operations, and prepares AzureHound and OpenHound collectors for case-sensitive OpenGraph Object ID support.
 
-It also expands OpenHound GitHub runner modeling and improves collector support and reliability across OpenHound, SharpHound, and AzureHound.
+It also expands OpenHound GitHub runner modeling and improves collector support and reliability.
 
 ### <Icon icon="sparkles" /> New Features
 
@@ -38,9 +38,7 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 | --- | --- | --- |
 | OpenGraph | [OpenGraph Management and Kind Metadata Improvements](/resources/release-notes/2026-08-17#opengraph-management-and-kind-metadata-improvements) | Manage OpenGraph extensions by default, validate extension markdown, and retrieve node or relationship kind metadata by graph kind ID. |
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
-| Data Collection | [Collector Compatibility for Raw Object ID Ingest](/resources/release-notes/2026-08-17#collector-compatibility-for-raw-object-id-ingest) | Reject unsupported OpenHound collector versions when raw Object ID ingest is enabled. |
-| Data Collection | [Uppercase Active Directory Object IDs](/resources/release-notes/2026-08-17#uppercase-active-directory-object-ids) | Keep case-insensitive Active Directory graph identities stable as normalization moves into collectors. |
-| Data Collection | [AzureHound Identifier Casing Updates](/resources/release-notes/2026-08-17#azurehound-identifier-casing-updates) | Normalize Entra ID collector output while preserving case-sensitive application ID values. |
+| Data Collection | [Collector Compatibility for Case-Sensitive OpenGraph Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-opengraph-object-ids) | Upgrade AzureHound and OpenHound before the November 2026 enforcement window so collector output remains compatible with case-sensitive OpenGraph Object ID ingest. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -37,7 +37,7 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 | Component | Update | Summary |
 | --- | --- | --- |
 | OpenGraph | [OpenGraph Extension Management Enabled by Default](/resources/release-notes/2026-08-17#opengraph-extension-management-enabled-by-default) | Manage OpenGraph extensions without enabling an early access feature flag first. |
-| OpenGraph | [OpenGraph Extension Markdown Validation](/resources/release-notes/2026-08-17#opengraph-extension-markdown-validation) | Validate extension-defined Markdown during schema upload and reject unsafe HTML without modifying stored Markdown. |
+| OpenGraph | [OpenGraph Markdown Validation](/resources/release-notes/2026-08-17#opengraph-markdown-validation) | Check custom Entity Panel and remediation Markdown during schema upload so unsafe content is rejected before it appears in BloodHound. |
 | API | [OpenGraph Kind Metadata APIs](/resources/release-notes/2026-08-17#opengraph-kind-metadata-apis) | Retrieve node and relationship kind details by graph-assigned kind ID for OpenGraph automation and integrations. |
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
 | Data Collection | [Collector Compatibility for Case-Sensitive OpenGraph Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-object-ids) | Upgrade AzureHound and OpenHound before the November 2026 enforcement window so collector output remains compatible with case-sensitive OpenGraph Object ID ingest. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -17,7 +17,12 @@ This page provides a summary of recent BloodHound product releases, including re
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-08-17 | v9.6.0 | v0.3.0 | v2.15.0 | v3.1.0 |
 
-This release improves OpenGraph extension management and APIs, optimizes PostgreSQL graph storage operations, and prepares AzureHound and OpenHound collectors for case-sensitive OpenGraph object ID support. Key highlights include:
+This release improves OpenGraph extension management, strengthens OpenGraph Markdown validation, and optimizes PostgreSQL graph database performance.
+
+Key highlights include:
+
+- **OpenGraph**: Manage extensions without having to manually enable the feature, and upload extension definition schemas with more confidence that custom Markdown content can render safely in BloodHound.
+- **PostgreSQL**: Get more reliable PostgreSQL graph database performance with storage optimization that runs after ingest and analysis.
 
 ### <Icon icon="sparkles" /> New Features
 
@@ -35,6 +40,7 @@ This release improves OpenGraph extension management and APIs, optimizes Postgre
 | OpenGraph | [OpenGraph Markdown Validation](/resources/release-notes/2026-08-17#opengraph-markdown-validation) | Upload extension definition schemas with more confidence that custom Markdown content can render safely in BloodHound. |
 | API | [Kind Metadata APIs](/resources/release-notes/2026-08-17#kind-metadata-apis) | Retrieve node and relationship kind details by graph-assigned kind ID for OpenGraph automation and integrations. |
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Get more reliable PostgreSQL graph database performance with storage optimization that runs after ingest and analysis. |
+| Database Management | [Faster Graph Data Deletion](/resources/release-notes/2026-08-17#faster-graph-data-deletion) | Delete graph data from PostgreSQL-backed environments more quickly with **Database Management**. |
 | Data Collection | [Collector Compatibility for Case-Sensitive Object IDs](/resources/release-notes/2026-08-17#collector-compatibility-for-case-sensitive-object-ids) | Learn how to keep collector output compatible with case-sensitive OpenGraph Object ID ingest. |
 | OpenHound GitHub Collector | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify membership, delegation, and access paths for enterprise and organization-scoped GitHub Actions self-hosted runners and runner groups. |
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -40,7 +40,6 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
 | Attack Paths | [Findings for Uncollected Environments](/resources/release-notes/2026-08-17#findings-for-uncollected-environments) | Archive findings associated with uncollected environments using a clearer status. |
 | Data Collection | [Collector Compatibility for Raw Object ID Ingest](/resources/release-notes/2026-08-17#collector-compatibility-for-raw-object-id-ingest) | Reject unsupported OpenHound collector versions when raw Object ID ingest is enabled. |
-| Data Collection | [SharpHound Enterprise Support Bundles](/resources/release-notes/2026-08-17#sharphound-enterprise-support-bundles) | Package and upload SharpHound Enterprise support bundles through resumable, checksum-verified upload sessions. |
 | Data Collection | [Uppercase Active Directory Object IDs](/resources/release-notes/2026-08-17#uppercase-active-directory-object-ids) | Keep case-insensitive Active Directory graph identities stable as normalization moves into collectors. |
 | Data Collection | [AzureHound Identifier Casing Updates](/resources/release-notes/2026-08-17#azurehound-identifier-casing-updates) | Normalize Entra ID collector output while preserving case-sensitive application ID values. |
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -29,7 +29,7 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Review and filter Attack Path findings by status, severity, platform, environment, and Privilege Zone in BloodHound Enterprise. |
+| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Review, filter, and track Attack Path findings by status, severity, platform, environment, Privilege Zone, and collection association in BloodHound Enterprise. |
 | GitHub | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes. |
 
 ### <Icon icon="check-circle" /> Enhancements
@@ -38,7 +38,6 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 | --- | --- | --- |
 | OpenGraph | [OpenGraph Management and Kind Metadata Improvements](/resources/release-notes/2026-08-17#opengraph-management-and-kind-metadata-improvements) | Manage OpenGraph extensions by default, validate extension markdown, and retrieve node or relationship kind metadata by graph kind ID. |
 | PostgreSQL | [PostgreSQL Graph Storage Optimization](/resources/release-notes/2026-08-17#postgresql-graph-storage-optimization) | Run graph storage optimization by default and speed up PostgreSQL graph deletion paths. |
-| Attack Paths | [Findings for Uncollected Environments](/resources/release-notes/2026-08-17#findings-for-uncollected-environments) | Archive findings associated with uncollected environments using a clearer status. |
 | Data Collection | [Collector Compatibility for Raw Object ID Ingest](/resources/release-notes/2026-08-17#collector-compatibility-for-raw-object-id-ingest) | Reject unsupported OpenHound collector versions when raw Object ID ingest is enabled. |
 | Data Collection | [Uppercase Active Directory Object IDs](/resources/release-notes/2026-08-17#uppercase-active-directory-object-ids) | Keep case-insensitive Active Directory graph identities stable as normalization moves into collectors. |
 | Data Collection | [AzureHound Identifier Casing Updates](/resources/release-notes/2026-08-17#azurehound-identifier-casing-updates) | Normalize Entra ID collector output while preserving case-sensitive application ID values. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -29,7 +29,7 @@ It also expands OpenHound GitHub runner modeling and improves collector support 
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Review, filter, and track Attack Path findings by status, severity, platform, environment, Privilege Zone, and collection association in BloodHound Enterprise. |
+| Attack Paths | [Findings Table Open Beta](/resources/release-notes/2026-08-17#findings-table-open-beta) | Triage Attack Path findings at scale with a sortable table, multi-select filters, lifecycle status values, and shareable table views in BloodHound Enterprise. |
 | GitHub | [GitHub Self-Hosted Runner Modeling](/resources/release-notes/2026-08-17#github-self-hosted-runner-modeling) | Identify which repositories can use GitHub self-hosted runners across enterprise and organization scopes. |
 
 ### <Icon icon="check-circle" /> Enhancements

--- a/docs/snippets/feature-flag-user-managed.mdx
+++ b/docs/snippets/feature-flag-user-managed.mdx
@@ -1,3 +1,3 @@
 <Note>
-  This feature is available under early access. Enable **{feature}** on the **Administration** > **Early Access Features** page to access it.
+  This feature is available under beta access. Enable **{feature}** on the **Administration** > **Early Access Features** page to access it.
 </Note>

--- a/docs/snippets/resources/collector-deprecation-notice.mdx
+++ b/docs/snippets/resources/collector-deprecation-notice.mdx
@@ -1,0 +1,3 @@
+<Warning>
+  Older AzureHound and OpenHound collector versions are deprecated in the release the week of November 8, 2026. Upgrade collectors before that release to keep data collection compatible with current BloodHound versions.
+</Warning>

--- a/docs/snippets/resources/collector-deprecation-notice.mdx
+++ b/docs/snippets/resources/collector-deprecation-notice.mdx
@@ -3,7 +3,7 @@
 
   When case-sensitive OpenGraph object ID support is enabled, older AzureHound and OpenHound versions can interrupt data collection because they do not normalize required object IDs before upload.
 
-  Starting with the release the week of November 8, 2026, BloodHound enables case-sensitive OpenGraph object ID support by default and rejects uploads from older unsupported AzureHound and OpenHound versions.
+  Starting with the  November 2026 release, case-sensitive OpenGraph object ID support will be enabled by default. BloodHound will reject uploads from older unsupported AzureHound and OpenHound versions.
 
-  Upgrade AzureHound and OpenHound before that release to keep data collection compatible with current BloodHound versions.
+  Upgrade AzureHound and OpenHound before then to keep data collection compatible with future versions of BloodHound.
 </Warning>

--- a/docs/snippets/resources/collector-deprecation-notice.mdx
+++ b/docs/snippets/resources/collector-deprecation-notice.mdx
@@ -1,3 +1,9 @@
 <Warning>
-  Older AzureHound and OpenHound collector versions are deprecated in the release the week of November 8, 2026. Upgrade collectors before that release to keep data collection compatible with current BloodHound versions.
+  **Upcoming collector deprecation**
+
+  When case-sensitive OpenGraph object ID support is enabled, older AzureHound and OpenHound versions can interrupt data collection because they do not normalize required object IDs before upload.
+
+  Starting with the release the week of November 8, 2026, BloodHound enables case-sensitive OpenGraph object ID support by default and rejects uploads from older unsupported AzureHound and OpenHound versions.
+
+  Upgrade AzureHound and OpenHound before that release to keep data collection compatible with current BloodHound versions.
 </Warning>

--- a/docs/snippets/resources/collector-deprecation-notice.mdx
+++ b/docs/snippets/resources/collector-deprecation-notice.mdx
@@ -1,9 +1,9 @@
 <Warning>
   **Upcoming collector deprecation**
 
-  When case-sensitive OpenGraph object ID support is enabled, older AzureHound and OpenHound versions can interrupt data collection because they do not normalize required object IDs before upload.
+  BloodHound Enterprise will soon ingest collector property values exactly as collectors send them instead of normalizing values during ingest. Older AzureHound and OpenHound versions depend on server-side normalization and can create duplicate nodes or identity mismatches when this change is enabled.
 
-  Starting with the  November 2026 release, case-sensitive OpenGraph object ID support will be enabled by default. BloodHound will reject uploads from older unsupported AzureHound and OpenHound versions.
+  Starting with the November 2026 release, BloodHound Enterprise will reject client and file ingest uploads from deprecated AzureHound and OpenHound versions.
 
-  Upgrade AzureHound and OpenHound before then to keep data collection compatible with future versions of BloodHound.
+  Upgrade AzureHound and OpenHound before then to keep data collection compatible with future versions of BloodHound Enterprise.
 </Warning>


### PR DESCRIPTION
## Summary

This pull request (PR) adds release notes for the v9.6.0 BloodHound release cycle to the release integration branch, which includes:

- BloodHound v9.6.0
- OpenHound v0.3.0
- SharpHound v2.15.0
- AzureHound v3.1.0

## Staging

We no longer have access to staging builds on Mintlify 😒

But you can [build the site locally](https://www.mintlify.com/docs/cli/preview) to preview the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for BloodHound 9.6.0, OpenHound 0.3.0, SharpHound 2.15.0, and AzureHound 3.1.0.
  * Documented the beta Findings Table, collector compatibility updates, OpenGraph and Markdown improvements, kind metadata APIs, PostgreSQL optimization, and GitHub self-hosted runner modeling.
  * Added summaries of fixes across querying, database management, authentication, collection, and interface features.
  * Updated feature availability language from “early access” to “beta access.”
  * Added a deprecation notice for legacy collector uploads and recommended upgrade timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->