### PR TITLE
Fix typo in "Run Multiple AzureHound Enterprise Collectors on One Server With Scheduled Tasks" installation instructions - Section B

### DIFF
--- a/docs/install-data-collector/install-azurehound/multiple-collectors.mdx
+++ b/docs/install-data-collector/install-azurehound/multiple-collectors.mdx
@@ -25,7 +25,7 @@ This article outlines how to set up multiple AzureHound Enterprise collectors on
 </Frame>
 ### B. Setup the Scheduled Task
 
-1.  Log in to an Administrator account on a computer with access to the desired collection server. Then, from the **Windows S****tart** menu, open the **Task Scheduler** application.
+1.  Log in to an Administrator account on a computer with access to the desired collection server. Then, from the **Windows Start** menu, open the **Task Scheduler** application.
 <Frame>
   <img src="/assets/image-176.png" alt=""/>
 </Frame>


### PR DESCRIPTION
Changing **Windows S****tart** to **Windows Start**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the bold formatting of “Start” in the Task Scheduler installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->