### PR TITLE
Add npmHound to OpenGraph library

### DIFF
--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -492,6 +492,26 @@ NetworkHound connects to Active Directory Domain Controllers, discovers computer
 - https://github.com/mordavid/NetworkHound
 
 </Accordion>
+<Accordion title="npm" icon="people-group">
+#### <Icon icon="people-group" size={22}/> npmHound
+
+**Description**
+
+npmHound is a BloodHound OpenGraph collector for the npm supply chain. It maps npm maintainers, the packages they hold publish rights over, and the packages that depend on those packages, so that a maintainer account compromise can be pathfound through its full downstream blast radius.
+
+All data comes from the public npm registry. The collector requires no account, token, or authentication. It is a single Python file that uses only the standard library and has no third-party dependencies.
+
+npmHound also emits optional bridge edges into the GitHub OpenGraph subgraph. The project documents those bridge edges as unverified.
+
+It ships with custom node icons, six Cypher starter queries, node and edge documentation, and a schema validator.
+
+**Authors/Maintainers**
+- [Dracaryzs](https://github.com/Dracaryzs)
+
+**Repo**
+- https://github.com/Dracaryzs/npmhound/
+
+</Accordion>
 <Accordion title="Okta" icon={<SO_Icon />}>
 #### <SO_Icon_Inline size={22}/> OktaHound
 

--- a/docs/opengraph/library.mdx
+++ b/docs/opengraph/library.mdx
@@ -506,7 +506,7 @@ npmHound also emits optional bridge edges into the GitHub OpenGraph subgraph. Th
 It ships with custom node icons, six Cypher starter queries, node and edge documentation, and a schema validator.
 
 **Authors/Maintainers**
-- [Dracaryzs](https://github.com/Dracaryzs)
+- [Rahil Hassan](https://www.linkedin.com/in/rk67890)
 
 **Repo**
 - https://github.com/Dracaryzs/npmhound/


### PR DESCRIPTION
Closes #405 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the npmHound community extension to the OpenGraph Library under a new npm category.
  * Documented its npm supply-chain mapping, public registry collection, optional GitHub connections, resources, maintainer, and repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->