### PR TITLE
DOCS-41: Configure OpenHound Okta collector

### DIFF
--- a/docs/openhound/collectors/okta/collect-data.mdx
+++ b/docs/openhound/collectors/okta/collect-data.mdx
@@ -101,7 +101,7 @@ The private key JSON has the following general structure. The values below are p
 
 ### Option 3: API Token (SSWS)
 
-Use this option when you want to authenticate with an API token (SSWS) associated with a specific Okta administrator account.
+Use this option when you want to authenticate with an API token (SSWS) associated with a specific Okta Super Administrator account.
 
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|

--- a/docs/openhound/collectors/okta/collect-data.mdx
+++ b/docs/openhound/collectors/okta/collect-data.mdx
@@ -31,20 +31,33 @@ Use an RSA public/private key pair when possible, because it provides stronger s
 The OpenHound Okta collector can also authenticate using API tokens (also known as SSWS tokens) associated with specific Okta Super Administrator accounts.
 This is the least secure option, but the easiest one to set up.
 
-
 ## Configure OpenHound
 
 The following OpenHound configuration parameters are required to run the Okta collector. These can either be set
 via the `[sources.source.okta.credentials]` section of the secrets file or via environment variables using the `SOURCES__OKTA__CREDENTIALS` prefix.
 
 ### Option 1: Service Application with JSON key file
+
+Use this option when you store the Okta private key in a file. Set `private_key_path` to the path of the complete private key JSON that Okta displays when you generate the key pair.
+
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|
 | `base_url`     | \{PREFIX\}__BASE_URL | The base URL of the Okta organization. For example: `https://spectoropspreview.oktapreview.com`. |
 | `client_id`     | \{PREFIX\}__CLIENT_ID | The client ID of the Okta service application used to authenticate to the Okta API. |
 | `private_key_path` | \{PREFIX\}__PRIVATE_KEY_PATH | The path to the private key (.json) used for authentication. |
 
+**Example Configuration**
+
+```toml title="secrets.toml"
+[sources.source.okta.credentials]
+base_url = "https://mytenant.oktapreview.com"
+client_id = "myclientid"
+private_key_path = "/path/to/private/key.json"
+```
+
 ### Option 2: Service Application with base64-encoded JSON key string
+
+Use this option when you store the Okta private key in a text-based secret.
 
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|
@@ -52,18 +65,55 @@ via the `[sources.source.okta.credentials]` section of the secrets file or via e
 | `client_id`     | \{PREFIX\}__CLIENT_ID | The client ID of the Okta service application used to authenticate to the Okta API. |
 | `private_key_b64` | \{PREFIX\}__PRIVATE_KEY_B64 | The private key (.json) encoded as a base64 string.  |
 
+**Example Configuration**
+
+```toml title="secrets.toml"
+[sources.source.okta.credentials]
+base_url = "https://mytenant.oktapreview.com"
+client_id = "myclientid"
+private_key_b64 = "<base64-encoded-complete-okta-private-key-json>"
+```
+
+Set `private_key_b64` to the base64-encoded contents of the complete private key JSON that Okta displays when you generate the key pair.
+
+The private key JSON includes the key identifier (`kid`). Keep this property in the JSON; you do not retrieve or configure `kid` separately. The collector uses it to identify the signing key when it requests an access token.
+
+The private key JSON has the following general structure. The values below are placeholders and are not a usable key.
+
+```json nocopy=true
+{
+  "kty": "RSA",
+  "kid": "<key-id-generated-by-okta>",
+  "n": "<public-modulus>",
+  "e": "AQAB",
+  "d": "<private-exponent>",
+  "p": "<first-prime-factor>",
+  "q": "<second-prime-factor>",
+  "dp": "<first-factor-exponent>",
+  "dq": "<second-factor-exponent>",
+  "qi": "<first-factor-coefficient>"
+}
+```
+
+<Warning>
+  Keep the complete private key JSON and its base64-encoded value secret. Okta displays the private key only when you generate it. If you do not have the JSON, generate and register a new key pair as described in the [Okta app registration guide](/openhound/collectors/okta/okta-app-registration).
+</Warning>
+
 ### Option 3: API Token (SSWS)
+
+Use this option when you want to authenticate with an API token (SSWS) associated with a specific Okta administrator account.
+
 | Parameter Name | Environment Variable            | Description                                                                        |
 |----------------|---------------------------------|------------------------------------------------------------------------------------|
 | `base_url`     | \{PREFIX\}__BASE_URL | The base URL of the Okta organization. For example: `https://spectoropspreview.oktapreview.com`. |
 | `token` | \{PREFIX\}__TOKEN | The API token (SSWS) used for authentication. |
 
-### Example Configuration
+**Example Configuration**
+
 ```toml title="secrets.toml"
- [sources.source.okta.credentials]
+[sources.source.okta.credentials]
 base_url = "https://mytenant.oktapreview.com"
-client_id = "myclientid"
-private_key_path = "/path/to/private/key.json"
+token = "<api-token>"
 ```
 
 ## Running OpenHound and Collecting Data


### PR DESCRIPTION
## Summary

This pull request (PR) adds more detail to the base64-encoded string option in the [Okta collector configuration](https://bloodhound.specterops.io/openhound/collectors/okta/collect-data#option-2-service-application-with-base64-encoded-json-key-string) docs based on user feedback.

It also normalizes introductory text and `secrets.toml` example configurations for the other options to ensure consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Okta collector setup guidance.
  * Added configuration examples for JSON key files, base64-encoded keys, and SSWS API tokens.
  * Documented private-key structure, key ID handling, and secure secret-management practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->