### PR TITLE
DOCS-38: Update API reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1096,8 +1096,8 @@
             "group": "BloodHound Users",
             "pages": [
               "reference/bloodhound-users/list-users",
-              "reference/bloodhound-users/list-users-minimal",
               "reference/bloodhound-users/create-a-new-user",
+              "reference/bloodhound-users/list-users-minimal",
               "reference/bloodhound-users/get-a-user",
               "reference/bloodhound-users/delete-a-user",
               "reference/bloodhound-users/update-a-user",
@@ -1115,9 +1115,9 @@
               "reference/collectors/get-collector-manifest",
               "reference/collectors/get-collector-download-by-version",
               "reference/collectors/get-collector-checksum-by-version",
-              "reference/collectors/download-asset",
+              "reference/collectors/get-kennel-manifest",
               "reference/collectors/get-kennel-enterprise-manifest",
-              "reference/collectors/get-kennel-manifest"
+              "reference/collectors/download-asset"
             ]
           },
           {
@@ -1175,35 +1175,35 @@
             "pages": [
               "reference/asset-isolation/list-all-asset-isolation-groups",
               "reference/asset-isolation/create-an-asset-group",
-              "reference/asset-isolation/create-asset-group-tag-selector",
-              "reference/asset-isolation/get-asset-group-tag",
-              "reference/asset-isolation/get-asset-group-tags",
               "reference/asset-isolation/get-asset-group-by-id",
-              "reference/asset-isolation/list-asset-group-tag-members-by-id",
-              "reference/asset-isolation/get-asset-group-tag-selector",
-              "reference/asset-isolation/get-asset-group-tag-selectors",
+              "reference/asset-isolation/update-an-asset-group",
+              "reference/asset-isolation/delete-an-asset-group",
+              "reference/asset-isolation/list-asset-group-collections",
+              "reference/asset-isolation/update-asset-group-selectors",
+              "reference/asset-isolation/update-asset-group-selectors-1",
+              "reference/asset-isolation/delete-an-asset-group-selector",
+              "reference/asset-isolation/get-asset-group-custom-member-count",
+              "reference/asset-isolation/list-all-asset-isolation-group-members",
+              "reference/asset-isolation/list-asset-group-member-count-by-kind",
               "reference/asset-isolation/get-asset-group-tag-selectors-of-a-specific-object-by-member-id",
+              "reference/asset-isolation/get-asset-group-tags",
+              "reference/asset-isolation/create-asset-group-tag",
+              "reference/asset-isolation/get-asset-group-tag",
+              "reference/asset-isolation/delete-an-asset-group-tag",
+              "reference/asset-isolation/update-asset-group-tag",
+              "reference/asset-isolation/list-asset-group-tag-members-by-id",
               "reference/asset-isolation/list-asset-group-tag-member-count-by-kind",
               "reference/asset-isolation/list-asset-group-tag-members-by-selector",
               "reference/asset-isolation/list-asset-group-tag-selector-member-count-by-kind",
-              "reference/asset-isolation/list-asset-group-collections",
-              "reference/asset-isolation/preview-selectors",
-              "reference/asset-isolation/update-an-asset-group",
-              "reference/asset-isolation/update-asset-group-selectors",
-              "reference/asset-isolation/update-asset-group-selectors-1",
-              "reference/asset-isolation/update-asset-group-tag-selector",
-              "reference/asset-isolation/delete-an-asset-group",
-              "reference/asset-isolation/delete-an-asset-group-selector",
+              "reference/asset-isolation/get-asset-group-tag-selectors",
+              "reference/asset-isolation/create-asset-group-tag-selector",
+              "reference/asset-isolation/get-asset-group-tag-selector",
               "reference/asset-isolation/delete-asset-group-tag-selector",
-              "reference/asset-isolation/get-asset-group-custom-member-count",
-              "reference/asset-isolation/list-all-asset-isolation-group-members",
-              "reference/asset-isolation/create-asset-group-tag",
-              "reference/asset-isolation/delete-an-asset-group-tag",
+              "reference/asset-isolation/update-asset-group-tag-selector",
+              "reference/asset-isolation/preview-selectors",
+              "reference/asset-isolation/search-asset-group-tags",
               "reference/asset-isolation/get-history-records",
               "reference/asset-isolation/search-history-records",
-              "reference/asset-isolation/list-asset-group-member-count-by-kind",
-              "reference/asset-isolation/search-asset-group-tags",
-              "reference/asset-isolation/update-asset-group-tag",
               "reference/asset-isolation/get-certifications-for-privilege-zones",
               "reference/asset-isolation/certify-or-revoke-certification-of-objects"
             ]
@@ -1237,16 +1237,16 @@
             "group": "Cypher",
             "pages": [
               "reference/cypher/list-saved-queries",
-              "reference/cypher/return-a-saved-query",
-              "reference/cypher/retrieves-saved-query-permissions-for-provided-query-id",
-              "reference/cypher/export-a-saved-query",
-              "reference/cypher/export-one-or-more-saved-queries",
-              "reference/cypher/import-one-or-more-cypher-queries",
               "reference/cypher/create-a-saved-query",
+              "reference/cypher/return-a-saved-query",
               "reference/cypher/update-a-saved-query",
               "reference/cypher/delete-a-saved-query",
+              "reference/cypher/retrieves-saved-query-permissions-for-provided-query-id",
               "reference/cypher/share-a-saved-query-or-set-it-to-public",
               "reference/cypher/revokes-permission-of-a-saved-query-from-users",
+              "reference/cypher/export-a-saved-query",
+              "reference/cypher/import-one-or-more-cypher-queries",
+              "reference/cypher/export-one-or-more-saved-queries",
               "reference/cypher/run-a-cypher-query"
             ]
           },
@@ -1468,8 +1468,18 @@
               "reference/clients/list-all-completed-jobs-for-a-client",
               "reference/clients/creates-a-scheduled-task",
               "reference/clients/creates-a-scheduled-job",
+              "reference/clients/queues-a-management-operation",
+              "reference/clients/download-a-management-operation-artifact-for-the-client",
+              "reference/clients/delete-a-management-operation-artifact-for-the-client",
+              "reference/clients/get-available-management-operations",
               "reference/clients/notifies-the-api-of-a-management-operation-start",
-              "reference/clients/notifies-the-api-of-a-management-operation-ending"
+              "reference/clients/notifies-the-api-of-a-management-operation-ending",
+              "reference/clients/create-an-artifact-upload-session",
+              "reference/clients/get-an-artifact-upload-session",
+              "reference/clients/upload-an-artifact-part",
+              "reference/clients/complete-an-artifact-upload-session",
+              "reference/clients/get-a-client-artifact-download-url",
+              "reference/clients/download-a-management-operation-artifact-for-the-client-1"
             ]
           },
           {
@@ -1534,9 +1544,37 @@
             ]
           },
           {
+            "group": "Asset Scores",
+            "pages": [
+              "reference/asset-scores/get-zone-protected-asset-score"
+            ]
+          },
+          {
             "group": "Meta Entities",
             "pages": [
               "reference/meta-entities/get-meta-entity-info"
+            ]
+          },
+          {
+            "group": "Alerts",
+            "pages": [
+              "reference/alerts/list-alert-webhooks",
+              "reference/alerts/create-alert-webhook",
+              "reference/alerts/get-alert-webhook",
+              "reference/alerts/delete-alert-webhook",
+              "reference/alerts/update-alert-webhook",
+              "reference/alerts/rotate-alert-webhook-secret",
+              "reference/alerts/test-alert-webhook",
+              "reference/alerts/list-alert-events",
+              "reference/alerts/get-alert-event",
+              "reference/alerts/list-alert-event-types",
+              "reference/alerts/list-alerts",
+              "reference/alerts/create-alert",
+              "reference/alerts/get-alert",
+              "reference/alerts/delete-alert",
+              "reference/alerts/update-alert",
+              "reference/alerts/list-alert-attempts",
+              "reference/alerts/retry-alert-attempt"
             ]
           }
         ]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6168,18 +6168,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/model.asset-group-tags-selector-request"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ],
-                "required": [
-                  "name",
-                  "seeds"
-                ]
+                "$ref": "#/components/schemas/model.asset-group-tags-selector-create-request"
               }
             }
           }
@@ -7408,7 +7397,11 @@
                                     "properties": {
                                       "content": {
                                         "type": "string",
-                                        "description": "Markdown content for the kindinfo object."
+                                        "description": "Rendered markdown content, or the original unexecuted template string when rendering fails."
+                                      },
+                                      "template_error": {
+                                        "type": "string",
+                                        "description": "Template parsing or execution error, when the markdown template could not be rendered for the requested node."
                                       }
                                     }
                                   }
@@ -7873,7 +7866,7 @@
                             "title": "Overview",
                             "position": 1,
                             "markdown": {
-                              "content": "This is an overview panel for Node Kind 1"
+                              "content": "This is an overview panel for **{{ .Properties.name | upper }}** (node {{ .NodeID }})"
                             }
                           },
                           "details": {
@@ -7910,7 +7903,7 @@
                             "title": "Abuse Info",
                             "position": 1,
                             "markdown": {
-                              "content": "Information about how this relationship can be abused"
+                              "content": "Information about how the {{ .Kind.Name }} relationship from {{ .Source.Properties.name }} to {{ .Target.Properties.name }} can be abused"
                             }
                           }
                         }
@@ -14744,6 +14737,10 @@
                           "type": "string",
                           "format": "date-time"
                         },
+                        "last_complete_optimize_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
                         "next_scheduled_analysis_at": {
                           "type": "string",
                           "format": "date-time",
@@ -16959,6 +16956,1029 @@
         }
       }
     },
+    "/api/v2/clients/{client_id}/management": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "QueueClientManagementOperation",
+        "summary": "Queues a management operation",
+        "description": "Endpoint for users to queue a management operation for a client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-management-operation-queue-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/{client_id}/artifacts/{artifact_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "DownloadClientArtifact",
+        "summary": "Download a management operation artifact for the client",
+        "description": "Downloads an operation artifact associated with the client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "**OK**\nThis response will contain the artifact file.\n",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "example": "private, no-store, no-transform"
+                }
+              },
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string",
+                  "example": "attachment; filename=\"support-bundle.zip\""
+                }
+              },
+              "Content-Length": {
+                "schema": {
+                  "type": "string",
+                  "example": 123456
+                }
+              },
+              "Content-Type": {
+                "schema": {
+                  "type": "string",
+                  "example": "application/zip"
+                }
+              }
+            },
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteClientArtifact",
+        "summary": "Delete a management operation artifact for the client",
+        "description": "Deletes an operation artifact associated with the client.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/available": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "summary": "Get available management operations",
+        "description": "Endpoint for clients to get next available management operations.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/model.client-management-operation"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/start": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "StartClientManagementOperation",
+        "summary": "Notifies the API of a management operation start",
+        "description": "Endpoint for clients to start a management operation and mark the start time.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-management-operation-start-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "invalid management operation status transition"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/end": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "EndClientManagementOperation",
+        "summary": "Notifies the API of a management operation ending",
+        "description": "Endpoint for clients to end a management operation and mark the completed time.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-management-operation-end-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-management-operation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "invalid management operation status transition"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "CreateClientArtifactUploadSession",
+        "summary": "Create an artifact upload session",
+        "description": "Endpoint for clients to create an artifact upload session and associate it\nwith a running management operation.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-artifact-upload-session-create-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session-create-response"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "management operation already has an associated artifact"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetClientArtifactUploadSession",
+        "summary": "Get an artifact upload session",
+        "description": "Endpoint for clients to get artifact upload-session state.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "part_number",
+          "description": "Artifact part number, starting at 1.",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          }
+        }
+      ],
+      "post": {
+        "operationId": "UploadClientArtifactPart",
+        "summary": "Upload an artifact part",
+        "description": "Endpoint for clients to upload one part of an artifact upload session.\n\nThe part checksum is supplied through the Content-Digest header. Supported\ndigest names are sha-256 and sha-512. The digest value must be a structured\nfield byte sequence containing the base64-encoded digest bytes, for example\nsha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "Content-Length",
+            "description": "Size of the uploaded artifact part, in bytes.",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "Content-Digest",
+            "description": "Structured field digest for the uploaded artifact part.",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-upload-session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact part already uploaded with a different checksum"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/management/artifacts/{artifact_id}/complete": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "CompleteClientArtifactUploadSession",
+        "summary": "Complete an artifact upload session",
+        "description": "Endpoint for clients to complete an artifact upload session after all\nexpected parts have been uploaded.\n\nNote: caller must be a client. For users, this endpoint will return a 403 as\nthey are not expected or allowed to call this endpoint.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.client-artifact-upload-session-complete-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/{client_id}/artifacts/{artifact_id}/download-url": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "GetClientArtifactDownloadURL",
+        "summary": "Get a client artifact download URL",
+        "description": "Issues a presigned URL that can be used to download an operation artifact associated\nwith the client\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "example": "private, no-store"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.client-artifact-download-url"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/clients/{client_id}/artifacts/{artifact_id}/download": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "client_id",
+          "description": "Client ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "artifact_id",
+          "description": "Artifact ID",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "PresignedDownloadClientArtifact",
+        "summary": "Download a management operation artifact for the client",
+        "description": "Downloads an operation artifact associated with the client using a\npreviously issued artifact download token.\n",
+        "tags": [
+          "Clients",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "**OK**\nThis response will contain the artifact file.\n",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "example": "private, no-store, no-transform"
+                }
+              },
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string",
+                  "example": "attachment; filename=\"support-bundle.zip\""
+                }
+              },
+              "Content-Length": {
+                "schema": {
+                  "type": "string",
+                  "example": 123456
+                }
+              },
+              "Content-Type": {
+                "schema": {
+                  "type": "string",
+                  "example": "application/zip"
+                }
+              }
+            },
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "example": "[this request has a binary response]"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-07-01T13:44:43.247Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "",
+                      "message": "artifact not finished uploading, must upload missing parts"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/tasks/available": {
       "parameters": [
         {
@@ -18509,7 +19529,7 @@
         "parameters": [
           {
             "name": "sort_by",
-            "description": "Sortable columns are `severity`, `finding_type`, `finding`, `title`, `platform`, `environment_id`, `environment_name`,\n`asset_group_tag_id`, `zone_name`, `source_principal_id`, `source_principal_kind`, `source_principal_name`, `target_principal_id`, `target_principal_kind`, `target_principal_name`, `status`, `first_seen`, `last_seen`.\n",
+            "description": "Sortable columns are `severity`, `finding_type`, `finding`, `title`, `platform`, `environment_id`, `environment_name`,\n`asset_group_tag_id`, `zone_name`, `source_principal_id`, `source_principal_kind`, `source_principal_name`, `target_principal_id`, `target_principal_kind`, `target_principal_name`, `status`, `id`, `first_seen`, `last_seen`.\n",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.query.sort-by"
@@ -18665,6 +19685,14 @@
             }
           },
           {
+            "name": "is_cross_platform",
+            "description": "Filter findings by whether source and target principals belong to different platforms.",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
+            }
+          },
+          {
             "$ref": "#/components/parameters/query.skip"
           },
           {
@@ -18682,7 +19710,7 @@
                 },
                 "examples": {
                   "Unified CSV export": {
-                    "value": "Severity,Finding,Title,FindingType,Platform,EnvironmentID,EnvironmentName,AssetGroupTagID,ZoneName,SourcePrincipalID,SourcePrincipalKind,SourcePrincipalName,TargetPrincipalID,TargetPrincipalKind,TargetPrincipalName,Status,FirstSeen,LastSeen\ncritical,T0GenericWrite,GenericWrite Privileges on Tier Zero Objects,relationship,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,RPATTON@CORP1.LAB.HOME-LABS.LOL,User,Robert Patton,ADMIN@CORP1.LAB.HOME-LABS.LOL,User,Domain Admin,active,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\nhigh,Kerberoasting,Kerberoastable User Accounts,list,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,,,, PSX_D_BA@CORP1.LAB.HOME-LABS.LOL,User,Backup Admin,accepted,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z\n"
+                    "value": "Severity,Finding,Title,FindingType,IsCrossPlatform,Platform,EnvironmentID,EnvironmentName,AssetGroupTagID,ZoneName,SourcePrincipalID,SourcePrincipalKind,SourcePrincipalName,TargetPrincipalID,TargetPrincipalKind,TargetPrincipalName,Status,FirstSeen,LastSeen,ArchivedAt\ncritical,T0GenericWrite,GenericWrite Privileges on Tier Zero Objects,relationship,true,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,RPATTON@CORP1.LAB.HOME-LABS.LOL,User,Robert Patton,ADMIN@CORP1.LAB.HOME-LABS.LOL,User,Domain Admin,active,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z,\nhigh,Kerberoasting,Kerberoastable User Accounts,list,false,Active Directory,S-1-5-21-1974516972-3116780949-2584384717,CORP1.LAB.HOME-LABS.LOL,1,Tier Zero,,,, PSX_D_BA@CORP1.LAB.HOME-LABS.LOL,User,Backup Admin,accepted,2026-04-11T00:30:18Z,2026-04-14T16:57:35Z,\n"
                   }
                 }
               },
@@ -18717,6 +19745,10 @@
                                   "relationship",
                                   "list"
                                 ]
+                              },
+                              "is_cross_platform": {
+                                "type": "boolean",
+                                "description": "Whether the source and target principals belonged to different platforms when the finding was calculated. Always false for list findings."
                               },
                               "finding": {
                                 "type": "string",
@@ -18781,6 +19813,10 @@
                                   "orphaned"
                                 ]
                               },
+                              "id": {
+                                "type": "integer",
+                                "description": "Unique identifier of the finding."
+                              },
                               "first_seen": {
                                 "type": "string",
                                 "format": "date-time",
@@ -18811,6 +19847,7 @@
                           "finding": "T0GenericWrite",
                           "title": "GenericWrite Privileges on Tier Zero Objects",
                           "finding_type": "relationship",
+                          "is_cross_platform": true,
                           "platform": "Active Directory",
                           "environment_id": "S-1-5-21-1974516972-3116780949-2584384717",
                           "environment_name": "CORP1.LAB.HOME-LABS.LOL",
@@ -18823,6 +19860,7 @@
                           "target_principal_kind": "User",
                           "target_principal_name": "Domain Admin",
                           "status": "active",
+                          "id": 101,
                           "first_seen": "2026-04-11T00:30:18.491666Z",
                           "last_seen": "2026-04-14T16:57:35.675609Z"
                         },
@@ -18831,6 +19869,7 @@
                           "finding": "Kerberoasting",
                           "title": "Kerberoastable User Accounts",
                           "finding_type": "list",
+                          "is_cross_platform": false,
                           "platform": "Active Directory",
                           "environment_id": "S-1-5-21-1974516972-3116780949-2584384717",
                           "environment_name": "CORP1.LAB.HOME-LABS.LOL",
@@ -18843,6 +19882,7 @@
                           "target_principal_kind": "User",
                           "target_principal_name": "Backup Admin",
                           "status": "accepted",
+                          "id": 102,
                           "first_seen": "2026-04-11T00:30:18.491666Z",
                           "last_seen": "2026-04-14T16:57:35.675609Z"
                         }
@@ -19107,11 +20147,7 @@
             "$ref": "#/components/parameters/query.skip"
           },
           {
-            "$ref": "#/components/parameters/query.limit",
-            "enum": [
-              "application/json",
-              "text/csv"
-            ]
+            "$ref": "#/components/parameters/query.limit"
           }
         ],
         "responses": {
@@ -19140,7 +20176,7 @@
               },
               "application/json": {
                 "schema": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "allOf": [
                         {
@@ -19152,13 +20188,19 @@
                             "data": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/components/schemas/model.relationship-finding",
-                                "type": "object",
-                                "properties": {
-                                  "Accepted": {
-                                    "type": "boolean"
+                                "allOf": [
+                                  {
+                                    "$ref": "#/components/schemas/model.relationship-finding"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "Accepted": {
+                                        "type": "boolean"
+                                      }
+                                    }
                                   }
-                                }
+                                ]
                               }
                             }
                           }
@@ -19176,13 +20218,19 @@
                             "data": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/components/schemas/model.list-finding",
-                                "type": "object",
-                                "properties": {
-                                  "Accepted": {
-                                    "type": "boolean"
+                                "allOf": [
+                                  {
+                                    "$ref": "#/components/schemas/model.list-finding"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "Accepted": {
+                                        "type": "boolean"
+                                      }
+                                    }
                                   }
-                                }
+                                ]
                               }
                             }
                           }
@@ -19862,6 +20910,189 @@
         }
       }
     },
+    "/api/v2/asset-scores/zone-protected-asset-score": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "GetZoneProtectedAssetScore",
+        "summary": "Get zone protected asset score",
+        "description": "Gets a per-day series describing how much of a zone is free of open findings\nover the requested time range. For each day in the range, the score is the\nnumber of objects in the zone without an open finding divided by the total\nnumber of objects in the zone. Zones that attack path analysis does not run\nagainst yield an empty series.\n",
+        "tags": [
+          "Asset Scores",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "environments",
+            "description": "Environment IDs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "asset_group_tag_id",
+            "description": "The asset group tag id of the zone requested",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "start",
+            "description": "Beginning datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime minus 30 days",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/api.response.time-window"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "environments": {
+                              "type": "array",
+                              "description": "The environment IDs the caller has access to out of those requested",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "asset_group_tag_id": {
+                              "type": "integer",
+                              "description": "The asset group tag id of the zone requested"
+                            },
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "date": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "readOnly": true
+                                  },
+                                  "exposed_count": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "description": "Number of objects in the zone holding an open finding",
+                                    "readOnly": true
+                                  },
+                                  "protected_count": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "description": "Number of objects in the zone without an open finding",
+                                    "readOnly": true
+                                  },
+                                  "total_count": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "description": "Total number of objects in the zone",
+                                    "readOnly": true
+                                  },
+                                  "value": {
+                                    "type": "number",
+                                    "format": "double",
+                                    "description": "The protected share of the zone, `protected_count` divided by `total_count`",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "examples": {
+                  "Zone protected asset score": {
+                    "value": {
+                      "data": {
+                        "start": "2026-08-01T00:00:00Z",
+                        "end": "2026-08-04T00:00:00Z",
+                        "environments": [
+                          "S-1-5-21-1004336348-1177238915-682003330"
+                        ],
+                        "asset_group_tag_id": 1,
+                        "data": [
+                          {
+                            "date": "2026-08-01T00:00:00Z",
+                            "exposed_count": 120,
+                            "protected_count": 880,
+                            "total_count": 1000,
+                            "value": 0.88
+                          },
+                          {
+                            "date": "2026-08-02T00:00:00Z",
+                            "exposed_count": 95,
+                            "protected_count": 905,
+                            "total_count": 1000,
+                            "value": 0.905
+                          },
+                          {
+                            "date": "2026-08-03T00:00:00Z",
+                            "exposed_count": 80,
+                            "protected_count": 922,
+                            "total_count": 1002,
+                            "value": 0.9201596806387226
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/meta/{object_id}": {
       "parameters": [
         {
@@ -19895,6 +21126,1438 @@
                           "additionalProperties": {
                             "type": "object"
                           }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-webhooks": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAlertWebhooks",
+        "summary": "List Alert Webhooks",
+        "description": "Returns a paginated list of alert webhooks.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Sortable columns are `name`, `created_at`, `updated_at`, `health`. Default `name` ascending.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "disabled",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
+            }
+          },
+          {
+            "name": "health",
+            "in": "query",
+            "description": "Filter by the webhook's rolling health score in [0, 1].",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.number"
+            }
+          },
+          {
+            "name": "attempts",
+            "in": "query",
+            "description": "Filter by the total attempts observed for the webhook.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+            }
+          },
+          {
+            "name": "failures",
+            "in": "query",
+            "description": "Filter by the total failed attempts observed for the webhook.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.created-at"
+          },
+          {
+            "$ref": "#/components/parameters/query.updated-at"
+          },
+          {
+            "name": "last_errored_at",
+            "in": "query",
+            "description": "Filter results by `last_errored_at` value. See filter schema details for valid predicates.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.time"
+            }
+          },
+          {
+            "name": "last_succeeded_at",
+            "in": "query",
+            "description": "Filter results by `last_succeeded_at` value. See filter schema details for valid predicates.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "webhooks": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/model.alert-webhook"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "post": {
+        "operationId": "CreateAlertWebhook",
+        "summary": "Create Alert Webhook",
+        "description": "Creates a new alert webhook (channel + webhook + HMAC secret in one\ntransaction). The generated HMAC secret is returned on this response only.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for creating an alert webhook.",
+                "required": [
+                  "type",
+                  "name",
+                  "url"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "generic",
+                      "slack",
+                      "ms-teams"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Must be https, http is not supported."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "description": "Response payload from creating an alert webhook. The newly generated HMAC\nsecret is included on this response only; subsequent reads of the webhook\ndo not expose the secret value.\n",
+                      "properties": {
+                        "webhook": {
+                          "$ref": "#/components/schemas/model.alert-webhook"
+                        },
+                        "hmac_secret": {
+                          "type": "string",
+                          "description": "Base64-encoded HMAC secret used to sign outbound webhook payloads."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "409": {
+            "description": "**Conflict**\nThe supplied `url` collides with an existing alert webhook\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-05-21T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "alert-webhooks",
+                      "message": "An alert webhook with the supplied URL already exists."
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-webhooks/{alert_webhook_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "$ref": "#/components/parameters/path.alert-webhook-id"
+        }
+      ],
+      "get": {
+        "operationId": "GetAlertWebhook",
+        "summary": "Get Alert Webhook",
+        "description": "Returns a single alert webhook by ID.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "webhook": {
+                          "$ref": "#/components/schemas/model.alert-webhook"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "UpdateAlertWebhook",
+        "summary": "Update Alert Webhook",
+        "description": "Partially updates an alert webhook by ID. Only fields present in the request body are modified.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "minProperties": 1,
+                "description": "Partial update for an alert webhook. At least one field is required. Only\nfields present in the request body are modified.\n",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "generic",
+                      "slack",
+                      "ms-teams"
+                    ]
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Set to `true` to disable the webhook (populates `disabled_at`/`disabled_by`),\n`false` to re-enable.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "webhook": {
+                          "$ref": "#/components/schemas/model.alert-webhook"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "**Conflict**\nThe supplied `url` collides with another alert webhook\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-05-21T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "alert-webhooks",
+                      "message": "An alert webhook with the supplied URL already exists."
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteAlertWebhook",
+        "summary": "Delete Alert Webhook",
+        "description": "Deletes an alert webhook. Cascades to `alert_webhook_secrets`,\n`alert_subscriptions`, and `alert_attempts` rows that reference this\nwebhook.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-webhooks/{alert_webhook_id}/rotate-secret": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "$ref": "#/components/parameters/path.alert-webhook-id"
+        }
+      ],
+      "post": {
+        "operationId": "RotateAlertWebhookSecret",
+        "summary": "Rotate Alert Webhook Secret",
+        "description": "Generates a new HMAC secret for an alert webhook. The new plaintext secret\nis returned on this response only and replaces the prior secret.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "webhook_secret": {
+                          "type": "object",
+                          "description": "Response payload from rotating an alert webhook's HMAC secret. The plaintext\nsecret value is returned only on rotation; subsequent reads of the webhook do\nnot expose it.\n",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "The channel UUID for the webhook whose secret was rotated."
+                            },
+                            "hmac_secret": {
+                              "type": "string",
+                              "description": "The newly generated base64-encoded HMAC secret."
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-webhooks/{alert_webhook_id}/test": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "$ref": "#/components/parameters/path.alert-webhook-id"
+        }
+      ],
+      "post": {
+        "operationId": "TestAlertWebhook",
+        "summary": "Test Alert Webhook",
+        "description": "Synchronously dispatches a mock payload for the given `event_type` to the\nwebhook's target URL using the current HMAC secret. No `alert_attempts`\nrow is persisted. The handler returns `200` for both successful and failed\nupstream deliveries; the `status_code` and `error` fields in the response\nbody surface the upstream outcome.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for dispatching a mock payload to an alert webhook.",
+                "required": [
+                  "event_type",
+                  "version"
+                ],
+                "properties": {
+                  "event_type": {
+                    "type": "string",
+                    "description": "The alert event type to mock in the dispatched payload. The server builds\na representative payload for the given type using the webhook's current\nHMAC secret.\n"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "description": "Payload data version for the supplied `event_type`. Must be one of\nthe data versions advertised for that type by\n`GET /api/v2/alert-event-types`.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "description": "Result of dispatching a mock payload to an alert webhook. The handler returns\nthis body with a `200` status code on both successful and failed upstream\ndeliveries; the `status_code` and `error` fields surface the upstream outcome.\n",
+                      "properties": {
+                        "status_code": {
+                          "type": "integer",
+                          "description": "HTTP status code returned by the webhook target.",
+                          "nullable": true
+                        },
+                        "error": {
+                          "$ref": "#/components/schemas/null.string.response"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-events": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAlertEvents",
+        "summary": "List Alert Events",
+        "description": "Returns a paginated list of alert events. Events are system-generated and read-only via the API.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Sortable columns are `created_at`, `attempts_queued_at`. Default `-created_at` (most recent first).",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Supported operators are `eq` and `neq`. Must provide valid alert event types.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.created-at"
+          },
+          {
+            "name": "delivered",
+            "in": "query",
+            "description": "When set to `false`, returns only events with `attempts_queued_at IS NULL`\n(events that have not yet had delivery attempts queued).\n",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "events": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/model.alert-event"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-events/{alert_event_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "alert_event_id",
+          "description": "ID of an alert event.",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "description": "uuidv7"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetAlertEvent",
+        "summary": "Get Alert Event",
+        "description": "Returns a single alert event by ID.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "event": {
+                          "$ref": "#/components/schemas/model.alert-event"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-event-types": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAlertEventTypes",
+        "summary": "List Alert Event Types",
+        "description": "Returns the list of alert event types registered with the system along with\nthe payload schema versions supported for each type. The response is not\npaginated or filtered.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "event_types": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/model.alert-event-type"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alerts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAlerts",
+        "summary": "List Alerts",
+        "description": "Returns a paginated list of alerts with their embedded subscriptions.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Sortable columns are `name`, `created_at`, `updated_at`. Default `name` ascending.",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "disabled",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.created-at"
+          },
+          {
+            "$ref": "#/components/parameters/query.updated-at"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "alerts": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/model.alert"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "post": {
+        "operationId": "CreateAlert",
+        "summary": "Create Alert",
+        "description": "Creates a new alert with the supplied subscription bindings. The\n`subscriptions` array is required but may be empty.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for creating an alert. The `subscriptions` array is required but\nmay be empty to create an alert with no channel bindings.\n",
+                "required": [
+                  "name",
+                  "subscriptions"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "subscriptions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/model.alert-subscription-request"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "alert": {
+                          "$ref": "#/components/schemas/model.alert"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "409": {
+            "description": "**Conflict**\nThe supplied `name` collides with an existing alert\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-05-21T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "alerts",
+                      "message": "An alert with the supplied name already exists."
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alerts/{alert_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "name": "alert_id",
+          "description": "ID of an alert.",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "description": "uuidv4"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetAlert",
+        "summary": "Get Alert",
+        "description": "Returns a single alert by ID with its embedded subscriptions.",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "alert": {
+                          "$ref": "#/components/schemas/model.alert"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "UpdateAlert",
+        "summary": "Update Alert",
+        "description": "Partially updates an alert by ID. All top-level fields are optional. If\n`subscriptions` is present, the supplied array fully replaces the current\nsubscription set for this alert in one transaction (delete-omitted,\ninsert-new, update-existing by composite key `(channel_id, event_type)`).\nOmit `subscriptions` to leave bindings unchanged.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "minProperties": 1,
+                "description": "Partial update for an alert. All fields are optional. If `subscriptions` is\npresent, the supplied array fully replaces the current subscription set for\nthis alert in one transaction (delete-omitted / insert-new / update-existing\nby composite key `(channel_id, event_type)`). Omit `subscriptions` to leave\nbindings unchanged.\n",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "subscriptions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/model.alert-subscription-request"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "alert": {
+                          "$ref": "#/components/schemas/model.alert"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "409": {
+            "description": "**Conflict**\nThe supplied `name` collides with an existing alert\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2026-05-21T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "alerts",
+                      "message": "An alert with the supplied name already exists."
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteAlert",
+        "summary": "Delete Alert",
+        "description": "Deletes an alert. Cascades to `alert_subscriptions` and `alert_attempts`\nrows referencing this alert.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/no-content"
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-attempts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListAlertAttempts",
+        "summary": "List Alert Attempts",
+        "description": "Returns a paginated list of alert delivery attempts. Composite-key filters\n(`alert_id`, `channel_id`, `event_id`) compose to support per-alert,\nper-webhook, per-event, and single-row views.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Sortable columns are `created_at`, `succeeded_at`, `next_attempt_at`,\n`attempts`. Default `-created_at` (most recent first).\n",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "alert_id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.uuid"
+            }
+          },
+          {
+            "name": "channel_id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.uuid"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.uuid"
+            }
+          },
+          {
+            "name": "succeeded",
+            "in": "query",
+            "description": "When set to `true`, returns only rows with `succeeded_at IS NOT NULL`.\n",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.created-at"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "attempts": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/model.alert-attempt"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/alert-attempts/retry": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "RetryAlertAttempt",
+        "summary": "Retry Alert Attempt",
+        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`).\n",
+                "required": [
+                  "alert_id",
+                  "channel_id",
+                  "event_id"
+                ],
+                "properties": {
+                  "alert_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "channel_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "event_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "alert_attempt": {
+                          "$ref": "#/components/schemas/model.alert-attempt"
                         }
                       }
                     }
@@ -20208,6 +22871,17 @@
         "in": "query",
         "schema": {
           "$ref": "#/components/schemas/api.params.predicate.filter.time"
+        }
+      },
+      "path.alert-webhook-id": {
+        "name": "alert_webhook_id",
+        "description": "ID of an alert webhook.",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "uuidv4"
         }
       }
     },
@@ -21961,16 +24635,6 @@
           }
         }
       },
-      "null.time.response": {
-        "type": "string",
-        "nullable": true,
-        "format": "date-time",
-        "description": "An RFC-3339 formatted string"
-      },
-      "null.string.response": {
-        "type": "string",
-        "nullable": true
-      },
       "model.asset-group-tags-selector-seed": {
         "type": "object",
         "properties": {
@@ -21988,35 +24652,9 @@
           }
         }
       },
-      "model.asset-group-tags-selector-response": {
+      "model.asset-group-tags-selector-base": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "asset_group_tag_id": {
-            "type": "integer"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          },
-          "disabled_at": {
-            "$ref": "#/components/schemas/null.time.response"
-          },
-          "disabled_by": {
-            "$ref": "#/components/schemas/null.string.response"
-          },
           "name": {
             "type": "string"
           },
@@ -22032,12 +24670,6 @@
             ],
             "description": "auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)"
           },
-          "is_default": {
-            "type": "boolean"
-          },
-          "allow_disable": {
-            "type": "boolean"
-          },
           "seeds": {
             "type": "array",
             "items": {
@@ -22045,6 +24677,74 @@
             }
           }
         }
+      },
+      "null.time.response": {
+        "type": "string",
+        "nullable": true,
+        "format": "date-time",
+        "description": "An RFC-3339 formatted string"
+      },
+      "null.string.response": {
+        "type": "string",
+        "nullable": true
+      },
+      "model.asset-group-tags-selector-response": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "asset_group_tag_id": {
+                "type": "integer"
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "created_by": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_by": {
+                "type": "string"
+              },
+              "disabled_at": {
+                "$ref": "#/components/schemas/null.time.response"
+              },
+              "disabled_by": {
+                "$ref": "#/components/schemas/null.string.response"
+              },
+              "is_default": {
+                "type": "boolean"
+              },
+              "allow_disable": {
+                "type": "boolean"
+              },
+              "rule_key": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.string.response"
+                  }
+                ],
+                "readOnly": true
+              },
+              "extension_id": {
+                "type": "integer",
+                "format": "int32",
+                "nullable": true,
+                "readOnly": true
+              }
+            }
+          }
+        ]
       },
       "api.params.predicate.filter.integer-strict": {
         "type": "string",
@@ -22109,26 +24809,25 @@
           "type": "string"
         }
       },
+      "model.asset-group-tags-selector-create-request": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
+          }
+        ],
+        "required": [
+          "name",
+          "seeds"
+        ]
+      },
       "model.asset-group-tags-selector-request": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/model.asset-group-tags-selector-response"
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
           },
           {
             "type": "object",
             "properties": {
-              "auto_certify": {
-                "type": "integer",
-                "enum": [
-                  0,
-                  1,
-                  2
-                ],
-                "description": "auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)"
-              },
-              "description": {
-                "type": "string"
-              },
               "disabled": {
                 "type": "boolean"
               }
@@ -22610,7 +25309,12 @@
             ],
             "properties": {
               "content": {
-                "type": "string"
+                "type": "string",
+                "description": "Rendered markdown content, or the original unexecuted template string when rendering fails."
+              },
+              "template_error": {
+                "type": "string",
+                "description": "Template parsing or execution error, when the markdown template could not be rendered for the requested entity."
               }
             }
           }
@@ -23706,7 +26410,11 @@
         "enum": [
           "idle",
           "ingesting",
-          "analyzing"
+          "analyzing",
+          "purging",
+          "pruning",
+          "starting",
+          "optimizing"
         ]
       },
       "model.components.base-ad-entity": {
@@ -23963,6 +26671,380 @@
             }
           }
         ]
+      },
+      "enum.client-management-operation-type": {
+        "type": "string",
+        "enum": [
+          "support_bundle"
+        ]
+      },
+      "model.client-management-operation-queue-request": {
+        "type": "object",
+        "required": [
+          "operation_type",
+          "execution_time"
+        ],
+        "properties": {
+          "operation_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/enum.client-management-operation-type"
+              }
+            ]
+          },
+          "execution_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "enum.client-management-operation-status": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "running",
+          "succeeded",
+          "failed",
+          "canceled"
+        ]
+      },
+      "model.client-management-operation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.uuid"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "client_id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "artifact_id": {
+                "type": "string",
+                "format": "uuid",
+                "nullable": true
+              },
+              "type": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/enum.client-management-operation-type"
+                  }
+                ]
+              },
+              "status": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/enum.client-management-operation-status"
+                  }
+                ]
+              },
+              "requested_by_user_id": {
+                "type": "string",
+                "format": "uuid",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "started_at": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.time.response"
+                  }
+                ]
+              },
+              "completed_at": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.time.response"
+                  }
+                ]
+              },
+              "execution_time": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              }
+            }
+          }
+        ]
+      },
+      "model.client-management-operation-start-request": {
+        "type": "object",
+        "required": [
+          "operation_id"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "model.client-management-operation-end-request": {
+        "type": "object",
+        "required": [
+          "operation_id",
+          "status"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "succeeded",
+              "failed",
+              "canceled"
+            ]
+          }
+        }
+      },
+      "enum.artifact-type": {
+        "type": "string",
+        "enum": [
+          "support_bundle"
+        ]
+      },
+      "enum.checksum-algorithm": {
+        "type": "string",
+        "enum": [
+          "sha256",
+          "sha512"
+        ]
+      },
+      "model.client-artifact-upload-session-create-request": {
+        "type": "object",
+        "required": [
+          "operation_id",
+          "artifact_type",
+          "total_size",
+          "part_count",
+          "checksum_algorithm",
+          "checksum"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "artifact_type": {
+            "$ref": "#/components/schemas/enum.artifact-type"
+          },
+          "total_size": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Optional upload part size. When omitted or zero, the server default is used."
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          },
+          "content_type": {
+            "type": "string",
+            "description": "Optional artifact content type. Support bundle uploads default to application/zip."
+          },
+          "checksum_algorithm": {
+            "$ref": "#/components/schemas/enum.checksum-algorithm"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for the completed artifact."
+          }
+        }
+      },
+      "enum.artifact-status": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "uploading",
+          "complete",
+          "failed",
+          "canceled"
+        ]
+      },
+      "model.client-artifact-upload-session-create-response": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/enum.artifact-status"
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "missing_parts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "management_operation": {
+            "$ref": "#/components/schemas/model.client-management-operation"
+          }
+        }
+      },
+      "model.client-artifact-upload-session-part": {
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for this uploaded part."
+          },
+          "offset_start": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          }
+        }
+      },
+      "model.client-artifact-upload-session": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": "string"
+          },
+          "storage_key": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/enum.artifact-status"
+          },
+          "total_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "part_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "checksum_algorithm": {
+            "$ref": "#/components/schemas/enum.checksum-algorithm"
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Hex-encoded checksum for the completed artifact."
+          },
+          "uploaded_parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.client-artifact-upload-session-part"
+            }
+          },
+          "missing_parts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expires_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          }
+        }
+      },
+      "model.client-artifact-upload-session-complete-request": {
+        "type": "object",
+        "required": [
+          "operation_id"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "model.client-artifact-download-url": {
+        "type": "object",
+        "properties": {
+          "download_url": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
       },
       "enum.risk-acceptance": {
         "type": "string",
@@ -24363,6 +27445,313 @@
           "attack-paths",
           "archived-findings"
         ]
+      },
+      "api.params.predicate.filter.number": {
+        "type": "string",
+        "pattern": "^((eq|neq|gt|gte|lt|lte):)?-?[0-9]+(\\.[0-9]+)?$",
+        "description": "Filter results by column numeric float (decimal) value. Valid filter predicates are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`.\n"
+      },
+      "model.alert-webhook": {
+        "type": "object",
+        "description": "Alert webhook resource — a joined view of the `alert_channels`, `alert_webhooks`\nfor a single webhook destination. The HMAC secret value is never included in this view;\nit is only returned at create or rotate time.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The channel UUID; also serves as the webhook identifier."
+          },
+          "type": {
+            "type": "string",
+            "description": "Webhook target type.",
+            "enum": [
+              "generic",
+              "slack",
+              "ms-teams"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "health": {
+            "type": "number",
+            "format": "double",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Rolling health score in [0, 1], where 1 is fully healthy."
+          },
+          "attempts": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total dispatch attempts observed for this webhook."
+          },
+          "failures": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total failed dispatch attempts observed for this webhook."
+          },
+          "last_error": {
+            "$ref": "#/components/schemas/null.string.response"
+          },
+          "last_errored_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "last_succeeded_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "disabled_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "disabled_by": {
+            "$ref": "#/components/schemas/null.string.response"
+          }
+        }
+      },
+      "model.alert-event": {
+        "type": "object",
+        "description": "Alert event resource. Events are system-generated source signals that fan out\ninto per-channel delivery attempts. The API exposes events as read-only; they\nare not mutable through this API surface.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "description": "Event type identifier, e.g. an alert kind name."
+          },
+          "message": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "description": "Event payload (`JSONB`); shape varies per event type.",
+            "additionalProperties": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "attempts_queued_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp at which delivery attempts were queued for this event. `null`\nwhen the event has not yet been dispatched (matches the `delivered`\nfilter on the list endpoint).\n"
+          }
+        }
+      },
+      "model.alert-event-type": {
+        "type": "object",
+        "description": "Describes a single alert event type registered with the system along with the\npayload data versions supported for that type. Used by clients to populate\nselectors when configuring alert subscriptions, document expected payload\nshapes, and fire type-specific test probes.\n",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Event type identifier. A concrete dotted leaf, e.g.\n`client.status.offline`; interior segments never carry events.\n"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "First segment of the type identifier, e.g. `client`."
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "description": "Second segment of the type identifier, e.g. `error`. `null` for\ntwo-segment types such as `client.created`.\n"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name, e.g. `Client Offline`."
+          },
+          "description": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "info",
+              "warning",
+              "critical"
+            ]
+          },
+          "versions": {
+            "type": "array",
+            "description": "Payload data versions supported for this event type.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "data_version": {
+                  "type": "integer",
+                  "description": "Payload data version. Bare integer; rendering such as `v1` is presentation-only."
+                },
+                "data_example": {
+                  "type": "object",
+                  "description": "Example instance of the event `data` payload for this version.\nNot a JSON Schema and not the delivery envelope.\n",
+                  "additionalProperties": true
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "deprecated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true,
+                  "description": "Timestamp at which this data version was deprecated. `null` while\nthe version is current. Deprecation does not invalidate existing\nsubscription pins.\n"
+                }
+              }
+            }
+          }
+        }
+      },
+      "model.alert": {
+        "type": "object",
+        "description": "Alert resource — a named, user-managed rule with an embedded set of\nsubscriptions that bind it to channels (e.g. webhooks) for specific event types.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "disabled_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "disabled_by": {
+            "$ref": "#/components/schemas/null.string.response"
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Subscription record embedded in the Alert resource. Binds the parent alert to\na channel for a specific `event_type` and `version`. The parent `alert_id` is\nimplied by containment in an `AlertView` and is omitted from this view.\n",
+              "properties": {
+                "channel_id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "ID of the alert channel (e.g. webhook) this subscription targets."
+                },
+                "event_type": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "integer",
+                  "description": "Payload data version this subscription targets."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "disabled_at": {
+                  "$ref": "#/components/schemas/null.time.response"
+                },
+                "disabled_by": {
+                  "$ref": "#/components/schemas/null.string.response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "model.alert-subscription-request": {
+        "type": "object",
+        "description": "Subscription element accepted in an Alert create or update request. The\nparent `alert_id` is supplied by the URL path on update or generated on\ncreate, and is not accepted in this payload.\n",
+        "required": [
+          "channel_id",
+          "event_type",
+          "version"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "disabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "model.alert-attempt": {
+        "type": "object",
+        "description": "System-generated delivery attempt for a single `(alert, channel, event)`\ntuple. Read-only via the API. Identity is the composite key\n`(alert_id, channel_id, event_id)`.\n",
+        "properties": {
+          "alert_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "channel_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "event_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "succeeded_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          },
+          "last_status_code": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "last_error": {
+            "$ref": "#/components/schemas/null.string.response"
+          },
+          "attempts": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total dispatch attempts fired."
+          },
+          "next_attempt_at": {
+            "$ref": "#/components/schemas/null.time.response"
+          }
+        }
       }
     },
     "responses": {
@@ -24690,6 +28079,7 @@
         "Events (Schedules)",
         "Attack Paths",
         "Risk Posture",
+        "Asset Scores",
         "Meta Entities",
         "Alerts"
       ]

--- a/docs/reference/alerts/create-alert-webhook.mdx
+++ b/docs/reference/alerts/create-alert-webhook.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/alert-webhooks
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/create-alert.mdx
+++ b/docs/reference/alerts/create-alert.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/alerts
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/delete-alert-webhook.mdx
+++ b/docs/reference/alerts/delete-alert-webhook.mdx
@@ -1,0 +1,5 @@
+---
+openapi: delete /api/v2/alert-webhooks/{alert_webhook_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/delete-alert.mdx
+++ b/docs/reference/alerts/delete-alert.mdx
@@ -1,0 +1,5 @@
+---
+openapi: delete /api/v2/alerts/{alert_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/get-alert-event.mdx
+++ b/docs/reference/alerts/get-alert-event.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-events/{alert_event_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/get-alert-webhook.mdx
+++ b/docs/reference/alerts/get-alert-webhook.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-webhooks/{alert_webhook_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/get-alert.mdx
+++ b/docs/reference/alerts/get-alert.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alerts/{alert_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/list-alert-attempts.mdx
+++ b/docs/reference/alerts/list-alert-attempts.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-attempts
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/list-alert-event-types.mdx
+++ b/docs/reference/alerts/list-alert-event-types.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-event-types
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/list-alert-events.mdx
+++ b/docs/reference/alerts/list-alert-events.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-events
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/list-alert-webhooks.mdx
+++ b/docs/reference/alerts/list-alert-webhooks.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alert-webhooks
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/list-alerts.mdx
+++ b/docs/reference/alerts/list-alerts.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/alerts
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/retry-alert-attempt.mdx
+++ b/docs/reference/alerts/retry-alert-attempt.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/alert-attempts/retry
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/rotate-alert-webhook-secret.mdx
+++ b/docs/reference/alerts/rotate-alert-webhook-secret.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/alert-webhooks/{alert_webhook_id}/rotate-secret
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/test-alert-webhook.mdx
+++ b/docs/reference/alerts/test-alert-webhook.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/alert-webhooks/{alert_webhook_id}/test
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/update-alert-webhook.mdx
+++ b/docs/reference/alerts/update-alert-webhook.mdx
@@ -1,0 +1,5 @@
+---
+openapi: patch /api/v2/alert-webhooks/{alert_webhook_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/alerts/update-alert.mdx
+++ b/docs/reference/alerts/update-alert.mdx
@@ -1,0 +1,5 @@
+---
+openapi: patch /api/v2/alerts/{alert_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/asset-scores/get-zone-protected-asset-score.mdx
+++ b/docs/reference/asset-scores/get-zone-protected-asset-score.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/asset-scores/zone-protected-asset-score
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/complete-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/complete-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts/{artifact_id}/complete
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/create-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/create-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/delete-a-management-operation-artifact-for-the-client.mdx
+++ b/docs/reference/clients/delete-a-management-operation-artifact-for-the-client.mdx
@@ -1,0 +1,5 @@
+---
+openapi: delete /api/v2/clients/{client_id}/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/download-a-management-operation-artifact-for-the-client-1.mdx
+++ b/docs/reference/clients/download-a-management-operation-artifact-for-the-client-1.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/{client_id}/artifacts/{artifact_id}/download
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/download-a-management-operation-artifact-for-the-client.mdx
+++ b/docs/reference/clients/download-a-management-operation-artifact-for-the-client.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/{client_id}/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/get-a-client-artifact-download-url.mdx
+++ b/docs/reference/clients/get-a-client-artifact-download-url.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/{client_id}/artifacts/{artifact_id}/download-url
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/get-an-artifact-upload-session.mdx
+++ b/docs/reference/clients/get-an-artifact-upload-session.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/management/artifacts/{artifact_id}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/get-available-management-operations.mdx
+++ b/docs/reference/clients/get-available-management-operations.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/v2/clients/management/available
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/queues-a-management-operation.mdx
+++ b/docs/reference/clients/queues-a-management-operation.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/{client_id}/management
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>

--- a/docs/reference/clients/upload-an-artifact-part.mdx
+++ b/docs/reference/clients/upload-an-artifact-part.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}
+---
+
+<img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise Only"/>


### PR DESCRIPTION
## Summary

This pull request (PR) updates the OpenAPI spec that we use to generate the REST API reference for the v9.7.0 release.

Aside from updates to request and response properties for existing paths, the following significant updates were made.

### New endpoints

Mostly related to the collector support bundles, notification system, and protected asset scores:

- `GET /api/v2/alert-attempts`
- `POST /api/v2/alert-attempts/retry`
- `GET /api/v2/alert-event-types`
- `GET /api/v2/alert-events`
- `GET /api/v2/alert-events/{alert_event_id}`
- `GET /api/v2/alert-webhooks`
- `POST /api/v2/alert-webhooks`
- `DELETE /api/v2/alert-webhooks/{alert_webhook_id}`
- `GET /api/v2/alert-webhooks/{alert_webhook_id}`
- `PATCH /api/v2/alert-webhooks/{alert_webhook_id}`
- `POST /api/v2/alert-webhooks/{alert_webhook_id}/rotate-secret`
- `POST /api/v2/alert-webhooks/{alert_webhook_id}/test`
- `GET /api/v2/alerts`
- `POST /api/v2/alerts`
- `DELETE /api/v2/alerts/{alert_id}`
- `GET /api/v2/alerts/{alert_id}`
- `PATCH /api/v2/alerts/{alert_id}`
- `GET /api/v2/asset-scores/zone-protected-asset-score`
- `POST /api/v2/clients/management/artifacts`
- `GET /api/v2/clients/management/artifacts/{artifact_id}`
- `POST /api/v2/clients/management/artifacts/{artifact_id}/complete`
- `POST /api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}`
- `GET /api/v2/clients/management/available`
- `POST /api/v2/clients/management/end`
- `POST /api/v2/clients/management/start`
- `DELETE /api/v2/clients/{client_id}/artifacts/{artifact_id}`
- `GET /api/v2/clients/{client_id}/artifacts/{artifact_id}`
- `GET /api/v2/clients/{client_id}/artifacts/{artifact_id}/download`
- `POST /api/v2/clients/{client_id}/artifacts/{artifact_id}/download-url`
- `POST /api/v2/clients/{client_id}/management`

See attachment for oasdiff: 
[openapi_change.log](https://github.com/user-attachments/files/31704798/openapi_change.log)