### PR TITLE
BED-9542: update azurehound image uri

### DIFF
--- a/docs/assets/deploy/deployment.yaml
+++ b/docs/assets/deploy/deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: azurehound
-          image: ghcr.io/bloodhoundad/azurehound:latest
+          image: ghcr.io/specterops/azurehound:latest
           imagePullPolicy: IfNotPresent
           args: ['start']
           env:


### PR DESCRIPTION
Point to the current azurehound docker image on GHCR

ref: BED-9542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AzureHound container image source used during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->