### PR TITLE
BED-9542: Update AzureHound image URI

### DIFF
--- a/docs/assets/deploy/docker-compose.yaml
+++ b/docs/assets/deploy/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3.8"
 services:
     azurehound:
-        image: ghcr.io/bloodhoundad/azurehound:latest
+        image: ghcr.io/specterops/azurehound:latest
         command: 'start --config /config/config.json'
         container_name: azurehound
         network_mode: bridge


### PR DESCRIPTION
Update AzureHound docker image URI for docker-compose

ref: BED-9542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the AzureHound container image reference used by Docker Compose deployments.
  - Deployments now pull the image from the SpecterOps container registry path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->