### PR TITLE
DOCS-37: v9.7.0 release notes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -937,14 +937,15 @@
                 "group": "Release Notes",
                 "pages": [
                   "resources/release-notes/summary",
+                  "resources/release-notes/2026-09-08",
                   "resources/release-notes/2026-08-18",
-                  "resources/release-notes/2026-08-04",
                   {
                     "group": "Archive",
                     "pages": [
                       {
                         "group": "2026",
                         "pages": [
+                          "resources/release-notes/2026-08-04",
                           "resources/release-notes/2026-07-29",
                           "resources/release-notes/2026-07-07",
                           "resources/release-notes/2026-06-17",

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -151,7 +151,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   ### Actions
   {/*BED-9146, BED-9144*/}
 
-  A [action bar](/analyze-data/findings/table-view#open-a-remediation-plan-or-explore-a-finding) is now available when you select findings in the Findings Table. The action bar allows you to open a finding's remediation plan or pivot directly to the **Explore** page for further investigation.
+  An [action bar](/analyze-data/findings/table-view#open-a-remediation-plan-or-explore-a-finding) is now available when you select findings in the Findings Table. The action bar allows you to open a finding's remediation plan or pivot directly to the **Explore** page for further investigation.
 
   ### Filtering and Context
 

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -131,7 +131,9 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   {/*BED-8871*/}
   ## Multi-Destination Pathfinding
 
-  Build a pathfinding query through up to two additional destination nodes. Reorder or remove destination nodes in the query, then review the combined graph result for the selected route.
+  Build a [pathfinding](/analyze-data/explore/search#pathfinding) query through up to three additional destination nodes.
+  
+  BloodHound now supports a total of four destination nodes in pathfinding. You can reorder or remove destination nodes in the query, then review the combined graph result for the selected route.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -1,0 +1,179 @@
+---
+title: 2026-09-08 Release Notes
+description: Learn about new features, enhancements, and fixed issues in BloodHound.
+sidebarTitle: "2026-09-08"
+---
+
+import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-09-08 | v9.7.0 | v0.4.0 | v2.16.0 | v3.1.1 |
+
+<CollectorDeprecationNotice />
+
+<Tip>
+  Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
+</Tip>
+
+<Update label="BloodHound" description="New Feature" tags={["Administration"]}>
+  {/*BED-7944, BED-9366, BED-9362, BED-8380, BED-8379, BED-8377, BED-8020, BED-9482, BED-9257, BED-9256, BED-9215, BED-8994, BED-8993, BED-8992, BED-8600, BED-8599, BED-8569, BED-8568, BED-8566, BED-8565, BED-8557, BED-8556, BED-8555, BED-8554, BED-8553, BED-8552, BED-8549, BED-9561*/}
+  ## Webhook Alerts <Badge color="yellow">Beta</Badge>
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Monitor collector availability with configurable webhook alerts. Create reusable generic HTTPS webhook destinations, connect them to **Collector Offline** rules, and review delivery results in **Event History**.
+
+  You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
+  {/*BED-7970, BED-9475, BED-9361, BED-9218, BED-9152, BED-8835, BED-8129, BED-7975, BED-7968*/}
+  ## Collector Support Bundles
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Request, download, and delete diagnostic support bundles from **Manage Clients** for supported SharpHound Enterprise and OpenHound collectors.
+
+  BloodHound Enterprise only displays support-bundle controls for compatible collector versions, downloads bundles through your browser, and automatically removes expired bundles. See [Manage collector support bundles](/collect-data/enterprise-collection/collector-support-bundles) for prerequisites and usage instructions.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
+  {/*BED-9126*/}
+  ## Enterprise Marketplace
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page. This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
+  {/*BED-8604, BED-9022, BED-9017*/}
+  ## Dynamic Entity Panel Content
+
+  Render selected-entity data in custom OpenGraph Entity Panel sections with Go templates in extension definition schemas.
+
+  BloodHound validates template syntax when you upload the schema, helping you catch invalid templates before they reach the Entity Panel. Dynamic Markdown supports node and relationship properties, conditional content, and supported helper functions.
+</Update>
+
+<Update label="OpenHound" description="New Feature" tags={["Microsoft Entra ID"]}>
+  {/*BED-9298, BED-9297*/}
+  ## Microsoft Entra ID Application Identity Collection
+
+  Analyze Microsoft Entra ID application identities with improved application and service-principal graph identity alignment and federated identity credential collection.
+
+  These updates improve the consistency of application relationships and surface federated credentials that can affect how workloads authenticate.
+</Update>
+
+<Update label="SharpHound" description="New Feature" tags={["Data Collection"]}>
+  {/*BED-8117*/}
+  ## Custom Deny ACE Counts
+
+  Audit explicitly denied access in Active Directory with new collected counts for custom explicit and inherited deny access control entries (ACEs).
+
+  SharpHound filters known default and system-protective deny ACE patterns so the counts focus on meaningful, custom-configured deny permissions. Use the `SkipDenyAcesCount` option when you do not want to collect these properties.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["Posture"]}>
+  {/*BED-8863, BED-8848, BED-8760*/}
+  ## Protected Asset Score
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Evaluate the protection of assets in each Privilege Zone with the new Protected Asset Score. The score uses the zone's active findings and asset-group tags to help you identify where protection requires attention.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  {/*BED-8618, BED-8947, BED-8623, BED-8622, BED-8281, BED-9241*/}
+  ## Findings Table Filtering and Context
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Use the Findings Table to focus investigations more precisely with cross-platform filtering, an Attack Path type filter, result counts, and a direct table view from Attack Path Management.
+
+  The updated layout keeps filters usable when the navigation panel is expanded.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  {/*BED-8785, BED-9442, BED-9081, BED-9024, BED-8951, BED-8918, BED-8620*/}
+  ## Findings Prioritization
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Compare active findings with prioritization scores and ranks in the Findings Table and the Attack Paths findings API. BloodHound uses calculated starting objects and analysis data to order findings, helping you focus remediation work on the most significant risks.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
+  {/*BED-9043*/}
+  ## Accessible Explore Toolbar and Export Options
+
+  Navigate the Explore graph toolbar with accessible icons, tooltips, improved keyboard behavior, and clearer screen-reader labels.
+
+  BloodHound Enterprise can also provide optional export actions in the **Export** menu while retaining JSON as the default export format.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
+  {/*BED-8871*/}
+  ## Multi-Destination Pathfinding
+
+  Build a pathfinding query through up to two additional destination nodes. Reorder or remove destination nodes in the query, then review the combined graph result for the selected route.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  {/*BED-9220, BED-9146, BED-9144, BED-9333*/}
+  ## Findings Table Actions
+
+  Select findings to open an action bar with a remediation-plan link or pivot directly to Explore for further investigation.
+
+  Updated multi-select controls and client create/edit dialogs make selected, empty, and configuration states easier to interpret.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
+  {/*BED-7211, BED-9129, BED-9128, BED-9127, BED-8975, BED-8641, BED-8639, BED-8635, BED-7225, BED-7223, BED-7220, BED-7217, BED-9173, BED-9172*/}
+  ## Accessibility Improvements
+
+  Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors that do not rely on color alone.
+
+  Form validation, posture results, environment selection, data tables, Administration, and Privilege Zones receive additional accessibility coverage and behavior improvements.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-9559, BED-9063, BED-8759*/}
+  ## OpenHound Configuration and Diagnostics
+
+  Use the current OpenHound GitHub collector with OpenHound v0.4.0 and configure the BloodHound Enterprise destination URL consistently in `config.toml` for asset uploads.
+
+  Collection logs now identify the installed collector extension version to make troubleshooting easier.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Cypher"]}>
+  {/*BED-9469*/}
+  ## More Efficient Cypher Query Optimization
+
+  Run Cypher queries with reduced CPU overhead from the query optimizer. The updated translation cache and optimization workflow reduce redundant work while preserving query optimization behavior.
+</Update>
+
+<Update label="BloodHound" tags={["Fixed Issues"]}>
+  ## API and Attack Paths
+
+  - {/*BED-9471*/} Resolved an issue where archived findings could return an active status from the Attack Paths findings API.
+  - {/*BED-9358*/} Resolved an issue where Findings Table filters could fail for environment IDs containing characters such as `:`.
+
+  ## Cypher
+
+  - {/*BED-8955*/} Resolved an issue where Cypher queries using traversal expansion to find a cyclical loop could fail.
+  - {/*BED-8779*/} Improved query optimization for Cypher queries that begin with an unbounded traversal expansion, reducing avoidable timeouts.
+
+  ## Data Quality and OpenGraph
+
+  - {/*BED-9445*/} Resolved an issue where the **Data Quality** page could fail to load after you switched domains.
+  - {/*BED-9316*/} Resolved an issue where columns in the **OpenGraph Management** table could be inaccessible when content wrapped.
+
+  ## Explore and Findings Table
+
+  - {/*BED-9216*/} Resolved an issue where the Cypher panel did not render correctly the first time you switched from a completed pathfinding query.
+  - {/*BED-9157*/} Resolved an issue where selecting a node reset manually positioned graph nodes.
+  - {/*BED-9107*/} Resolved a Findings Table column-header contrast regression in light and dark modes.
+  - {/*BED-9563*/} Improved tooltip contrast for Attack Paths finding charts in dark mode.
+</Update>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -34,7 +34,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Create reusable generic HTTPS webhook destinations, connect them with configurable alert rules, and review delivery attempts.
+  Create reusable generic HTTPS webhooks, connect them to configurable rules, and review delivery attempts.
   
   The initial release of [Alerts](/manage-bloodhound/alerts/overview) supports the **Collector Offline** event type and **Webhook** delivery method to monitor collector availability. You can configure rules to trigger when a collector is offline for a specified duration and BloodHound Enterprise will send an alert to the configured webhook URL.
 

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -86,7 +86,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   | [`GET`](/reference/clients/download-a-management-operation-artifact-for-the-client-1) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}/download` |
 </Update>
 
-<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
+<Update label="BloodHound" description="New Feature" tags={["Administration"]}>
   {/*BED-9126*/}
   ## Enterprise Marketplace
 
@@ -95,6 +95,15 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page.
   
   This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases. Click the <Icon icon="grid-2" size={24} /> icon in the left navigation panel to open the **Marketplace** page.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
+  {/*BED-7211, BED-9129, BED-9128, BED-9127, BED-8975, BED-8641, BED-8639, BED-8635, BED-7225, BED-7223, BED-7220, BED-7217, BED-9173, BED-9172*/}
+  ## Accessibility Improvements
+
+  Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors that do not rely on color alone.
+
+  Form validation, posture results, environment selection, data tables, Administration, and Privilege Zones receive additional accessibility coverage and behavior improvements.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
@@ -113,15 +122,6 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   Build a [pathfinding](/analyze-data/explore/search#pathfinding) query through up to three destination nodes, which can help focus the results on a specific set of nodes.
   
   BloodHound now supports up to four pathfinding nodes total: one source and three destinations. You can reorder nodes, remove destination nodes, and review the combined graph result for the selected route.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
-  {/*BED-7211, BED-9129, BED-9128, BED-9127, BED-8975, BED-8641, BED-8639, BED-8635, BED-7225, BED-7223, BED-7220, BED-7217, BED-9173, BED-9172*/}
-  ## Accessibility Improvements
-
-  Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors that do not rely on color alone.
-
-  Form validation, posture results, environment selection, data tables, Administration, and Privilege Zones receive additional accessibility coverage and behavior improvements.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
@@ -173,22 +173,6 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-9063*/}
-  ## OpenHound Configuration
-
-  Store the BloodHound Enterprise destination URL as configuration instead of a secret when you configure [CLI authentication](/openhound/upload-extension-assets#configure-cli-authentication) for extension asset uploads.
-  
-  OpenHound now reads the destination URL from `~/.dlt/config.toml` and the browser JWT from `~/.dlt/secrets.toml`. This change separates the destination URL from sensitive credentials, which remain in the secrets file.
-</Update>
-
-<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-8759*/}
-  ## OpenHound Logs
-
-  Review collector lifecycle logs to identify the collector name and version, OpenHound version, and job ID, making it easier to troubleshoot collection runs.
-</Update>
-
-<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9562, BED-9519, BED-9505*/}
   ## GitHub and Okta Collection Resilience
 
@@ -201,7 +185,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   - Organization-only GitHub collections also resolve the canonical organization login before resource collection begins, preventing case-sensitive lookup failures.
 </Update>
 
-<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9473*/}
   ## GitHub Enterprise Role Memberships
 
@@ -210,7 +194,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   OpenHound now uses the available enterprise or organization-backed collection paths to populate `GH_User -[:GH_HasRole]-> GH_EnterpriseRole` relationships.
 </Update>
 
-<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9472*/}
   ## GitHub EMU External Group Modeling
 
@@ -219,13 +203,31 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   OpenHound adds the `external_group_id` and `external_group_name` properties and emits a `SCIM_Provisioned` relationship to the matching `SCIM_Group` when the corresponding SCIM data is available.
 </Update>
 
-<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9437*/}
   ## Authoritative Okta Application-Group Assignments
 
   Collect group-to-application assignments from Okta's application assignment endpoints instead of relying on group statistics that may be stale.
 
   The collector preserves the existing `Okta_AppAssignment` relationships and assignment evidence while failing closed when required assignment data is incomplete or ambiguous.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8759*/}
+  ## OpenHound Logs
+
+  Review collector lifecycle logs to identify the collector name and version, OpenHound version, and job ID, making it easier to troubleshoot collection runs.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-9063*/}
+  ## OpenHound Configuration
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Store the BloodHound Enterprise destination URL as configuration instead of a secret when you configure [CLI authentication](/openhound/upload-extension-assets#configure-cli-authentication) for extension asset uploads.
+  
+  OpenHound now reads the destination URL from `~/.dlt/config.toml` and the browser JWT from `~/.dlt/secrets.toml`. This change separates the destination URL from sensitive credentials, which remain in the secrets file.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -94,16 +94,16 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page.
   
-  This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases. Click the <Icon icon="grid-2" size={24} /> icon in the left navigation panel to open the **Marketplace** page.
+  This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases. Click the <Icon icon="grid-2" /> icon in the left navigation panel to open the **Marketplace** page.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
   {/*BED-7211, BED-9129, BED-9128, BED-9127, BED-8975, BED-8641, BED-8639, BED-8635, BED-7225, BED-7223, BED-7220, BED-7217, BED-9173, BED-9172*/}
   ## Accessibility Improvements
 
-  Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors that do not rely on color alone.
+  Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors.
 
-  Form validation, posture results, environment selection, data tables, Administration, and Privilege Zones receive additional accessibility coverage and behavior improvements.
+  Form validation, posture results, environment selection, data tables, administration, and Zone Builder receive additional accessibility coverage and behavior improvements.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
@@ -134,7 +134,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   
   The score shows the percentage of objects in the selected zone that do not have Attack Path findings, helping you identify where protection requires attention over time.
 
-  This feature introduces new APIs to retrieve protection score results for Privilege Zones. You can use them to programmatically retrieve the protection score for a specific Privilege Zone or for all Privilege Zones in the current environment:
+  This feature introduces a new API to retrieve protection score results for Privilege Zones. You can use it to programmatically retrieve the protection score for a specific Privilege Zone or for all Privilege Zones in the current environment:
 
   | Method | Endpoint |
   | --- | --- |
@@ -176,7 +176,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   {/*BED-9562, BED-9519, BED-9505*/}
   ## GitHub and Okta Collection Resilience
 
-  Improve collection reliability for large environments and organization-scoped GitHub runs.
+  Improve collection reliability for large environments and organization-scoped GitHub collection runs.
 
   - The Okta collector pages expanded group requests and retries the initial request with limits of 200, 100, and 50 when a timeout persists. You can tune these and other Okta resource page sizes with the new [pagination settings](/openhound/collectors/okta/collect-data#pagination-settings).
 

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -184,7 +184,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   {/*BED-9508*/}
   ## GitHub Enterprise Server Endpoint Support
 
-  Configure separate `rest_api_url` and `graphql_url` values to collect data from GitHub Enterprise Server. GitHub.com remains the default, so existing configurations continue to work without changes.
+  [Configure](/openhound/collectors/github/collect-data#configure-github-enterprise-server-endpoints) separate `rest_api_url` and `graphql_url` values to collect data from GitHub Enterprise Server. GitHub.com remains the default, so existing configurations continue to work without changes.
 
   The endpoint settings must use HTTPS, share the same origin, and be configured together. GitHub App authentication and PAT validation now use the configured REST endpoint instead of assuming GitHub.com.
 </Update>
@@ -204,11 +204,11 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   Improve collection reliability for large environments and organization-scoped GitHub runs.
 
-  The Okta collector pages expanded group requests and retries the initial request with limits of 200, 100, and 50 when a timeout persists.
+  - The Okta collector pages expanded group requests and retries the initial request with limits of 200, 100, and 50 when a timeout persists. You can tune these and other Okta resource page sizes with the new [pagination settings](/openhound/collectors/okta/collect-data#pagination-settings).
 
-  The GitHub collector reduces repository GraphQL page sizes from 100 to 50 and then 25 after transient gateway failures, then returns to the default page size when later pages succeed.
+  - The GitHub collector reduces repository GraphQL page sizes from 100 to 50 and then 25 after transient gateway failures, then returns to the default page size when later pages succeed.
 
-  Organization-only GitHub collections also resolve the canonical organization login before resource collection begins, preventing case-sensitive lookup failures.
+  - Organization-only GitHub collections also resolve the canonical organization login before resource collection begins, preventing case-sensitive lookup failures.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -166,18 +166,18 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   <BetaAccessNote feature="Findings Table" />
 
   ### Actions
-  {/*BED-9220, BED-9146, BED-9144, BED-9333*/}
+  {/*BED-9146, BED-9144*/}
 
-  Select findings to open an action bar with a remediation-plan link or pivot directly to Explore for further investigation.
-
-  Updated multi-select controls and client create/edit dialogs make selected, empty, and configuration states easier to interpret.
+  A [action bar](/analyze-data/findings/table-view#open-a-remediation-plan-or-explore-a-finding) is now available when you select findings in the Findings Table. The action bar allows you to open a finding's remediation plan or pivot directly to the **Explore** page for further investigation.
 
   ### Filtering and Context
-  {/*BED-8618, BED-8947, BED-8623, BED-8622, BED-8281, BED-9241*/}
 
-  Use the Findings Table to focus investigations more precisely with cross-platform filtering, an Attack Path type filter, result counts, and a direct table view from Attack Path Management.
+  This release also includes the following enhancements to the Findings Table filtering behavior:
 
-  The updated layout keeps filters usable when the navigation panel is expanded.
+  - {/*BED-9220*/} Default-selected filters now use an outlined enabled state and visually change when you modify their selections, so you can distinguish filters that remain at their defaults from filters you changed.
+  - {/*BED-8281*/} Use the new **Attack Path** filter to select one or more Attack Path types and limit the table to matching findings.
+  - {/*BED-8622*/} View the total number of findings that match the current filter selections in a count displayed above the table. The count updates as you change the filters.
+  - {/*BED-8623*/} Open a finding in the Findings Table from its Attack Path details in the Graph view. The finding's status, environment, and Privilege Zone context are carried into the table so you can continue the investigation with the relevant filters applied.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
@@ -263,4 +263,5 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   - {/*BED-9358*/} Resolved an issue where Findings Table filters could fail for environment IDs containing characters such as `:`.
   - {/*BED-9107*/} Resolved a Findings Table column-header contrast regression in light and dark modes.
   - {/*BED-9563*/} Improved tooltip contrast for Attack Paths finding charts in dark mode.
+  - {/*BED-9241*/} Resolved an issue where Findings Table filters overflowed when the navigation panel was expanded.
 </Update>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -36,7 +36,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   Create reusable generic HTTPS webhook destinations, connect them with configurable alert rules, and review delivery attempts.
   
-  This release supports the **Collector Offline** event type and **Webhook** delivery method to monitor collector availability. You can configure alert rules to trigger when a collector is offline for a specified duration, and BloodHound Enterprise will send an alert to the configured webhook destination.
+  The initial release of [Alerts](/manage-bloodhound/alerts/overview) supports the **Collector Offline** event type and **Webhook** delivery method to monitor collector availability. You can configure rules to trigger when a collector is offline for a specified duration and BloodHound Enterprise will send an alert to the configured webhook URL.
 
   <EarlyAccessNote feature="Alerts" />
 

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -4,8 +4,8 @@ description: Learn about new features, enhancements, and fixed issues in BloodHo
 sidebarTitle: "2026-09-08"
 ---
 
-import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+import EarlyAccessNote from '/snippets/feature-flag-user-managed.mdx';
 import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
 <Tip>
@@ -30,17 +30,17 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
 <Update label="BloodHound" description="New Feature" tags={["Administration"]}>
   {/*BED-7944, BED-9366, BED-9362, BED-8380, BED-8379, BED-8377, BED-8020, BED-9482, BED-9257, BED-9256, BED-9215, BED-8994, BED-8993, BED-8992, BED-8600, BED-8599, BED-8569, BED-8568, BED-8566, BED-8565, BED-8557, BED-8556, BED-8555, BED-8554, BED-8553, BED-8552, BED-8549, BED-9561*/}
-  ## Webhook Alerts <Badge color="yellow">Beta</Badge>
+  ## Webhook Alerts <Badge color="yellow">Early Access</Badge>
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Monitor collector availability with configurable webhook alerts. Create reusable generic HTTPS webhook destinations, define rules for **Collector Offline** events, and review delivery results.
+  Create reusable generic HTTPS webhook destinations, connect them with configurable alert rules, and review delivery attempts.
+  
+  This release supports the **Collector Offline** event type and **Webhook** delivery method to monitor collector availability. You can configure alert rules to trigger when a collector is offline for a specified duration, and BloodHound Enterprise will send an alert to the configured webhook destination.
 
-  You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
+  <EarlyAccessNote feature="Alerts" />
 
-  <BetaAccessNote feature="Alerts" />
-
-  This feature introduces new APIs to manage alerts. You can use them to programmatically manage webhooks and  rules, inspect event types, events, and delivery attempts, test webhook destinations, rotate webhook secrets, and retry failed deliveries:
+  This feature introduces new APIs to manage alerts. You can use them to programmatically manage webhooks and rules, inspect event types, events, and delivery attempts, test webhook destinations, rotate webhook secrets, and retry failed deliveries:
 
   | Method | Endpoint |
   | --- | --- |

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -4,7 +4,13 @@ description: Learn about new features, enhancements, and fixed issues in BloodHo
 sidebarTitle: "2026-09-08"
 ---
 
+import BetaAccessNote from '/snippets/feature-flag-user-managed.mdx';
 import CollectorDeprecationNotice from '/snippets/resources/collector-deprecation-notice.mdx';
+import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
+
+<Tip>
+  Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
+</Tip>
 
 |     |     |     |     |     |
 | --- | --- | --- | --- | --- |
@@ -13,9 +19,14 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 
 <CollectorDeprecationNotice />
 
-<Tip>
-  Use the filters on the right side of this page to narrow down the updates by component. You can select multiple filters at the same time to refine your results.
-</Tip>
+<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
+  {/*BED-8604, BED-9022, BED-9017*/}
+  ## Dynamic Entity Panel Content
+
+  Render selected-entity data in custom OpenGraph Entity Panel sections with Go templates in extension definition schemas.
+
+  BloodHound validates template syntax when you upload the schema, helping you catch invalid templates before they reach the Entity Panel. Dynamic Markdown supports node and relationship properties, conditional content, and supported helper functions.
+</Update>
 
 <Update label="BloodHound" description="New Feature" tags={["Administration"]}>
   {/*BED-7944, BED-9366, BED-9362, BED-8380, BED-8379, BED-8377, BED-8020, BED-9482, BED-9257, BED-9256, BED-9215, BED-8994, BED-8993, BED-8992, BED-8600, BED-8599, BED-8569, BED-8568, BED-8566, BED-8565, BED-8557, BED-8556, BED-8555, BED-8554, BED-8553, BED-8552, BED-8549, BED-9561*/}
@@ -23,9 +34,11 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Monitor collector availability with configurable webhook alerts. Create reusable generic HTTPS webhook destinations, connect them to **Collector Offline** rules, and review delivery results in **Event History**.
+  Monitor collector availability with configurable webhook alerts. Create reusable generic HTTPS webhook destinations, define rules for **Collector Offline** events, and review delivery results.
 
   You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
+
+  <BetaAccessNote feature="Alerts" />
 </Update>
 
 <Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
@@ -34,9 +47,10 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Request, download, and delete diagnostic support bundles from **Manage Clients** for supported SharpHound Enterprise and OpenHound collectors.
+  Request, download, and delete diagnostic [support bundles](/collect-data/enterprise-collection/collector-support-bundles) from the **Manage Clients** page for SharpHound Enterprise and OpenHound collector clients.
 
-  BloodHound Enterprise only displays support-bundle controls for compatible collector versions, downloads bundles through your browser, and automatically removes expired bundles. See [Manage collector support bundles](/collect-data/enterprise-collection/collector-support-bundles) for prerequisites and usage instructions.
+  SharpHound Enterprise v2.16.0 or OpenHound v0.4.0 are prerequisites for this feature.
+  <FeatureFlagNote />
 </Update>
 
 <Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
@@ -48,65 +62,9 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page. This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases.
 </Update>
 
-<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
-  {/*BED-8604, BED-9022, BED-9017*/}
-  ## Dynamic Entity Panel Content
-
-  Render selected-entity data in custom OpenGraph Entity Panel sections with Go templates in extension definition schemas.
-
-  BloodHound validates template syntax when you upload the schema, helping you catch invalid templates before they reach the Entity Panel. Dynamic Markdown supports node and relationship properties, conditional content, and supported helper functions.
-</Update>
-
-<Update label="OpenHound" description="New Feature" tags={["Microsoft Entra ID"]}>
-  {/*BED-9298, BED-9297*/}
-  ## Microsoft Entra ID Application Identity Collection
-
-  Analyze Microsoft Entra ID application identities with improved application and service-principal graph identity alignment and federated identity credential collection.
-
-  These updates improve the consistency of application relationships and surface federated credentials that can affect how workloads authenticate.
-</Update>
-
-<Update label="SharpHound" description="New Feature" tags={["Data Collection"]}>
-  {/*BED-8117*/}
-  ## Custom Deny ACE Counts
-
-  Audit explicitly denied access in Active Directory with new collected counts for custom explicit and inherited deny access control entries (ACEs).
-
-  SharpHound filters known default and system-protective deny ACE patterns so the counts focus on meaningful, custom-configured deny permissions. Use the `SkipDenyAcesCount` option when you do not want to collect these properties.
-</Update>
-
-<Update label="BloodHound" description="New Feature" tags={["Posture"]}>
-  {/*BED-8863, BED-8848, BED-8760*/}
-  ## Protected Asset Score
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Evaluate the protection of assets in each Privilege Zone with the new Protected Asset Score. The score uses the zone's active findings and asset-group tags to help you identify where protection requires attention.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
-  {/*BED-8618, BED-8947, BED-8623, BED-8622, BED-8281, BED-9241*/}
-  ## Findings Table Filtering and Context
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Use the Findings Table to focus investigations more precisely with cross-platform filtering, an Attack Path type filter, result counts, and a direct table view from Attack Path Management.
-
-  The updated layout keeps filters usable when the navigation panel is expanded.
-</Update>
-
-<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
-  {/*BED-8785, BED-9442, BED-9081, BED-9024, BED-8951, BED-8918, BED-8620*/}
-  ## Findings Prioritization
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Compare active findings with prioritization scores and ranks in the Findings Table and the Attack Paths findings API. BloodHound uses calculated starting objects and analysis data to order findings, helping you focus remediation work on the most significant risks.
-</Update>
-
 <Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
   {/*BED-9043*/}
-  ## Accessible Explore Toolbar and Export Options
+  ## Accessible Explore Toolbar
 
   Navigate the Explore graph toolbar with accessible icons, tooltips, improved keyboard behavior, and clearer screen-reader labels.
 
@@ -120,15 +78,6 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Build a pathfinding query through up to two additional destination nodes. Reorder or remove destination nodes in the query, then review the combined graph result for the selected route.
 </Update>
 
-<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
-  {/*BED-9220, BED-9146, BED-9144, BED-9333*/}
-  ## Findings Table Actions
-
-  Select findings to open an action bar with a remediation-plan link or pivot directly to Explore for further investigation.
-
-  Updated multi-select controls and client create/edit dialogs make selected, empty, and configuration states easier to interpret.
-</Update>
-
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
   {/*BED-7211, BED-9129, BED-9128, BED-9127, BED-8975, BED-8641, BED-8639, BED-8635, BED-7225, BED-7223, BED-7220, BED-7217, BED-9173, BED-9172*/}
   ## Accessibility Improvements
@@ -136,6 +85,37 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Navigate BloodHound with clearer focus indicators, improved keyboard navigation, more useful screen-reader announcements, and chart colors that do not rely on color alone.
 
   Form validation, posture results, environment selection, data tables, Administration, and Privilege Zones receive additional accessibility coverage and behavior improvements.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  {/*BED-8863, BED-8848, BED-8760*/}
+  ## Protected Asset Score
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Evaluate the protection of assets in each Privilege Zone with the new Protected Asset Score. The score uses the zone's active findings and asset-group tags to help you identify where protection requires attention.
+</Update>
+
+<Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
+  ## Findings Table <Badge color="yellow">Beta</Badge>
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  <BetaAccessNote feature="Findings Table" />
+
+  ### Actions
+  {/*BED-9220, BED-9146, BED-9144, BED-9333*/}
+
+  Select findings to open an action bar with a remediation-plan link or pivot directly to Explore for further investigation.
+
+  Updated multi-select controls and client create/edit dialogs make selected, empty, and configuration states easier to interpret.
+
+  ### Filtering and Context
+  {/*BED-8618, BED-8947, BED-8623, BED-8622, BED-8281, BED-9241*/}
+
+  Use the Findings Table to focus investigations more precisely with cross-platform filtering, an Attack Path type filter, result counts, and a direct table view from Attack Path Management.
+
+  The updated layout keeps filters usable when the navigation panel is expanded.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
@@ -147,33 +127,29 @@ import CollectorDeprecationNotice from '/snippets/resources/collector-deprecatio
   Collection logs now identify the installed collector extension version to make troubleshooting easier.
 </Update>
 
-<Update label="BloodHound" description="Enhancement" tags={["Cypher"]}>
-  {/*BED-9469*/}
-  ## More Efficient Cypher Query Optimization
-
-  Run Cypher queries with reduced CPU overhead from the query optimizer. The updated translation cache and optimization workflow reduce redundant work while preserving query optimization behavior.
-</Update>
-
 <Update label="BloodHound" tags={["Fixed Issues"]}>
-  ## API and Attack Paths
-
-  - {/*BED-9471*/} Resolved an issue where archived findings could return an active status from the Attack Paths findings API.
-  - {/*BED-9358*/} Resolved an issue where Findings Table filters could fail for environment IDs containing characters such as `:`.
-
   ## Cypher
 
   - {/*BED-8955*/} Resolved an issue where Cypher queries using traversal expansion to find a cyclical loop could fail.
   - {/*BED-8779*/} Improved query optimization for Cypher queries that begin with an unbounded traversal expansion, reducing avoidable timeouts.
+  - {/*BED-9469*/} Resolved an issue where Cypher query optimization consumed excessive CPU, increasing query durations and causing failures.
 
-  ## Data Quality and OpenGraph
+  ## Explore
+
+  - {/*BED-9216*/} Resolved an issue where the Cypher panel did not render correctly the first time you switched from a completed pathfinding query.
+  - {/*BED-9157*/} Resolved an issue where selecting a node reset manually positioned graph nodes.
+
+  ## OpenGraph
 
   - {/*BED-9445*/} Resolved an issue where the **Data Quality** page could fail to load after you switched domains.
   - {/*BED-9316*/} Resolved an issue where columns in the **OpenGraph Management** table could be inaccessible when content wrapped.
 
-  ## Explore and Findings Table
+  ## Findings
 
-  - {/*BED-9216*/} Resolved an issue where the Cypher panel did not render correctly the first time you switched from a completed pathfinding query.
-  - {/*BED-9157*/} Resolved an issue where selecting a node reset manually positioned graph nodes.
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  - {/*BED-9471*/} Resolved an issue where archived findings could return an active status from the Attack Paths findings API.
+  - {/*BED-9358*/} Resolved an issue where Findings Table filters could fail for environment IDs containing characters such as `:`.
   - {/*BED-9107*/} Resolved a Findings Table column-header contrast regression in light and dark modes.
   - {/*BED-9563*/} Improved tooltip contrast for Attack Paths finding charts in dark mode.
 </Update>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -38,6 +38,8 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
 
+  To automate alert configuration and delivery workflows, see the [alert APIs](#alerts).
+
   <BetaAccessNote feature="Alerts" />
 </Update>
 
@@ -50,6 +52,8 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   Request, download, and delete diagnostic [support bundles](/collect-data/enterprise-collection/collector-support-bundles) from the **Manage Clients** page for SharpHound Enterprise and OpenHound collector clients.
 
   SharpHound Enterprise v2.16.0 or OpenHound v0.4.0 are prerequisites for this feature.
+
+  To automate collector management and artifact workflows, see the [collector management and artifact APIs](#collector-management-and-artifacts).
   <FeatureFlagNote />
 </Update>
 
@@ -60,6 +64,58 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page. This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases.
+</Update>
+
+<Update label="BloodHound" description="New Feature" tags={["API"]}>
+  ## New API Endpoints
+
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Automate alerting, collector management, artifact transfers, and Protected Asset Score workflows with new BloodHound API v2 endpoints.
+
+  ### Alerts
+
+  Manage alert webhooks and alert rules, inspect event types, events, and delivery attempts, test webhook destinations, rotate webhook secrets, and retry failed deliveries:
+
+  | Method | Endpoint |
+  | --- | --- |
+  | [`GET`](/reference/alerts/list-alert-webhooks), [`POST`](/reference/alerts/create-alert-webhook) | `/api/v2/alert-webhooks` |
+  | [`GET`](/reference/alerts/get-alert-webhook), [`PATCH`](/reference/alerts/update-alert-webhook), [`DELETE`](/reference/alerts/delete-alert-webhook) | `/api/v2/alert-webhooks/{alert_webhook_id}` |
+  | [`POST`](/reference/alerts/rotate-alert-webhook-secret) | `/api/v2/alert-webhooks/{alert_webhook_id}/rotate-secret` |
+  | [`POST`](/reference/alerts/test-alert-webhook) | `/api/v2/alert-webhooks/{alert_webhook_id}/test` |
+  | [`GET`](/reference/alerts/list-alert-event-types) | `/api/v2/alert-event-types` |
+  | [`GET`](/reference/alerts/list-alert-events) | `/api/v2/alert-events` |
+  | [`GET`](/reference/alerts/get-alert-event) | `/api/v2/alert-events/{alert_event_id}` |
+  | [`GET`](/reference/alerts/list-alerts), [`POST`](/reference/alerts/create-alert) | `/api/v2/alerts` |
+  | [`GET`](/reference/alerts/get-alert), [`PATCH`](/reference/alerts/update-alert), [`DELETE`](/reference/alerts/delete-alert) | `/api/v2/alerts/{alert_id}` |
+  | [`GET`](/reference/alerts/list-alert-attempts) | `/api/v2/alert-attempts` |
+  | [`POST`](/reference/alerts/retry-alert-attempt) | `/api/v2/alert-attempts/retry` |
+
+  ### Collector Management and Artifacts
+
+  Queue collector management operations, report operation status, and upload, retrieve, download, or delete operation artifacts:
+
+  | Method | Endpoint |
+  | --- | --- |
+  | [`GET`](/reference/clients/get-available-management-operations) | `/api/v2/clients/management/available` |
+  | [`POST`](/reference/clients/queues-a-management-operation) | `/api/v2/clients/{client_id}/management` |
+  | [`POST`](/reference/clients/notifies-the-api-of-a-management-operation-start) | `/api/v2/clients/management/start` |
+  | [`POST`](/reference/clients/notifies-the-api-of-a-management-operation-ending) | `/api/v2/clients/management/end` |
+  | [`POST`](/reference/clients/create-an-artifact-upload-session) | `/api/v2/clients/management/artifacts` |
+  | [`GET`](/reference/clients/get-an-artifact-upload-session) | `/api/v2/clients/management/artifacts/{artifact_id}` |
+  | [`POST`](/reference/clients/upload-an-artifact-part) | `/api/v2/clients/management/artifacts/{artifact_id}/parts/{part_number}` |
+  | [`POST`](/reference/clients/complete-an-artifact-upload-session) | `/api/v2/clients/management/artifacts/{artifact_id}/complete` |
+  | [`GET`](/reference/clients/download-a-management-operation-artifact-for-the-client), [`DELETE`](/reference/clients/delete-a-management-operation-artifact-for-the-client) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}` |
+  | [`POST`](/reference/clients/get-a-client-artifact-download-url) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}/download-url` |
+  | [`GET`](/reference/clients/download-a-management-operation-artifact-for-the-client-1) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}/download` |
+
+  ### Protected Asset Score
+
+  Retrieve Protected Asset Score results for Privilege Zones:
+
+  | Method | Endpoint |
+  | --- | --- |
+  | [`GET`](/reference/asset-scores/get-zone-protected-asset-score) | `/api/v2/asset-scores/zone-protected-asset-score` |
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
@@ -94,6 +150,8 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
   Evaluate the protection of assets in each Privilege Zone with the new Protected Asset Score. The score uses the zone's active findings and asset-group tags to help you identify where protection requires attention.
+
+  To retrieve scores programmatically, see the [Protected Asset Score API](#protected-asset-score).
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -30,7 +30,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
 <Update label="BloodHound" description="New Feature" tags={["Administration"]}>
   {/*BED-7944, BED-9366, BED-9362, BED-8380, BED-8379, BED-8377, BED-8020, BED-9482, BED-9257, BED-9256, BED-9215, BED-8994, BED-8993, BED-8992, BED-8600, BED-8599, BED-8569, BED-8568, BED-8566, BED-8565, BED-8557, BED-8556, BED-8555, BED-8554, BED-8553, BED-8552, BED-8549, BED-9561*/}
-  ## Webhook Alerts <Badge color="yellow">Early Access</Badge>
+  ## Alerts <Badge color="yellow">Early Access</Badge>
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -38,7 +38,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
 
-  To automate alert configuration and delivery workflows, see the [alert APIs](#alerts).
+  To automate alert configuration and delivery workflows, see the [alert APIs](/resources/release-notes/2026-09-08#alerts).
 
   <BetaAccessNote feature="Alerts" />
 </Update>
@@ -53,7 +53,7 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   SharpHound Enterprise v2.16.0 or OpenHound v0.4.0 are prerequisites for this feature.
 
-  To automate collector management and artifact workflows, see the [collector management and artifact APIs](#collector-management-and-artifacts).
+  To automate collector management and artifact workflows, see the [collector management and artifact APIs](/resources/release-notes/2026-09-08#collector-management-and-artifacts).
   <FeatureFlagNote />
 </Update>
 
@@ -147,13 +147,15 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
 <Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
   {/*BED-8863, BED-8848, BED-8760*/}
-  ## Protected Asset Score
+  ## Protection Score
 
   <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  Evaluate the protection of assets in each Privilege Zone with the new Protected Asset Score. The score uses the zone's active findings and asset-group tags to help you identify where protection requires attention.
+  Evaluate the protection of assets in each Privilege Zone with the new Protection Score on the [Posture](/analyze-data/findings/posture) page.
+  
+  The score shows the percentage of objects in the selected zone that do not have Attack Path findings, helping you identify where protection requires attention over time.
 
-  To retrieve scores programmatically, see the [Protected Asset Score API](#protected-asset-score).
+  To retrieve scores programmatically, see the [Protected Asset Score API](/resources/release-notes/2026-09-08#protected-asset-score).
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -179,12 +179,61 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-9508*/}
+  ## GitHub Enterprise Server Endpoint Support
+
+  Configure separate `rest_api_url` and `graphql_url` values to collect data from GitHub Enterprise Server. GitHub.com remains the default, so existing configurations continue to work without changes.
+
+  The endpoint settings must use HTTPS, share the same origin, and be configured together. GitHub App authentication and PAT validation now use the configured REST endpoint instead of assuming GitHub.com.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
   {/*BED-9559, BED-9063, BED-8759*/}
   ## OpenHound Configuration and Diagnostics
 
   Use the current OpenHound GitHub collector with OpenHound v0.4.0 and configure the BloodHound Enterprise destination URL consistently in `config.toml` for asset uploads.
 
   Collection logs now identify the installed collector extension version to make troubleshooting easier.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-9562, BED-9519, BED-9505*/}
+  ## GitHub and Okta Collection Resilience
+
+  Improve collection reliability for large environments and organization-scoped GitHub runs.
+
+  The Okta collector pages expanded group requests and retries the initial request with limits of 200, 100, and 50 when a timeout persists.
+
+  The GitHub collector reduces repository GraphQL page sizes from 100 to 50 and then 25 after transient gateway failures, then returns to the default page size when later pages succeed.
+
+  Organization-only GitHub collections also resolve the canonical organization login before resource collection begins, preventing case-sensitive lookup failures.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-9473*/}
+  ## GitHub Enterprise Role Memberships
+
+  Restore accurate membership data for the synthetic `GH_EnterpriseRole` `owners` and `members` roles across supported GitHub authentication configurations.
+
+  OpenHound now uses the available enterprise or organization-backed collection paths to populate `GH_User -[:GH_HasRole]-> GH_EnterpriseRole` relationships.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-9472*/}
+  ## GitHub EMU External Group Modeling
+
+  Collect external identity-provider group metadata for normal `GH_Team` nodes in GitHub Enterprise Managed User organizations.
+
+  OpenHound adds the `external_group_id` and `external_group_name` properties and emits a `SCIM_Provisioned` relationship to the matching `SCIM_Group` when the corresponding SCIM data is available.
+</Update>
+
+<Update label="OpenHound" description="Enhancement" tags={["OpenGraph"]}>
+  {/*BED-9437*/}
+  ## Authoritative Okta Application-Group Assignments
+
+  Collect group-to-application assignments from Okta's application assignment endpoints instead of relying on group statistics that may be stale.
+
+  The collector preserves the existing `Okta_AppAssignment` relationships and assignment evidence while failing closed when required assignment data is incomplete or ambiguous.
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>

--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -38,44 +38,9 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 
   You can test a destination before using it, enable or disable individual rules and destinations, and retry failed delivery attempts. BloodHound Enterprise signs webhook requests with an HMAC secret so your receiver can verify their origin.
 
-  To automate alert configuration and delivery workflows, see the [alert APIs](/resources/release-notes/2026-09-08#alerts).
-
   <BetaAccessNote feature="Alerts" />
-</Update>
 
-<Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
-  {/*BED-7970, BED-9475, BED-9361, BED-9218, BED-9152, BED-8835, BED-8129, BED-7975, BED-7968*/}
-  ## Collector Support Bundles
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Request, download, and delete diagnostic [support bundles](/collect-data/enterprise-collection/collector-support-bundles) from the **Manage Clients** page for SharpHound Enterprise and OpenHound collector clients.
-
-  SharpHound Enterprise v2.16.0 or OpenHound v0.4.0 are prerequisites for this feature.
-
-  To automate collector management and artifact workflows, see the [collector management and artifact APIs](/resources/release-notes/2026-09-08#collector-management-and-artifacts).
-  <FeatureFlagNote />
-</Update>
-
-<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
-  {/*BED-9126*/}
-  ## Enterprise Marketplace
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page. This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases.
-</Update>
-
-<Update label="BloodHound" description="New Feature" tags={["API"]}>
-  ## New API Endpoints
-
-  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
-
-  Automate alerting, collector management, artifact transfers, and Protected Asset Score workflows with new BloodHound API v2 endpoints.
-
-  ### Alerts
-
-  Manage alert webhooks and alert rules, inspect event types, events, and delivery attempts, test webhook destinations, rotate webhook secrets, and retry failed deliveries:
+  This feature introduces new APIs to manage alerts. You can use them to programmatically manage webhooks and  rules, inspect event types, events, and delivery attempts, test webhook destinations, rotate webhook secrets, and retry failed deliveries:
 
   | Method | Endpoint |
   | --- | --- |
@@ -90,10 +55,21 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   | [`GET`](/reference/alerts/get-alert), [`PATCH`](/reference/alerts/update-alert), [`DELETE`](/reference/alerts/delete-alert) | `/api/v2/alerts/{alert_id}` |
   | [`GET`](/reference/alerts/list-alert-attempts) | `/api/v2/alert-attempts` |
   | [`POST`](/reference/alerts/retry-alert-attempt) | `/api/v2/alert-attempts/retry` |
+</Update>
 
-  ### Collector Management and Artifacts
+<Update label="BloodHound" description="New Feature" tags={["Data Collection"]}>
+  {/*BED-7970, BED-9475, BED-9361, BED-9218, BED-9152, BED-8835, BED-8129, BED-7975, BED-7968*/}
+  ## Collector Support Bundles
 
-  Queue collector management operations, report operation status, and upload, retrieve, download, or delete operation artifacts:
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
+
+  Request, download, and delete diagnostic [support bundles](/collect-data/enterprise-collection/collector-support-bundles) from the **Manage Clients** page for SharpHound Enterprise and OpenHound collector clients.
+
+  SharpHound Enterprise v2.16.0 or OpenHound v0.4.0 are prerequisites for this feature.
+
+  <FeatureFlagNote />
+
+  This feature introduces new APIs to manage support bundles for collector clients. You can use them to programmatically request, download, and delete support bundles, as well as retrieve available management operations and upload artifacts for management operations:
 
   | Method | Endpoint |
   | --- | --- |
@@ -108,14 +84,17 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   | [`GET`](/reference/clients/download-a-management-operation-artifact-for-the-client), [`DELETE`](/reference/clients/delete-a-management-operation-artifact-for-the-client) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}` |
   | [`POST`](/reference/clients/get-a-client-artifact-download-url) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}/download-url` |
   | [`GET`](/reference/clients/download-a-management-operation-artifact-for-the-client-1) | `/api/v2/clients/{client_id}/artifacts/{artifact_id}/download` |
+</Update>
 
-  ### Protected Asset Score
+<Update label="BloodHound" description="New Feature" tags={["OpenGraph"]}>
+  {/*BED-9126*/}
+  ## Enterprise Marketplace
 
-  Retrieve Protected Asset Score results for Privilege Zones:
+  <img noZoom src="/assets/enterprise-edition-pill-tag.svg" alt="Applies to BloodHound Enterprise only" style={{ width: "25%" }}/>
 
-  | Method | Endpoint |
-  | --- | --- |
-  | [`GET`](/reference/asset-scores/get-zone-protected-asset-score) | `/api/v2/asset-scores/zone-protected-asset-score` |
+  Discover supported OpenGraph extensions, community extensions, and integrations from the new **Marketplace** page.
+  
+  This initial release includes search, filtering, and links to learn more, with expanded Marketplace capabilities planned for future releases. Click the <Icon icon="grid-2" size={24} /> icon in the left navigation panel to open the **Marketplace** page.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Explore"]}>
@@ -131,9 +110,9 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   {/*BED-8871*/}
   ## Multi-Destination Pathfinding
 
-  Build a [pathfinding](/analyze-data/explore/search#pathfinding) query through up to three additional destination nodes.
+  Build a [pathfinding](/analyze-data/explore/search#pathfinding) query through up to three destination nodes, which can help focus the results on a specific set of nodes.
   
-  BloodHound now supports a total of four destination nodes in pathfinding. You can reorder or remove destination nodes in the query, then review the combined graph result for the selected route.
+  BloodHound now supports up to four pathfinding nodes total: one source and three destinations. You can reorder nodes, remove destination nodes, and review the combined graph result for the selected route.
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Accessibility"]}>
@@ -155,7 +134,11 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
   
   The score shows the percentage of objects in the selected zone that do not have Attack Path findings, helping you identify where protection requires attention over time.
 
-  To retrieve scores programmatically, see the [Protected Asset Score API](/resources/release-notes/2026-09-08#protected-asset-score).
+  This feature introduces new APIs to retrieve protection score results for Privilege Zones. You can use them to programmatically retrieve the protection score for a specific Privilege Zone or for all Privilege Zones in the current environment:
+
+  | Method | Endpoint |
+  | --- | --- |
+  | [`GET`](/reference/asset-scores/get-zone-protected-asset-score) | `/api/v2/asset-scores/zone-protected-asset-score` |
 </Update>
 
 <Update label="BloodHound" description="Enhancement" tags={["Attack Paths"]}>
@@ -190,12 +173,19 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
-  {/*BED-9559, BED-9063, BED-8759*/}
-  ## OpenHound Configuration and Diagnostics
+  {/*BED-9063*/}
+  ## OpenHound Configuration
 
-  Use the current OpenHound GitHub collector with OpenHound v0.4.0 and configure the BloodHound Enterprise destination URL consistently in `config.toml` for asset uploads.
+  Store the BloodHound Enterprise destination URL as configuration instead of a secret when you configure [CLI authentication](/openhound/upload-extension-assets#configure-cli-authentication) for extension asset uploads.
+  
+  OpenHound now reads the destination URL from `~/.dlt/config.toml` and the browser JWT from `~/.dlt/secrets.toml`. This change separates the destination URL from sensitive credentials, which remain in the secrets file.
+</Update>
 
-  Collection logs now identify the installed collector extension version to make troubleshooting easier.
+<Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>
+  {/*BED-8759*/}
+  ## OpenHound Logs
+
+  Review collector lifecycle logs to identify the collector name and version, OpenHound version, and job ID, making it easier to troubleshoot collection runs.
 </Update>
 
 <Update label="OpenHound" description="Enhancement" tags={["Data Collection"]}>

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -25,35 +25,37 @@ Choose from courses covering red team operations, identity-driven offensive trad
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-09-08 | v9.7.0 | v0.4.0 | v2.16.0 | v3.1.1 |
 
-This release adds new operational workflows for webhook alerts and collector support bundles, expands OpenGraph and collector capabilities, and improves how BloodHound Enterprise prioritizes and investigates findings.
+This release expands OpenGraph customization and Marketplace discovery, adds webhook alerts and collector diagnostics workflows, and improves investigation workflows in BloodHound Enterprise.
 
 Key highlights include:
 
-- **Operational visibility**: Send signed Collector Offline webhook alerts and request support bundles directly from **Manage Clients**.
-- **Attack Path analysis**: Filter, prioritize, and act on Findings Table results more effectively, and evaluate Privilege Zone protected assets with a new score.
-- **Collection**: Audit custom Active Directory deny ACEs with SharpHound and collect Microsoft Entra ID federated identity credentials with OpenHound.
+- **OpenGraph**: Add dynamic, data-driven content to Entity Panel sections.
+- **Marketplace**: Discover supported extensions, community extensions, and integrations with search and filtering.
+- **Collector diagnostics**: Request, download, and delete SharpHound Enterprise and OpenHound support bundles directly from the **Manage Clients** page.
 
 ### <Icon icon="sparkles" /> New Features
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Administration | [Webhook Alerts](/resources/release-notes/2026-09-08#webhook-alerts-beta) | Send signed **Collector Offline** events to generic HTTPS webhook destinations. |
-| Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request and download SharpHound Enterprise and OpenHound diagnostics from **Manage Clients**. |
 | OpenGraph | [Dynamic Entity Panel Content](/resources/release-notes/2026-09-08#dynamic-entity-panel-content) | Render selected entity data in custom OpenGraph Entity Panel Markdown. |
-| Data Collection | [Custom Deny ACE Counts](/resources/release-notes/2026-09-08#custom-deny-ace-counts) | Audit meaningful custom explicit and inherited deny ACEs in Active Directory. |
+| Administration | [Webhook Alerts](/resources/release-notes/2026-09-08#webhook-alerts-beta) | Monitor collector availability with signed **Collector Offline** webhook alerts. |
+| Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request, download, and delete SharpHound Enterprise and OpenHound diagnostics from the **Manage Clients** page. |
+| Marketplace | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported extensions, community extensions, and integrations with search and filtering. |
 
 ### <Icon icon="check-circle" /> Enhancements
 
 | Component | Update | Summary |
 | --- | --- | --- |
-| Attack Paths | [Findings Table Filtering and Context](/resources/release-notes/2026-09-08#findings-table-filtering-and-context) | Filter Findings Table results by cross-platform status and Attack Path type, with clearer result context. |
-| Attack Paths | [Findings Prioritization](/resources/release-notes/2026-09-08#findings-prioritization) | Use calculated scores and ranks to focus remediation on the most significant findings. |
-| Posture | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
+| Explore | [Accessible Explore Toolbar](/resources/release-notes/2026-09-08#accessible-explore-toolbar) | Navigate the Explore graph toolbar with improved keyboard behavior, tooltips, and screen-reader labels. |
 | Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to two additional destination nodes. |
+| Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
+| Attack Paths | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
+| Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
+| Data Collection | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 
-See the [release notes](/resources/release-notes/2026-09-08#api-and-attack-paths) for a full list of fixed issues in this release.
+See the [release notes](/resources/release-notes/2026-09-08#cypher) for a full list of fixed issues in this release.
 
 ## 2026-08-18
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -38,7 +38,7 @@ Key highlights include:
 | Component | Update | Summary |
 | --- | --- | --- |
 | OpenGraph | [Dynamic Entity Panel Content](/resources/release-notes/2026-09-08#dynamic-entity-panel-content) | Render selected entity data in custom OpenGraph Entity Panel Markdown. |
-| Administration | [Webhook Alerts](/resources/release-notes/2026-09-08#webhook-alerts-beta) | Monitor collector availability with signed **Collector Offline** webhook alerts. |
+| Administration | [Alerts](/resources/release-notes/2026-09-08#alerts-early-access) | Monitor collector availability with signed **Collector Offline** webhook alerts. |
 | Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request, download, and delete SharpHound Enterprise and OpenHound diagnostics from the **Manage Clients** page. |
 | Marketplace | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported extensions, community extensions, and integrations with search and filtering. |
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Summary
 This page provides a summary of recent BloodHound product releases, including release dates, version numbers, and links to detailed release notes.
 
 <Tip>
-  See the release notes [archive](/resources/release-notes/v8-4-0) for previous releases.
+  See the release notes [archive](/resources/release-notes/2026-08-04) for previous releases.
 </Tip>
 
 ## <Icon icon="bullhorn" /> Announcements
@@ -30,7 +30,7 @@ This release expands OpenGraph customization and Marketplace discovery, adds web
 Key highlights include:
 
 - **Pathfinding**: Build routes through up to three destination nodes in a single pathfinding query.
-- **Marketplace**: Discover supported extensions, community extensions, and integrations with search and filtering.
+- **Marketplace**: Discover supported OpenGraph extensions, community extensions, and integrations with search and filtering.
 - **Collector Support Bundles**: Request, download, and delete SharpHound Enterprise and OpenHound support bundles directly from the **Manage Clients** page.
 
 ### <Icon icon="sparkles" /> New Features
@@ -40,7 +40,7 @@ Key highlights include:
 | OpenGraph | [Dynamic Entity Panel Content](/resources/release-notes/2026-09-08#dynamic-entity-panel-content) | Render selected entity data in custom OpenGraph Entity Panel Markdown. |
 | Administration | [Alerts](/resources/release-notes/2026-09-08#alerts-early-access) | Monitor collector availability with signed **Collector Offline** webhook alerts. |
 | Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request, download, and delete SharpHound Enterprise and OpenHound diagnostics from the **Manage Clients** page. |
-| Administration | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported extensions, community extensions, and integrations with search and filtering. |
+| Administration | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported OpenGraph extensions, community extensions, and integrations with search and filtering. |
 
 ### <Icon icon="check-circle" /> Enhancements
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -25,13 +25,13 @@ Choose from courses covering red team operations, identity-driven offensive trad
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-09-08 | v9.7.0 | v0.4.0 | v2.16.0 | v3.1.1 |
 
-This release expands OpenGraph customization and Marketplace discovery, adds webhook alerts and collector diagnostics workflows, and improves OpenHound collection compatibility and data accuracy.
+This release expands OpenGraph customization and Marketplace discovery, adds webhook alerts and collector support bundle workflows, and improves Explore, Findings, and OpenHound collection capabilities.
 
 Key highlights include:
 
-- **OpenGraph**: Add dynamic, data-driven content to Entity Panel sections.
+- **Pathfinding**: Build routes through up to three destination nodes in a single pathfinding query.
 - **Marketplace**: Discover supported extensions, community extensions, and integrations with search and filtering.
-- **Collector diagnostics**: Request, download, and delete SharpHound Enterprise and OpenHound support bundles directly from the **Manage Clients** page.
+- **Collector Support Bundles**: Request, download, and delete SharpHound Enterprise and OpenHound support bundles directly from the **Manage Clients** page.
 
 ### <Icon icon="sparkles" /> New Features
 
@@ -47,11 +47,12 @@ Key highlights include:
 | Component | Update | Summary |
 | --- | --- | --- |
 | Explore | [Accessible Explore Toolbar](/resources/release-notes/2026-09-08#accessible-explore-toolbar) | Navigate the Explore graph toolbar with improved keyboard behavior, tooltips, and screen-reader labels. |
-| Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to two additional destination nodes. |
+| Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to three destination nodes. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
 | Attack Paths | [Protection Score](/resources/release-notes/2026-09-08#protection-score) | Evaluate the protection of assets in each Privilege Zone. |
 | Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
-| Data Collection | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
+| Data Collection | [OpenHound Configuration](/resources/release-notes/2026-09-08#openhound-configuration) | Keep OpenHound destination URLs in `config.toml` and sensitive credentials in `secrets.toml` for extension asset uploads. |
+| Data Collection | [OpenHound Logs](/resources/release-notes/2026-09-08#openhound-logs) | Identify the collector name and version, OpenHound version, and job ID in collector lifecycle logs. |
 | Data Collection | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |
 | Data Collection | [GitHub and Okta Collection Resilience](/resources/release-notes/2026-09-08#github-and-okta-collection-resilience) | Recover from large-environment timeouts, transient GitHub gateway failures, and organization-login casing differences. |
 | Data Collection | [GitHub Enterprise Role Memberships](/resources/release-notes/2026-09-08#github-enterprise-role-memberships) | Restore accurate `owners` and `members` role memberships in GitHub enterprise data. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -25,7 +25,7 @@ Choose from courses covering red team operations, identity-driven offensive trad
 | **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
 | 2026-09-08 | v9.7.0 | v0.4.0 | v2.16.0 | v3.1.1 |
 
-This release expands OpenGraph customization and Marketplace discovery, adds webhook alerts and collector diagnostics workflows, and improves investigation workflows in BloodHound Enterprise.
+This release expands OpenGraph customization and Marketplace discovery, adds webhook alerts and collector diagnostics workflows, and improves OpenHound collection compatibility and data accuracy.
 
 Key highlights include:
 
@@ -51,7 +51,12 @@ Key highlights include:
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
 | Attack Paths | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
 | Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
-| Data Collection | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
+| OpenHound | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |
+| OpenHound | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
+| OpenHound | [GitHub and Okta Collection Resilience](/resources/release-notes/2026-09-08#github-and-okta-collection-resilience) | Recover from large-environment timeouts, transient GitHub gateway failures, and organization-login casing differences. |
+| OpenHound | [GitHub Enterprise Role Memberships](/resources/release-notes/2026-09-08#github-enterprise-role-memberships) | Restore accurate `owners` and `members` role memberships in GitHub enterprise data. |
+| OpenHound | [GitHub EMU External Group Modeling](/resources/release-notes/2026-09-08#github-emu-external-group-modeling) | Connect normal GitHub teams to matching SCIM groups in Enterprise Managed User organizations. |
+| OpenHound | [Authoritative Okta Application-Group Assignments](/resources/release-notes/2026-09-08#authoritative-okta-application-group-assignments) | Collect reliable group-to-application assignments from Okta's application endpoints. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -11,18 +11,49 @@ This page provides a summary of recent BloodHound product releases, including re
 </Tip>
 
 ## <Icon icon="bullhorn" /> Announcements
-
-### Webinar: The Evolution of Identity Attack Path Management
-
-Join Jared Atkinson and Justin Kohler on August 25 for a community conversation about how AI, AWS, non-human identities, and hybrid identity attack paths are changing the way security teams think about identity risk.
-
-Join us live or watch the recording afterward to continue the conversation. [Register here](https://app.livestorm.co/specterops/securing-the-ai-era-the-next-evolution-of-identity-attack-path-management).
  
 ### Specter Bash 2026: Four days of Trick-or-Tradecrafting
 
 Join us October 5-8 in Denver or virtually for four days of technical training taught by the operators who build and run SpecterOps engagements.
 
 Choose from courses covering red team operations, identity-driven offensive tradecraft, detection engineering, and Azure security, with community events and connection throughout the week. [Explore Specter Bash](https://specterops.io/specter-bash/).
+
+## 2026-09-08
+
+|     |     |     |     |     |
+| --- | --- | --- | --- | --- |
+| **Release** | **BloodHound** | **OpenHound** | **SharpHound** | **AzureHound** |
+| 2026-09-08 | v9.7.0 | v0.4.0 | v2.16.0 | v3.1.1 |
+
+This release adds new operational workflows for webhook alerts and collector support bundles, expands OpenGraph and collector capabilities, and improves how BloodHound Enterprise prioritizes and investigates findings.
+
+Key highlights include:
+
+- **Operational visibility**: Send signed Collector Offline webhook alerts and request support bundles directly from **Manage Clients**.
+- **Attack Path analysis**: Filter, prioritize, and act on Findings Table results more effectively, and evaluate Privilege Zone protected assets with a new score.
+- **Collection**: Audit custom Active Directory deny ACEs with SharpHound and collect Microsoft Entra ID federated identity credentials with OpenHound.
+
+### <Icon icon="sparkles" /> New Features
+
+| Component | Update | Summary |
+| --- | --- | --- |
+| Administration | [Webhook Alerts](/resources/release-notes/2026-09-08#webhook-alerts-beta) | Send signed **Collector Offline** events to generic HTTPS webhook destinations. |
+| Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request and download SharpHound Enterprise and OpenHound diagnostics from **Manage Clients**. |
+| OpenGraph | [Dynamic Entity Panel Content](/resources/release-notes/2026-09-08#dynamic-entity-panel-content) | Render selected entity data in custom OpenGraph Entity Panel Markdown. |
+| Data Collection | [Custom Deny ACE Counts](/resources/release-notes/2026-09-08#custom-deny-ace-counts) | Audit meaningful custom explicit and inherited deny ACEs in Active Directory. |
+
+### <Icon icon="check-circle" /> Enhancements
+
+| Component | Update | Summary |
+| --- | --- | --- |
+| Attack Paths | [Findings Table Filtering and Context](/resources/release-notes/2026-09-08#findings-table-filtering-and-context) | Filter Findings Table results by cross-platform status and Attack Path type, with clearer result context. |
+| Attack Paths | [Findings Prioritization](/resources/release-notes/2026-09-08#findings-prioritization) | Use calculated scores and ranks to focus remediation on the most significant findings. |
+| Posture | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
+| Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to two additional destination nodes. |
+
+### <Icon icon="wrench" /> Fixed Issues
+
+See the [release notes](/resources/release-notes/2026-09-08#api-and-attack-paths) for a full list of fixed issues in this release.
 
 ## 2026-08-18
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -40,24 +40,24 @@ Key highlights include:
 | OpenGraph | [Dynamic Entity Panel Content](/resources/release-notes/2026-09-08#dynamic-entity-panel-content) | Render selected entity data in custom OpenGraph Entity Panel Markdown. |
 | Administration | [Alerts](/resources/release-notes/2026-09-08#alerts-early-access) | Monitor collector availability with signed **Collector Offline** webhook alerts. |
 | Data Collection | [Collector Support Bundles](/resources/release-notes/2026-09-08#collector-support-bundles) | Request, download, and delete SharpHound Enterprise and OpenHound diagnostics from the **Manage Clients** page. |
-| Marketplace | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported extensions, community extensions, and integrations with search and filtering. |
+| Administration | [Enterprise Marketplace](/resources/release-notes/2026-09-08#enterprise-marketplace) | Discover supported extensions, community extensions, and integrations with search and filtering. |
 
 ### <Icon icon="check-circle" /> Enhancements
 
 | Component | Update | Summary |
 | --- | --- | --- |
+| Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
 | Explore | [Accessible Explore Toolbar](/resources/release-notes/2026-09-08#accessible-explore-toolbar) | Navigate the Explore graph toolbar with improved keyboard behavior, tooltips, and screen-reader labels. |
 | Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to three destination nodes. |
-| Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
 | Attack Paths | [Protection Score](/resources/release-notes/2026-09-08#protection-score) | Evaluate the protection of assets in each Privilege Zone. |
 | Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
-| Data Collection | [OpenHound Configuration](/resources/release-notes/2026-09-08#openhound-configuration) | Keep OpenHound destination URLs in `config.toml` and sensitive credentials in `secrets.toml` for extension asset uploads. |
-| Data Collection | [OpenHound Logs](/resources/release-notes/2026-09-08#openhound-logs) | Identify the collector name and version, OpenHound version, and job ID in collector lifecycle logs. |
 | Data Collection | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |
 | Data Collection | [GitHub and Okta Collection Resilience](/resources/release-notes/2026-09-08#github-and-okta-collection-resilience) | Recover from large-environment timeouts, transient GitHub gateway failures, and organization-login casing differences. |
 | Data Collection | [GitHub Enterprise Role Memberships](/resources/release-notes/2026-09-08#github-enterprise-role-memberships) | Restore accurate `owners` and `members` role memberships in GitHub enterprise data. |
 | Data Collection | [GitHub EMU External Group Modeling](/resources/release-notes/2026-09-08#github-emu-external-group-modeling) | Connect normal GitHub teams to matching SCIM groups in Enterprise Managed User organizations. |
 | Data Collection | [Authoritative Okta Application-Group Assignments](/resources/release-notes/2026-09-08#authoritative-okta-application-group-assignments) | Collect reliable group-to-application assignments from Okta's application endpoints. |
+| Data Collection | [OpenHound Logs](/resources/release-notes/2026-09-08#openhound-logs) | Identify the collector name and version, OpenHound version, and job ID in collector lifecycle logs. |
+| Data Collection | [OpenHound Configuration](/resources/release-notes/2026-09-08#openhound-configuration) | Keep OpenHound destination URLs in `config.toml` and sensitive credentials in `secrets.toml` for extension asset uploads. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -49,7 +49,7 @@ Key highlights include:
 | Explore | [Accessible Explore Toolbar](/resources/release-notes/2026-09-08#accessible-explore-toolbar) | Navigate the Explore graph toolbar with improved keyboard behavior, tooltips, and screen-reader labels. |
 | Explore | [Multi-Destination Pathfinding](/resources/release-notes/2026-09-08#multi-destination-pathfinding) | Build routes through up to two additional destination nodes. |
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
-| Attack Paths | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
+| Attack Paths | [Protection Score](/resources/release-notes/2026-09-08#protection-score) | Evaluate the protection of assets in each Privilege Zone. |
 | Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
 | Data Collection | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
 | Data Collection | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -51,12 +51,12 @@ Key highlights include:
 | Accessibility | [Accessibility Improvements](/resources/release-notes/2026-09-08#accessibility-improvements) | Navigate BloodHound with clearer focus indicators, improved keyboard navigation, and more useful screen-reader announcements. |
 | Attack Paths | [Protected Asset Score](/resources/release-notes/2026-09-08#protected-asset-score) | Evaluate the protection of assets in each Privilege Zone. |
 | Attack Paths | [Findings Table](/resources/release-notes/2026-09-08#findings-table-beta) | Filter findings by cross-platform status and Attack Path type, review result context, and pivot to remediation or Explore. |
-| OpenHound | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |
-| OpenHound | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
-| OpenHound | [GitHub and Okta Collection Resilience](/resources/release-notes/2026-09-08#github-and-okta-collection-resilience) | Recover from large-environment timeouts, transient GitHub gateway failures, and organization-login casing differences. |
-| OpenHound | [GitHub Enterprise Role Memberships](/resources/release-notes/2026-09-08#github-enterprise-role-memberships) | Restore accurate `owners` and `members` role memberships in GitHub enterprise data. |
-| OpenHound | [GitHub EMU External Group Modeling](/resources/release-notes/2026-09-08#github-emu-external-group-modeling) | Connect normal GitHub teams to matching SCIM groups in Enterprise Managed User organizations. |
-| OpenHound | [Authoritative Okta Application-Group Assignments](/resources/release-notes/2026-09-08#authoritative-okta-application-group-assignments) | Collect reliable group-to-application assignments from Okta's application endpoints. |
+| Data Collection | [OpenHound Configuration and Diagnostics](/resources/release-notes/2026-09-08#openhound-configuration-and-diagnostics) | Configure the OpenHound destination URL consistently and identify the installed collector extension version in logs. |
+| Data Collection | [GitHub Enterprise Server Endpoint Support](/resources/release-notes/2026-09-08#github-enterprise-server-endpoint-support) | Configure separate REST and GraphQL endpoints for GitHub Enterprise Server collection. |
+| Data Collection | [GitHub and Okta Collection Resilience](/resources/release-notes/2026-09-08#github-and-okta-collection-resilience) | Recover from large-environment timeouts, transient GitHub gateway failures, and organization-login casing differences. |
+| Data Collection | [GitHub Enterprise Role Memberships](/resources/release-notes/2026-09-08#github-enterprise-role-memberships) | Restore accurate `owners` and `members` role memberships in GitHub enterprise data. |
+| Data Collection | [GitHub EMU External Group Modeling](/resources/release-notes/2026-09-08#github-emu-external-group-modeling) | Connect normal GitHub teams to matching SCIM groups in Enterprise Managed User organizations. |
+| Data Collection | [Authoritative Okta Application-Group Assignments](/resources/release-notes/2026-09-08#authoritative-okta-application-group-assignments) | Collect reliable group-to-application assignments from Okta's application endpoints. |
 
 ### <Icon icon="wrench" /> Fixed Issues
 


### PR DESCRIPTION
## Summary

This pull request (PR) adds release notes for the v9.6.0 BloodHound release cycle to the release integration branch, which includes:

- BloodHound v9.7.0
- OpenHound v0.4.0
- SharpHound v2.16.0
- AzureHound v3.1.1

>[!TIP]
>Since we no longer have automatic staging builds, you can [build the site locally](https://www.mintlify.com/docs/cli/preview) if a preview is helpful for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release notes for BloodHound v9.7.0, OpenHound v0.4.0, SharpHound v2.16.0, and AzureHound v3.1.1.
  - Highlights include dynamic Entity Panel content, webhook alerts, collector support bundles, Marketplace updates, and Protection Score improvements.
  - Added enhancements to Explore, accessibility, Findings Tables, OpenHound configuration, collection resilience, and GitHub and Okta modeling.

- **Bug Fixes**
  - Documented fixes across Cypher, Explore, OpenGraph, and Findings.

- **Documentation**
  - Added the September 8, 2026 release notes to navigation and updated the release summary.
  - Removed the webinar announcement from the summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->