### PR TITLE
DOCS-58: add AD Site collection, nodes, and edges

### DIFF
--- a/docs/collect-data/ce-collection/sharphound-flags.mdx
+++ b/docs/collect-data/ce-collection/sharphound-flags.mdx
@@ -12,9 +12,9 @@ SharpHound Community Edition has several optional flags that let you control sca
 
 This tells SharpHound what kind of data you want to collect. These are the most common options you’ll likely use:
 
-* **Default:** You can specify default collection, or don’t use the CollectionMethods option and this is what SharpHound will do. Default collection includes Active Directory security group membership, domain trusts, abusable permissions on AD objects (incl. ADCS objects), OU tree structure, Group Policy links, the most relevant AD object properties, local groups from domain-joined Windows systems, and user sessions.
+* **Default:** You can specify default collection, or don’t use the CollectionMethods option and this is what SharpHound will do. Default collection includes Active Directory security group membership, domain trusts, abusable permissions on AD objects (incl. ADCS objects), OU tree structure, Group Policy links, Site objects, the most relevant AD object properties, local groups from domain-joined Windows systems, and user sessions.
 * **All:** Performs all collection methods.
-* **DCOnly:** Collects data ONLY from the domain controller, will not touch other domain-joined Windows systems. Collects AD security group memberships, domain trusts, abusable permissions on AD objects (incl. ADCS objects), OU tree structure, Group Policy links, the most relevant AD object properties, and will attempt to correlate Group Policy-enforced local groups to affected computers.
+* **DCOnly:** Collects data ONLY from the domain controller, will not touch other domain-joined Windows systems. Collects AD security group memberships, domain trusts, abusable permissions on AD objects (incl. ADCS objects), OU tree structure, Group Policy links, Site objects, the most relevant AD object properties, and will attempt to correlate Group Policy-enforced local groups to affected computers.
 * **ComputerOnly:** Collects user sessions (_Session_), local groups (_LocalGroup_), and User Rights Assignment (_UserRights_) from domain-joined Windows systems. Additionally, CA registry (_CARegistry_) data and DC registry (_DCRegistry_) data is collected. Will NOT collect the data collected with the DCOnly collection method.
 * **Session:** Just does user session collection. You will likely couple this with the `--Loop` option. See SharpHound examples below for more info on that.
 * **LoggedOn:** Does session collection using the privileged collection method. Use this if you are running as a user with local admin rights on lots of systems for the best user session data.
@@ -26,6 +26,7 @@ Here are the less common CollectionMethods and what they do:
 * **GPOLocalGroup:** Just attempt GPO to computer correlation to determine members of the relevant local groups on each computer in the domain. Doesn’t actually touch domain-joined systems, just gets info from domain controllers
 * **Trusts:** Just collect domain trusts
 * **Container:** Just collect the OU tree structure and Group Policy links
+* **Site:** Collect Active Directory Site, SiteServer, and SiteSubnet objects from the configuration partition; their site-to-server and site-to-subnet mappings; site GPO links; and ACLs on Site objects
 * **LocalGroup:** Just collect the members of all interesting local groups on each domain-joined computer. Equivalent for _LocalAdmin_ + _RDP_ + _DCOM_ + _PSRemote_
 * **LocalAdmin:** Just collect the members of the local Administrators group on each domain-joined computer
 * **RDP:** Just collect the members of the Remote Desktop Users group on each domain-joined computer

--- a/docs/collect-data/ce-collection/sharphound.mdx
+++ b/docs/collect-data/ce-collection/sharphound.mdx
@@ -25,6 +25,7 @@ SharpHound CE will automatically determine what domain your current user belongs
 * Abusable rights on Active Directory objects
 * Group Policy links
 * OU tree structure
+* Sites and their server and subnet mappings
 * Several properties from computer, group and user objects
 * SQL admin links
 

--- a/docs/collect-data/sharphound-data-permissions.mdx
+++ b/docs/collect-data/sharphound-data-permissions.mdx
@@ -28,8 +28,8 @@ Information about the objects and relationships within your Active Directory env
 This information includes:
 
 * Domain trusts.
-* Object properties of users, groups, computers, GPOs, OUs containers, and Domain objects.
-* ACLs related to users, groups, computers, GPOs, OUs, containers, and Domain objects.
+* Object properties of users, groups, computers, GPOs, OUs containers, sites, and domain objects.
+* ACLs related to users, groups, computers, GPOs, OUs, containers, sites, and domain objects.
 * Enumerated objects contained in every OU, container, and Domain.
 * Enumerated memberships of all Groups.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -776,6 +776,9 @@
                   "resources/nodes/nt-auth-store",
                   "resources/nodes/ou",
                   "resources/nodes/root-ca",
+                  "resources/nodes/site",
+                  "resources/nodes/site-server",
+                  "resources/nodes/site-subnet",
                   "resources/nodes/user"
                 ]
               },
@@ -899,6 +902,7 @@
                   "resources/edges/remote-interactive-logon-right",
                   "resources/edges/root-ca-for",
                   "resources/edges/same-forest-trust",
+                  "resources/edges/server-is",
                   "resources/edges/spoof-sid-history",
                   "resources/edges/sql-admin",
                   "resources/edges/sync-laps-password",

--- a/docs/images/nodes/ad/site-server.svg
+++ b/docs/images/nodes/ad/site-server.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <circle cx="128" cy="128" r="119.424" fill="#60A5FA" stroke="#000000" stroke-width="17.152"/>
+  <g transform="translate(128,128) scale(0.32) translate(-192,-256)" fill="#000000" color="#000000">
+    <!--! Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc. -->
+    <path d="M384 192c0 87.4-117 243-168.3 307.2c-12.3 15.3-35.1 15.3-47.4 0C117 435 0 279.4 0 192C0 86 86 0 192 0S384 86 384 192z"/>
+  </g>
+</svg>

--- a/docs/images/nodes/ad/site-subnet.svg
+++ b/docs/images/nodes/ad/site-subnet.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <circle cx="128" cy="128" r="119.424" fill="#F59E0B" stroke="#000000" stroke-width="17.152"/>
+  <g transform="translate(128,128) scale(0.28444444444444444) translate(-288,-256)" fill="#000000" color="#000000">
+    <!--! Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc. -->
+    <path d="M384 476.1L192 421.2l0-385.3L384 90.8l0 385.3zm32-1.2l0-386.5L543.1 37.5c15.8-6.3 32.9 5.3 32.9 22.3l0 334.8c0 9.8-6 18.6-15.1 22.3L416 474.8zM15.1 95.1L160 37.2l0 386.5L32.9 474.5C17.1 480.8 0 469.2 0 452.2L0 117.4c0-9.8 6-18.6 15.1-22.3z"/>
+  </g>
+</svg>

--- a/docs/images/nodes/ad/site.svg
+++ b/docs/images/nodes/ad/site.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <circle cx="128" cy="128" r="119.424" fill="#2DD4BF" stroke="#000000" stroke-width="17.152"/>
+  <g transform="translate(128,128) scale(0.32) translate(-256,-256)" fill="#000000" color="#000000">
+    <!--! Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc. -->
+    <path d="M224 32L64 32C46.3 32 32 46.3 32 64l0 64c0 17.7 14.3 32 32 32l377.4 0c4.2 0 8.3-1.7 11.3-4.7l48-48c6.2-6.2 6.2-16.4 0-22.6l-48-48c-3-3-7.1-4.7-11.3-4.7L288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32zM480 256c0-17.7-14.3-32-32-32l-160 0 0-32-64 0 0 32L70.6 224c-4.2 0-8.3 1.7-11.3 4.7l-48 48c-6.2 6.2-6.2 16.4 0 22.6l48 48c3 3 7.1 4.7 11.3 4.7L448 352c17.7 0 32-14.3 32-32l0-64zM288 480l0-96-64 0 0 96c0 17.7 14.3 32 32 32s32-14.3 32-32z"/>
+  </g>
+</svg>

--- a/docs/resources/edges/contains.mdx
+++ b/docs/resources/edges/contains.mdx
@@ -19,8 +19,8 @@ Creation and modification of ACEs will be logged depending on the auditing setup
 
 ## Edge Schema
 
-Source: [Computer](/resources/nodes/computer), [OU](/resources/nodes/ou), [Container](/resources/nodes/container)  
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Source: [Computer](/resources/nodes/computer), [OU](/resources/nodes/ou), [Container](/resources/nodes/container), [Site](/resources/nodes/site)<br/>
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [SiteServer](/resources/nodes/site-server), [SiteSubnet](/resources/nodes/site-subnet), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/edges/generic-all.mdx
+++ b/docs/resources/edges/generic-all.mdx
@@ -90,6 +90,10 @@ Users and computers with ACL inheritance disabled (directly or through a parent 
 
 See the [WriteGPLink](/resources/edges/write-gp-link) edge documentation for details.
 
+### With GenericAll Over a Site
+
+Full control of a [Site](/resources/nodes/site) allows you to modify its `gPLink` attribute. Link a controlled or malicious [GPO](/resources/nodes/gpo) to the site to apply policy to the site's domain controllers and computers mapped to its subnets. This can force affected computers and users to run attacker-controlled commands, for example through an immediate scheduled task. See [WriteGPLink](/resources/edges/write-gp-link) for the site-specific impact and requirements.
+
 ### With GenericAll Over a Domain Object
 
 #### DCSync
@@ -135,7 +139,7 @@ This will depend on the actual attack performed. See the particular opsec consid
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)  
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/edges/generic-write.mdx
+++ b/docs/resources/edges/generic-write.mdx
@@ -47,6 +47,10 @@ You can compromise child users and computers of the [OU](/resources/nodes/ou) by
 
 You can compromise users and computers of the domain by abusing write access to the `gPLink` attribute of the domain. See the [WriteGPLink](/resources/edges/write-gp-link) edge documentation for details.
 
+**[Site](/resources/nodes/site)**
+
+You can compromise the site's domain controllers and computers mapped to its subnets by abusing write access to the site's `gPLink` attribute. See the [WriteGPLink](/resources/edges/write-gp-link) edge documentation for details.
+
 **[CertTemplate](/resources/nodes/cert-template)**
 
 With GenericWrite permission over a certificate template, you may be able to perform an ESC4 attack by modifying the template's attributes. BloodHound will in that case create an [ADCSESC4](/resources/edges/adcs-esc4) edge from the principal to the forest domain node.
@@ -74,7 +78,7 @@ This will depend on which type of object you are targeting and the attack you pe
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)
 
 Traversable: ✅
 

--- a/docs/resources/edges/gp-link.mdx
+++ b/docs/resources/edges/gp-link.mdx
@@ -9,9 +9,9 @@ import GpoAbuseTools from '/snippets/edges/gpo-abuse-tools.mdx';
 <ResourceEditionPill />
 
 
-The GPLink relationship connects a Group Policy Object ([GPO](/resources/nodes/gpo)) to an AD domain or organizational unit ([OU](/resources/nodes/ou)) it is linked to.
+The GPLink relationship connects a Group Policy Object ([GPO](/resources/nodes/gpo)) to an AD [Domain](/resources/nodes/domain), organizational unit ([OU](/resources/nodes/ou)), or [Site](/resources/nodes/site) it is linked to.
 
-The [GPO](/resources/nodes/gpo)'s settings apply to AD accounts (users and computers) within that domain or [OU](/resources/nodes/ou).
+For a [Domain](/resources/nodes/domain) or [OU](/resources/nodes/ou), the [GPO](/resources/nodes/gpo)'s settings apply to users and computers in that scope, including nested OUs. For a [Site](/resources/nodes/site), they apply to the site's domain controllers and to computers whose IP addresses fall within one of the site's subnets. The default site also covers computers that do not map to another site. User-side settings affect users who sign in to those computers.
 
 The Enforced property on the edge indicates whether the [GPO](/resources/nodes/gpo) link is enforced, meaning it still applies if an [OU](/resources/nodes/ou) has blocked GPO inheritance.
 
@@ -28,7 +28,7 @@ There is no opsec information for this edge.
 ## Edge Schema
 
 Source: [GPO](/resources/nodes/gpo)  
-Destination: [Domain](/resources/nodes/domain), [OU](/resources/nodes/ou)   
+Destination: [Domain](/resources/nodes/domain), [OU](/resources/nodes/ou), [Site](/resources/nodes/site)<br/>
 Traversable: ✅  
 
 ## References
@@ -36,4 +36,3 @@ Traversable: ✅
 * [A Red Teamer's Guide to GPOs and OUs](https://wald0.com/?p=179)
 * [GitHub: SharpGPOAbuse](https://github.com/FSecureLABS/SharpGPOAbuse)
 * [GitHub: pyGPOAbuse](https://github.com/Hackndo/pyGPOAbuse)
-

--- a/docs/resources/edges/owns-limited-rights.mdx
+++ b/docs/resources/edges/owns-limited-rights.mdx
@@ -18,7 +18,7 @@ Please refer to the OPSEC section in the [edge documentation](/resources/edges/o
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/edges/owns.mdx
+++ b/docs/resources/edges/owns.mdx
@@ -25,7 +25,7 @@ This depends on the target object and how to take advantage of this privilege.
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)   
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 

--- a/docs/resources/edges/server-is.mdx
+++ b/docs/resources/edges/server-is.mdx
@@ -1,0 +1,29 @@
+---
+title: ServerIs
+description: This edge connects an Active Directory site server object to the Computer object it represents.
+---
+
+import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
+
+<ResourceEditionPill />
+
+The ServerIs relationship is created from a [SiteServer](/resources/nodes/site-server) to the [Computer](/resources/nodes/computer) object referenced by its `serverReference` attribute. In Active Directory Domain Services, this identifies the computer object for the domain controller represented by the site server.
+
+## Abuse Info
+
+ServerIs does not grant a principal control of the referenced computer on its own. It makes the impact of control over a [Site](/resources/nodes/site) traversable: if a malicious GPO is linked to the site, it can apply to the site server's referenced domain controller. Review the site's inbound control and [GPLink](/resources/edges/gp-link) relationships to identify the preceding privilege.
+
+## Opsec Considerations
+
+This relationship is collected directory metadata. Abuse occurs through the preceding site-control or GPO-control relationship, not by using ServerIs directly.
+
+## Edge Schema
+
+Source: [SiteServer](/resources/nodes/site-server)  
+Destination: [Computer](/resources/nodes/computer)  
+Traversable: ✅
+
+## References
+
+- [Microsoft: Server object](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/9164e4e8-f892-4ca2-8067-059f6f9387a4)
+- [Microsoft: DC existence and object relationships](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/803edcd5-476d-4554-a700-a9f27480c0f1)

--- a/docs/resources/edges/traversable-edges.mdx
+++ b/docs/resources/edges/traversable-edges.mdx
@@ -40,10 +40,10 @@ These are the traversable AD edge types in BloodHound:
 | [ManageCertificates](/resources/edges/manage-certificates)      | [MemberOf](/resources/edges/member-of)                | [Owns](/resources/edges/owns)                        |
 | [OwnsLimitedRights](/resources/edges/owns-limited-rights)       | [ReadGMSAPassword](/resources/edges/read-gmsa-password)         | [ReadLAPSPassword](/resources/edges/read-laps-password)            |
 | [SameForestTrust](/resources/edges/same-forest-trust)         | [SpoofSIDHistory](/resources/edges/spoof-sid-history)          | [SQLAdmin](/resources/edges/sql-admin)                   |
-| [SyncedToADUser](/resources/edges/synced-to-ad-user)          | [SyncedToEntraUser](/resources/edges/synced-to-entra-user)        | [SyncLAPSPassword](/resources/edges/sync-laps-password)            |
-| [WriteAccountRestrictions](/resources/edges/write-account-restrictions)| [WriteAltSecurityIdentities](/resources/edges/write-alt-security-identities) | [WriteDacl](/resources/edges/write-dacl)                |
-| [WriteGPLink](/resources/edges/write-gp-link)              | [WriteOwner](/resources/edges/write-owner) | [WriteOwnerLimitedRights](/resources/edges/write-owner-limited-rights) |
-| [WritePublicInformation](/resources/edges/write-public-information) | [WriteSPN](/resources/edges/write-spn) | |
+| [ServerIs](/resources/edges/server-is)                       | [SyncedToADUser](/resources/edges/synced-to-ad-user)          | [SyncedToEntraUser](/resources/edges/synced-to-entra-user) |
+| [SyncLAPSPassword](/resources/edges/sync-laps-password)       | [WriteAccountRestrictions](/resources/edges/write-account-restrictions) | [WriteAltSecurityIdentities](/resources/edges/write-alt-security-identities) |
+| [WriteDacl](/resources/edges/write-dacl)                      | [WriteGPLink](/resources/edges/write-gp-link)                 | [WriteOwner](/resources/edges/write-owner) |
+| [WriteOwnerLimitedRights](/resources/edges/write-owner-limited-rights) | [WritePublicInformation](/resources/edges/write-public-information) | [WriteSPN](/resources/edges/write-spn) |
 
 These are the traversable Azure edge types in BloodHound:
 

--- a/docs/resources/edges/write-dacl.mdx
+++ b/docs/resources/edges/write-dacl.mdx
@@ -61,6 +61,10 @@ Add-DomainObjectAcl -TargetIdentity (OU GUID) -Rights All
 
 See the abuse info for [GenericAll](/resources/edges/generic-all) over an [OU](/resources/nodes/ou) for more information about how to continue from there.
 
+**[Sites](/resources/nodes/site)**
+
+With WriteDACL over a [Site](/resources/nodes/site), grant yourself full control of the site, then use the site's `gPLink` attribute to link a controlled GPO. See the abuse info for [GenericAll](/resources/edges/generic-all) over a Site for more information.
+
 ## Opsec Considerations
 
 <AdPermissionModificationOpsec />
@@ -70,7 +74,7 @@ Additional opsec considerations depend on the target object and how to take adva
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/edges/write-gp-link.mdx
+++ b/docs/resources/edges/write-gp-link.mdx
@@ -1,6 +1,6 @@
 ---
 title: WriteGPLink
-description: The WriteGPLink edge indicates that the principal has the permissions to modify the gPLink attribute of the targeted OU/domain node.
+description: The WriteGPLink edge indicates that the principal can modify the gPLink attribute of the targeted domain, OU, or site.
 ---
 
 import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
@@ -8,13 +8,15 @@ import GpoAbuseTools from '/snippets/edges/gpo-abuse-tools.mdx';
 
 <ResourceEditionPill />
 
-The ability to alter the `gPLink` attribute may allow an attacker to apply a malicious Group Policy Object ([GPO](/resources/nodes/gpo)) to all child user and computer objects (including the ones located in nested [OUs](/resources/nodes/ou)). This can be exploited to make said child objects execute arbitrary commands through an immediate scheduled task, thus compromising them.
+The ability to alter the `gPLink` attribute may allow an attacker to apply a malicious Group Policy Object ([GPO](/resources/nodes/gpo)) to a domain, [OU](/resources/nodes/ou), or [Site](/resources/nodes/site). This can be exploited to make affected computers and users execute arbitrary commands through an immediate scheduled task.
 
 ## Abuse Info
 
-An attacker with permission to modify the `gPLink` attribute can link [GPOs](/resources/nodes/gpo) to the object, affecting all contained users and computers. The GPO can be weaponized by injecting a malicious configuration, such as a scheduled task executing a malicious script.
+An attacker with permission to modify the `gPLink` attribute can link [GPOs](/resources/nodes/gpo) to the object. For a domain or [OU](/resources/nodes/ou), the linked GPO affects contained users and computers, including nested OUs. The GPO can be weaponized by injecting a malicious configuration, such as a scheduled task executing a malicious script.
 
-The [GPO](/resources/nodes/gpo) can be linked as enforced to bypass blocked GPO inheritance. WMI or security filtering can be used to limit the impact to specific accounts, which is important in environments with many users or computers under the affected scope.
+For a [Site](/resources/nodes/site), the linked GPO affects the site's domain controllers and computers mapped to the site's subnets. The default site also affects computers that do not map to another site. User-side settings affect users who sign in to the affected computers. A site-linked GPO does not rely on OU inheritance.
+
+For a domain or OU, the [GPO](/resources/nodes/gpo) can be linked as enforced to bypass blocked GPO inheritance. WMI or security filtering can be used to limit the impact to specific accounts, which is important in environments with many users or computers under the affected scope.
 
 <GpoAbuseTools />
 
@@ -22,7 +24,7 @@ The [GPO](/resources/nodes/gpo) can be linked as enforced to bypass blocked GPO 
 
 An attacker can still execute the attack without control over a [GPO](/resources/nodes/gpo) by setting up a fake LDAP server to host a GPO. This approach requires the ability to add non-existent DNS records and create machine accounts, or access to a compromised domain-joined machine. However, this method is complex and requires significant setup.
 
-From a domain-joined compromised Windows machine, the write access to the `gPLink` attribute may be abused through Powermad, PowerView and native Windows functionalities. For a detailed outline of exploit requirements and implementation, you can refer to this article: [OU having a laugh?](https://labs.withsecure.com/publications/ou-having-a-laugh)
+From a domain-joined compromised Windows machine, the write access to the `gPLink` attribute may be abused through Powermad, PowerView and native Windows functionalities. For site-specific requirements and implementation, see [Site Unseen: Enumerating and Attacking Active Directory Sites](https://www.synacktiv.com/en/publications/site-unseen-enumerating-and-attacking-active-directory-sites). For domains and OUs, see [OU having a laugh?](https://labs.withsecure.com/publications/ou-having-a-laugh).
 
 From a Linux machine, the write access to the `gPLink` attribute may be abused using the [OUned.py](https://github.com/synacktiv/OUned) exploitation tool. For a detailed outline of exploit requirements and implementation, you can refer to [the article associated to the OUned.py tool](https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory).
 
@@ -32,8 +34,8 @@ There is no opsec information for this edge.
 
 ## Edge Schema
 
-Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [GPO](/resources/nodes/gpo)  
+Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)<br/>
+Destination: [Domain](/resources/nodes/domain), [OU](/resources/nodes/ou), [Site](/resources/nodes/site)<br/>
 Traversable: ✅  
 
 ## References
@@ -46,3 +48,4 @@ This edge is related to the following MITRE ATT&CK technique:
 
 * [OU having a laugh?](https://labs.withsecure.com/publications/ou-having-a-laugh)
 * [OUned.py: exploiting hidden Organizational Units ACL attack vectors in Active Directory](https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory)
+* [Site Unseen: Enumerating and Attacking Active Directory Sites](https://www.synacktiv.com/en/publications/site-unseen-enumerating-and-attacking-active-directory-sites)

--- a/docs/resources/edges/write-owner-limited-rights.mdx
+++ b/docs/resources/edges/write-owner-limited-rights.mdx
@@ -18,7 +18,7 @@ Please refer to the OPSEC section in the [edge documentation](/resources/edges/o
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [Group](/resources/nodes/group), [GPO](/resources/nodes/gpo), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/edges/write-owner.mdx
+++ b/docs/resources/edges/write-owner.mdx
@@ -40,7 +40,7 @@ This depends on the target object and how to take advantage of this privilege.
 ## Edge Schema
 
 Source: [User](/resources/nodes/user), [Group](/resources/nodes/group), [Computer](/resources/nodes/computer)   
-Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [User](/resources/nodes/user)  
+Destination: [AIACA](/resources/nodes/aiaca), [CertTemplate](/resources/nodes/cert-template), [Computer](/resources/nodes/computer), [Container](/resources/nodes/container), [Domain](/resources/nodes/domain), [EnterpriseCA](/resources/nodes/enterprise-ca), [GPO](/resources/nodes/gpo), [Group](/resources/nodes/group), [IssuancePolicy](/resources/nodes/issuance-policy), [NTAuthStore](/resources/nodes/nt-auth-store), [OU](/resources/nodes/ou), [RootCA](/resources/nodes/root-ca), [Site](/resources/nodes/site), [User](/resources/nodes/user)<br/>
 Traversable: ✅  
 
 ## References

--- a/docs/resources/nodes/site-server.mdx
+++ b/docs/resources/nodes/site-server.mdx
@@ -1,0 +1,53 @@
+---
+title: SiteServer
+icon: '/images/nodes/ad/site-server.svg'
+---
+
+import NodePropertiesIntro from '/snippets/resources/node-properties-intro.mdx';
+import NodeEdgesIntro from '/snippets/resources/node-edges-intro.mdx';
+import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
+
+<ResourceEditionPill />
+
+## Representation
+
+The SiteServer node represents an Active Directory `server` object under a site's `Servers` container. A [ServerIs](/resources/edges/server-is) relationship connects it to the corresponding [Computer](/resources/nodes/computer) object through the directory object's `serverReference` attribute.
+
+By default, a SiteServer linked to a domain controller is classified as Tier Zero / High Value. This lets BloodHound surface the impact of a compromised [Site](/resources/nodes/site): a malicious GPO linked to the site can apply to the domain controller represented by the SiteServer.
+
+## Node properties
+
+<NodePropertiesIntro />
+
+|     |     |
+| --- | --- |
+| **Entity Panel name** | **Description** |
+| Tier Zero / High Value | Whether the SiteServer is classified as Tier Zero / High Value. By default, this applies when its referenced computer is a domain controller. |
+| Display Name | The display name for the server object. |
+| Object ID | The server object's object GUID, a unique identifier in Active Directory. |
+| Referenced Computer | The [Computer](/resources/nodes/computer) object referenced by the server object's `serverReference` attribute. |
+| Created | The time when the server object was created in the directory. |
+| Description | The contents of the `description` field for the server object. |
+
+## Edges
+
+<NodeEdgesIntro />
+
+### Incoming edges
+
+|     |     |
+| --- | --- |
+| **Edge type** | **Entity panel category** |
+| [Contains](/resources/edges/contains) | - |
+
+### Outgoing edges
+
+|     |     |
+| --- | --- |
+| **Edge type** | **Entity panel category** |
+| [ServerIs](/resources/edges/server-is) | Referenced Computer |
+
+## References
+
+- [Microsoft: Server object](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/9164e4e8-f892-4ca2-8067-059f6f9387a4)
+- [Microsoft: DC existence and object relationships](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/803edcd5-476d-4554-a700-a9f27480c0f1)

--- a/docs/resources/nodes/site-subnet.mdx
+++ b/docs/resources/nodes/site-subnet.mdx
@@ -1,0 +1,45 @@
+---
+title: SiteSubnet
+icon: '/images/nodes/ad/site-subnet.svg'
+---
+
+import NodePropertiesIntro from '/snippets/resources/node-properties-intro.mdx';
+import NodeEdgesIntro from '/snippets/resources/node-edges-intro.mdx';
+import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
+
+<ResourceEditionPill />
+
+## Representation
+
+The SiteSubnet node represents an Active Directory subnet object. Its name identifies an IP address range, and its `siteObject` attribute associates that range with a [Site](/resources/nodes/site). This mapping determines which site a computer belongs to for site-based GPO application.
+
+## Node properties
+
+<NodePropertiesIntro />
+
+|     |     |
+| --- | --- |
+| **Entity Panel name** | **Description** |
+| Display Name | The subnet name, expressed as an IP address and prefix length. |
+| Object ID | The subnet object's object GUID, a unique identifier in Active Directory. |
+| Created | The time when the subnet object was created in the directory. |
+| Description | The contents of the `description` field for the subnet object. |
+
+## Edges
+
+<NodeEdgesIntro />
+
+### Incoming edges
+
+|     |     |
+| --- | --- |
+| **Edge type** | **Entity panel category** |
+| [Contains](/resources/edges/contains) | - |
+
+### Outgoing edges
+
+This node does not have outgoing edges.
+
+## References
+
+- [Microsoft: Subnet object](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/255d4630-f033-4289-8db6-c36060b47e17)

--- a/docs/resources/nodes/site.mdx
+++ b/docs/resources/nodes/site.mdx
@@ -1,0 +1,62 @@
+---
+title: Site
+icon: '/images/nodes/ad/site.svg'
+---
+
+import NodePropertiesIntro from '/snippets/resources/node-properties-intro.mdx';
+import NodeEdgesIntro from '/snippets/resources/node-edges-intro.mdx';
+import ResourceEditionPill from '/snippets/resources/edition-pill.mdx';
+
+<ResourceEditionPill />
+
+## Representation
+
+The Site node represents an Active Directory site object. An AD site maps one or more IP subnets with LAN connectivity and contains the directory server objects for that site. BloodHound uses the site to represent its linked [GPOs](/resources/nodes/gpo), [site servers](/resources/nodes/site-server), and [site subnets](/resources/nodes/site-subnet).
+
+A GPO linked to a site applies to the site's domain controllers and to computers whose IP address belongs to one of the site's subnets. If the site is the default site, it also applies to computers that do not map to another site. Users who sign in to those computers are affected by user-side policy settings.
+
+## Node properties
+
+<NodePropertiesIntro />
+
+|     |     |
+| --- | --- |
+| **Entity Panel name** | **Description** |
+| Display Name | The display name for the site object. |
+| Object ID | The site's object GUID, a unique identifier in Active Directory. |
+| ACL Inheritance Denied | Identifies whether the site object prevents ACL inheritance to itself. |
+| Created | The time when the site object was created in the directory. |
+| Description | The contents of the `description` field for the site object. |
+
+## Edges
+
+<NodeEdgesIntro />
+
+### Incoming edges
+
+|     |     |
+| --- | --- |
+| **Edge type** | **Entity panel category** |
+| [Contains](/resources/edges/contains) | - |
+| [GenericAll](/resources/edges/generic-all) | Inbound Object Control |
+| [GenericWrite](/resources/edges/generic-write) | Inbound Object Control |
+| [GPLink](/resources/edges/gp-link) | Linked GPOs |
+| [Owns](/resources/edges/owns) | Inbound Object Control |
+| [OwnsLimitedRights](/resources/edges/owns-limited-rights) | Inbound Object Control |
+| [WriteDacl](/resources/edges/write-dacl) | Inbound Object Control |
+| [WriteGPLink](/resources/edges/write-gp-link) | Inbound Object Control |
+| [WriteOwner](/resources/edges/write-owner) | Inbound Object Control |
+| [WriteOwnerLimitedRights](/resources/edges/write-owner-limited-rights) | Inbound Object Control |
+
+### Outgoing edges
+
+|     |     |
+| --- | --- |
+| **Edge type** | **Entity panel category** |
+| [Contains](/resources/edges/contains) | Linked Site Servers |
+| [Contains](/resources/edges/contains) | Linked Site Subnets |
+
+## References
+
+- [Microsoft: Site object](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/cdacdd51-f324-41e9-b83f-71263902dabe)
+- [Microsoft: Designing the site topology](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/plan/designing-the-site-topology)


### PR DESCRIPTION
## Summary

Document Active Directory Site graph support and the associated SharpHound `Site` collection method.

The new nodes and edges will introduced with this PR: https://github.com/SpecterOps/BloodHound/pull/2031
The PR has been merged into main, so it should go live with v9.8.0.

## Changes

- Added documentation for the new `Site`, `SiteServer`, and `SiteSubnet` node types, including node properties, edge summaries, navigation entries, and matching icons.
- Added `ServerIs` edge documentation and included it in the traversable-edge reference.
- Updated Site-aware graph documentation for:
  - `Contains`
  - `GPLink`
  - `WriteGPLink`
  - `GenericAll`
  - `GenericWrite`
  - Related ownership and DACL control edge schemas
- Documented Site-specific GPO impact, including affected domain controllers, subnet-mapped computers, and default-site behavior.
- Documented SharpHound’s new `Site` collection method:
  - Collects Site, SiteServer, and SiteSubnet objects.
  - Captures Site GPO links, Site-to-server/subnet mappings, `ServerIs` relationships, and Site ACLs.
  - Included in `Default`, `DCOnly`, and `All`.
  - Added guidance for LDAP permissions and least-privileged collection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive documentation for Active Directory Sites, Site Servers, and Site Subnets.
  - Updated collection guidance to cover site objects, server and subnet mappings, OU trees, Group Policy links, and site ACLs.
  - Documented the `ServerIs` relationship and expanded relationship schemas and abuse guidance to include Sites.
  - Clarified Group Policy behavior across domains, OUs, and Sites.
  - Added navigation links for the new resource documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->