### PR TITLE
DOCS-44: OpenHound collector updates for GitHub and OKta

### DIFF
--- a/docs/openhound/collectors/github/collect-data.mdx
+++ b/docs/openhound/collectors/github/collect-data.mdx
@@ -134,6 +134,36 @@ Click the tab that matches your authentication setup for details and example con
   </Tab>
 </Tabs>
 
+## Configure GitHub Enterprise Server endpoints
+
+GitHub.com is the default deployment and requires no endpoint configuration. To collect from GitHub Enterprise Server (GHES), set both the REST and GraphQL endpoint URLs in the `[sources.github]` section of `config.toml` or as environment variables.
+
+| Setting | Description | Environment Variable |
+|---------|-------------|----------------------|
+| `rest_api_url` | The GHES REST API base URL. | `SOURCES__GITHUB__REST_API_URL` |
+| `graphql_url` | The GHES GraphQL endpoint URL. | `SOURCES__GITHUB__GRAPHQL_URL` |
+
+**`config.toml`**
+
+```toml title="~/.dlt/config_github.toml"
+[sources.github]
+rest_api_url = "https://ghe.example/api/v3"
+graphql_url = "https://ghe.example/api/graphql"
+```
+
+**Environment variables**
+
+```text
+SOURCES__GITHUB__REST_API_URL=https://ghe.example/api/v3
+SOURCES__GITHUB__GRAPHQL_URL=https://ghe.example/api/graphql
+```
+
+<Note>
+  `rest_api_url` and `graphql_url` must be configured together. Both values must use HTTPS and share the same origin. If you authenticate with a GitHub App, `credentials.api_uri` can only override the path on that same origin, not the origin itself.
+
+  GitHub App authentication and secret scanning PAT validation use the configured REST endpoint instead of assuming GitHub.com, so existing GitHub.com configurations continue to work without changes.
+</Note>
+
 ## Running OpenHound and Collecting Data
 
 <RunAndCollect source="GitHub" env="organization or enterprise account" />

--- a/docs/openhound/collectors/github/configure-enterprise-app.mdx
+++ b/docs/openhound/collectors/github/configure-enterprise-app.mdx
@@ -48,6 +48,10 @@ Follow these steps to create a GitHub App that can be installed at the enterpris
            <GitHubEnterprisePermissions />
          </Expandable>
 
+       <Note>
+         If you plan to collect external group mapping data for IdP-synced teams, set the organization **Members** permission to **Read and write** instead of **Read-only**. See [Optional privileged collection](/openhound/collectors/github/configure-enterprise-app#optional-privileged-collection) for details.
+       </Note>
+
     1. Under **Where can this GitHub App be installed?**, select the option for organizations owned by your enterprise.
   </Step>
   <Step title="Create the app">
@@ -82,6 +86,24 @@ Install the same GitHub App in the enterprise account and in each organization y
     </Note>
   </Step>
 </Steps>
+
+## Optional privileged collection
+
+The collector runs successfully with the read-only permission set described above. Some higher-fidelity relationships require optional non-read-only permissions because GitHub exposes the supporting read APIs behind privileged permission names.
+
+<Note>
+  In most environments you can skip these; grant them only if you need the specific data they unlock.
+</Note>
+
+- Organization **Members: Read and write** enables external group mapping collection for IdP-synced teams, which allows the converter to emit `SCIM_Provisioned` edges from `SCIM_Group` to `GH_Team`.
+
+  This is useful when the organization uses team synchronization with an external identity provider. If no GitHub teams are linked to external groups, this permission does not add graph data.
+
+- Classic PAT scope `manage_runners:enterprise` enables enterprise self-hosted runner group and runner collection.
+
+  This is useful when the enterprise has enterprise-scoped runner groups or runners, especially runner groups shared into organizations. If all runners are organization- or repository-scoped, this scope does not add graph data.
+
+If you don't grant these optional permissions, OpenHound skips the affected resources and continues collecting the rest of the GitHub environment.
 
 ## Create a Classic PAT for SSO, SCIM, and Runners
 

--- a/docs/openhound/collectors/okta/collect-data.mdx
+++ b/docs/openhound/collectors/okta/collect-data.mdx
@@ -116,6 +116,27 @@ base_url = "https://mytenant.oktapreview.com"
 token = "<api-token>"
 ```
 
+## Pagination settings
+
+The Okta collector requests explicit page sizes for resources that support large result sets. You can tune these defaults with the following DLT source configuration environment variables:
+
+| Environment variable | Default | Purpose |
+| --- | ---: | --- |
+| `SOURCES__SOURCE__OKTA__APPLICATION_USERS_PAGE_SIZE` | `500` | Application users per page, from 1 through 500 |
+| `SOURCES__SOURCE__OKTA__GROUPS_PAGE_SIZE` | `200` | Expanded groups per page, from 1 through 200 |
+| `SOURCES__SOURCE__OKTA__APPLICATION_GROUP_ASSIGNMENTS_PAGE_SIZE` | `200` | Application-group assignments per page, from 20 through 200 |
+| `SOURCES__SOURCE__OKTA__GROUP_PUSH_MAPPINGS_PAGE_SIZE` | `1000` | Group push mappings per page, from 1 through 1,000 |
+| `SOURCES__SOURCE__OKTA__IDENTITY_PROVIDER_USERS_PAGE_SIZE` | `200` | Identity-provider users per page, from 1 through 200 |
+| `SOURCES__SOURCE__OKTA__ENDPOINT_CONCURRENCY` | `2` | Maximum simultaneous requests per endpoint family |
+| `SOURCES__SOURCE__OKTA__RATE_LIMIT_MAX_ELAPSED_SECONDS` | `900` | Maximum elapsed retry window for an individual 429 request |
+| `SOURCES__SOURCE__OKTA__RATE_LIMIT_REMAINING_RESERVE` | `1` | Requests held in reserve when pacing against a rate-limit window |
+
+Application-group assignments are collected from each application's public assignment endpoint, and the collector retains Okta's assignment timestamp, priority, and profile field names without publishing assignment profile values to the graph.
+
+<Note>
+  If the initial expanded group page repeatedly times out on large Okta tenants, the collector retries that first page with successively halved page sizes before failing. With the default `GROUPS_PAGE_SIZE` of 200, that fallback sequence is 200, then 100, then 50.
+</Note>
+
 ## Running OpenHound and Collecting Data
 
 <RunAndCollect source="Okta" env="organization" />


### PR DESCRIPTION
## Summary

This pull request (PR) updates the OpenHound GitHub and Okta collector configuration docs for the v0.4.0 OpenHound release. Release notes will be added in a separate PR (#420). 

>[!TIP]
>Since we no longer have automatic staging builds, you can [build the site locally](https://www.mintlify.com/docs/cli/preview) if a preview is helpful for review.

Updates to the GitHub reference docs are also necessary, but we should do that in a separate PR.

>[!NOTE]
>There have been changes to the doc generation scripts we use to update the reference docs. See #377 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring GitHub Enterprise Server REST and GraphQL endpoints, including HTTPS and origin requirements.
  - Documented optional GitHub permissions and token scopes for collecting privileged organization and enterprise data.
  - Added Okta collector guidance for pagination, rate limits, retries, concurrency, and application-group assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->