### PR TITLE
DOCS-37: Add fix description for SAML replay vuln

### DIFF
--- a/docs/resources/release-notes/2026-09-08.mdx
+++ b/docs/resources/release-notes/2026-09-08.mdx
@@ -231,6 +231,16 @@ import FeatureFlagNote from '/snippets/feature-flag-so-managed.mdx';
 </Update>
 
 <Update label="BloodHound" tags={["Fixed Issues"]}>
+  ## Authentication
+
+  {/*BED-9064*/} **SAML replay protection:** Resolved an issue where a valid signed SAML response could be replayed to create multiple BloodHound sessions.
+
+  BloodHound now records both the SAML response ID and assertion ID before creating a session. Any later callback that reuses either identifier is rejected.
+
+  <Callout icon="heart" color="#FFB74D">
+    Special thanks to Corban Villa, Sohee Kim, and Austin Chu for their detailed report and responsible disclosure.
+  </Callout>
+
   ## Cypher
 
   - {/*BED-8955*/} Resolved an issue where Cypher queries using traversal expansion to find a cyclical loop could fail.

--- a/docs/resources/release-notes/summary.mdx
+++ b/docs/resources/release-notes/summary.mdx
@@ -61,7 +61,7 @@ Key highlights include:
 
 ### <Icon icon="wrench" /> Fixed Issues
 
-See the [release notes](/resources/release-notes/2026-09-08#cypher) for a full list of fixed issues in this release.
+See the [release notes](/resources/release-notes/2026-09-08#bloodhound-10) for a full list of fixed issues in this release.
 
 ## 2026-08-18
 


### PR DESCRIPTION
## Summary

This pull request (PR)  adds a fix description for a CVE fix being released in v9.7.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SAML authentication security by detecting reused response and assertion identifiers.
  - Rejected authentication callbacks associated with previously processed SAML responses, helping prevent replay attacks.

- **Documentation**
  - Corrected the fixed-issues link for the September 8, 2026 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->