### PR TITLE
Add missing enterprise people permission

### DIFF
--- a/docs/snippets/hounds/openhound-gh-enterprise-permissions.mdx
+++ b/docs/snippets/hounds/openhound-gh-enterprise-permissions.mdx
@@ -5,4 +5,5 @@
 - Enterprise organization installation repositories
 - Enterprise organization installations
 - Enterprise single sign-on
+- Enteerprise people
 - Enterprise teams

--- a/docs/snippets/hounds/openhound-gh-enterprise-permissions.mdx
+++ b/docs/snippets/hounds/openhound-gh-enterprise-permissions.mdx
@@ -5,5 +5,5 @@
 - Enterprise organization installation repositories
 - Enterprise organization installations
 - Enterprise single sign-on
-- Enteerprise people
+- Enterprise people
 - Enterprise teams


### PR DESCRIPTION
## Summary

This pull request (PR) adds a missing permission to the [Configure an Enterprise GitHub App](https://bloodhound.specterops.io/openhound/collectors/github/configure-enterprise-app) docs for OpenHound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Enterprise people” to the documented enterprise permissions list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->